### PR TITLE
Fixes #38508 - use transient flag for all transient actions

### DIFF
--- a/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/install_packages_by_search_query_-_katello_ansible_default.erb
@@ -19,23 +19,15 @@ template_inputs:
 - hosts: all
   tasks:
 <%= indent(4) { snippet('check_bootc_status') } %>
-    - name: Enable bootc overlay
-      shell:
-        cmd: 'bootc usr-overlay'
-      register: out
-      ignore_errors: true
-      when: is_bootc_host
-    - debug: var=out
-    - name: Install packages via dnf for image mode machines
-      package:
-        use: 'dnf'
 <% if package_names.empty? -%>
-        name: []
-<% else -%>
-        name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
-        state: present
-<% end -%>
+    - name: Install all packages transiently for image mode machines
+      shell: "dnf --transient install -y '*'"
       when: is_bootc_host
+<% else -%>
+    - name: Install packages transiently for image mode machines
+      shell: "dnf --transient install -y <%= package_names.join(' ') %>"
+      when: is_bootc_host
+<% end -%>
     - name: Install packages normally
       package:
 <% if package_names.empty? -%>

--- a/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/remove_packages_by_search_query_-_katello_ansible_default.erb
@@ -19,21 +19,8 @@ template_inputs:
 - hosts: all
   tasks:
 <%= indent(4) { snippet('check_bootc_status') } %>
-    - name: Enable bootc overlay
-      shell:
-        cmd: 'bootc usr-overlay'
-      register: out
-      ignore_errors: true
-      when: is_bootc_host
-    - debug: var=out
-    - name: Remove packages via dnf for image mode machines
-      package:
-        name:
-<% package_names.each do |package_name| -%>
-          - <%= package_name %>
-<% end -%>
-        state: absent
-        use: 'dnf'
+    - name: Remove packages transiently for image mode machines
+      shell: "dnf --transient remove -y <%= package_names.join(' ') %>"
       when: is_bootc_host
     - name: Remove packages normally
       package:

--- a/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
+++ b/app/views/foreman/job_templates/update_packages_by_search_query_-_katello_ansible_default.erb
@@ -28,20 +28,12 @@ template_inputs:
 - hosts: all
   tasks:
 <%= indent(4) { snippet('check_bootc_status') } %>
-    - name: Enable bootc overlay
-      shell:
-        cmd: 'bootc usr-overlay'
-      register: out
-      ignore_errors: true
+    - name: Update packages transiently for image mode machines
+      shell: |
+        dnf --transient install -y <%= package_names.join(' ') %>
+        dnf --transient upgrade -y --best <%= package_names.join(' ') %>
       when: is_bootc_host
-    - debug: var=out
-    - name: Install packages via dnf for image mode machines
-      package:
-        name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
-        state: latest
-        use: 'dnf'
-      when: is_bootc_host
-    - name: Install packages normally
+    - name: Update packages normally
       package:
         name: <%= indent(10) { to_yaml(package_names).gsub(/---/, "") } -%>
         state: latest


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Removes usr-overlay enablement and replaces it with calls to `dnf --transient`. This works around the fact that Ansible does not yet support `dnf --transient` and that usr-overlay installs without `--transient` fail after the first transiently installed package is installed.

#### Considerations taken when implementing this change?
The old logic should remain the same for package mode hosts.

#### What are the testing steps for this pull request?
Try the 3 templates updated in this PR for both image mode and package mode hosts.

Note: Also relies on https://github.com/theforeman/foreman_ansible/pull/768 for the use of the vanilla Ansible package action template.

## Summary by Sourcery

Consolidate transient package management for image mode hosts by replacing usr-overlay steps and Ansible package module usage with direct dnf --transient shell commands in install, update, and remove job templates.

Enhancements:
- Use dnf --transient flag for transient install, upgrade, and removal of packages on image mode hosts
- Remove usr-overlay enablement tasks from job templates
- Update install, update, and remove ERB templates to invoke dnf commands via shell instead of the Ansible package module