### PR TITLE
Fixes #38497 - migrate erratum packages to bigint

### DIFF
--- a/db/migrate/20250613210050_use_big_int_for_erratum_packages_id.rb
+++ b/db/migrate/20250613210050_use_big_int_for_erratum_packages_id.rb
@@ -1,0 +1,11 @@
+class UseBigIntForErratumPackagesId < ActiveRecord::Migration[7.0]
+  def up
+    execute 'ALTER SEQUENCE katello_erratum_packages_id_seq AS bigint;'
+    change_column :katello_erratum_packages, :id, :bigint
+  end
+
+  def down
+    change_column :katello_erratum_packages, :id, :integer
+    execute 'ALTER SEQUENCE katello_erratum_packages_id_seq AS integer;'
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Migrates the erratum packages table to bigint. One user exhausted the maximum integer value. 

#### Considerations taken when implementing this change?
At this time I don't see other values that are worth moving to bigint as well. Erratum packages are generally more likely to fill up since errata can have so many associated packages.
Eventually we should migrate all integer IDs to bigint.

I thought migrating the ID to bigint should also migrate the sequence, but it does not in postgres 13.

#### What are the testing steps for this pull request?
1) Run the migration
2) Check that both the sequence and the ID column are now bigints.

## Summary by Sourcery

Bug Fixes:
- Change katello_erratum_packages.id and its sequence to bigint to avoid exhausting the integer limit