### PR TITLE
Fixes #38514 - Support cert authentication for capsules

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -77,11 +77,12 @@ module Katello
           redirect_authorization_headers if redirect_on_failure
           return false
         end
+      elsif request.headers['HostUUID']
+        @host = Katello::Host::ContentFacet.find_by(uuid: request.headers['HostUUID'])&.host
       else
         authenticate_cert_request
-        return true if @host
       end
-      false
+      return @host.presence
     end
 
     def optional_authorize

--- a/app/controllers/katello/concerns/api/v2/registration_commands_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_commands_controller_extensions.rb
@@ -31,6 +31,7 @@ module Katello
             param :activation_keys, Array, desc: N_('Activation keys for subscription-manager client, required for CentOS and Red Hat Enterprise Linux. Required only if host group has no activation keys or if you do not provide a host group.')
             param :force, :bool, required: false, desc: N_('Clear any previous registration and run subscription-manager with --force.')
             param :ignore_subman_errors, :bool, required: false, desc: N_('Ignore subscription-manager errors for `subscription-manager register` command')
+            param :setup_container_registry_certs, :bool, required: false, desc: N_('Use container certificates for container registry authentication. If it is set to true, container registry certificates will be installed on the host')
           end
         end
       end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -234,7 +234,19 @@ module Katello
           update_container_repo_list
           users = container_gateway_users
           update_user_container_repo_mapping(users) if users.any?
+          update_container_gateway_hosts if content_facets.any?
+          update_host_container_repo_mapping(content_facets)
         end
+      end
+
+      def update_container_gateway_hosts
+        # This method updates the hosts that are registered with the container gateway.
+        hosts = self.content_facets.map do |facet|
+          {
+            uuid: facet.uuid,
+          }
+        end
+        ProxyAPI::ContainerGateway.new(url: self.url).update_hosts({ hosts: hosts })
       end
 
       def update_container_repo_list
@@ -269,6 +281,28 @@ module Katello
           user_repo_map[:users] << { user.login => inner_repo_list }
         end
         ProxyAPI::ContainerGateway.new(url: self.url).user_repository_mapping(user_repo_map)
+      end
+
+      def update_host_container_repo_mapping(content_facets)
+        # Example host-repo mapping:
+        # { hosts:
+        #   [
+        #     'host_uuid a' => [{ repository: 'repo 1', auth_required: true }]
+        #   ]
+        # }
+
+        host_repo_map = { hosts: [] }
+        content_facets.each do |facet|
+          inner_repo_list = []
+          repositories = ::Katello::Repository.readable_docker_catalog(facet.host)
+          repositories.each do |repo|
+            next if repo.container_repository_name.nil?
+            inner_repo_list << { repository: repo.container_repository_name,
+                                 auth_required: !unauthenticated_container_repositories.include?(repo.id) }
+          end
+          host_repo_map[:hosts] << { facet.uuid => inner_repo_list }
+        end
+        ProxyAPI::ContainerGateway.new(url: self.url).host_repository_mapping(host_repo_map)
       end
 
       def unauthenticated_container_repositories

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -316,7 +316,7 @@ Foreman::Plugin.register :katello do
   extend_allowed_registration_vars :lifecycle_environment_id
   extend_allowed_registration_vars :force
   extend_allowed_registration_vars :ignore_subman_errors
-
+  extend_allowed_registration_vars :setup_container_registry_certs
   extend_page "smart_proxies/show" do |cx|
     cx.add_pagelet :details_content,
                    :name => _('Storage'),

--- a/lib/proxy_api/container_gateway.rb
+++ b/lib/proxy_api/container_gateway.rb
@@ -28,5 +28,21 @@ module ProxyAPI
     rescue => e
       raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to get users"))
     end
+
+    def update_hosts(args)
+      # put '/v2/update_hosts/?'
+      @url += "/update_hosts"
+      parse put(args)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to update hosts"))
+    end
+
+    def host_repository_mapping(args)
+      # put '/v2/update_host_repository_mapping/?'
+      @url += "/host_repository_mapping"
+      parse put(args)
+    rescue => e
+      raise ::ProxyAPI::ProxyException.new(url, e, N_("Unable to update host-repository mapping"))
+    end
   end
 end

--- a/test/controllers/foreman/registration_commands_controller_test.rb
+++ b/test/controllers/foreman/registration_commands_controller_test.rb
@@ -86,6 +86,12 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
     assert_includes(JSON.parse(@response.body)['registration_command'], 'ignore_subman_errors=true')
   end
 
+  def test_with_setup_container_registry_certs
+    post :create, params: { setup_container_registry_certs: true, activation_keys: ['key1'] }
+    assert_response :success
+    assert_includes(JSON.parse(@response.body)['registration_command'], 'setup_container_registry_certs=true')
+  end
+
   def test_hostgroup_with_ack
     hostgroup = FactoryBot.create(:hostgroup)
     FactoryBot.create(:hostgroup_parameter, hostgroup: hostgroup, name: 'kt_activation_keys', value: 'key1')

--- a/webpack/components/extensions/RegistrationCommands/fields/SetupContainerRegistryCerts.js
+++ b/webpack/components/extensions/RegistrationCommands/fields/SetupContainerRegistryCerts.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { noop } from 'foremanReact/common/helpers';
+
+import { FormGroup, Checkbox } from '@patternfly/react-core';
+import LabelIcon from 'foremanReact/components/common/LabelIcon';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const SetupContainerRegistryCerts = ({ value, onChange, isLoading }) => (
+  <FormGroup fieldId="reg_container_certs">
+    <Checkbox
+      ouiaId="reg-container-certs"
+      label={
+        <span>
+          {__('Set up container registry certs')}{' '}
+          <LabelIcon text={__('Place symlinks to entitlement certificates on the host, enabling container/flatpak registry access without a username or password.')} />
+        </span>
+            }
+      id="reg_container_certs"
+      onChange={() => onChange({ setupContainerRegistryCerts: !value })}
+      isDisabled={isLoading}
+      isChecked={value}
+    />
+  </FormGroup>
+);
+
+SetupContainerRegistryCerts.propTypes = {
+  value: PropTypes.bool,
+  onChange: PropTypes.func,
+  isLoading: PropTypes.bool,
+};
+
+SetupContainerRegistryCerts.defaultProps = {
+  value: false,
+  onChange: noop,
+  isLoading: false,
+};
+
+export default SetupContainerRegistryCerts;

--- a/webpack/components/extensions/RegistrationCommands/index.js
+++ b/webpack/components/extensions/RegistrationCommands/index.js
@@ -7,6 +7,7 @@ import { determineInitialAKSelection } from './helpers';
 import ActivationKeys from './fields/ActivationKeys';
 import IgnoreSubmanErrors from './fields/IgnoreSubmanErrors';
 import Force from './fields/Force';
+import SetupContainerRegistryCerts from './fields/SetupContainerRegistryCerts';
 
 export const RegistrationCommands = ({
   pluginValues,
@@ -22,6 +23,12 @@ export const RegistrationCommands = ({
     />
     <Force
       value={pluginValues?.force}
+      pluginValues={pluginValues}
+      onChange={onChange}
+      isLoading={isLoading}
+    />
+    <SetupContainerRegistryCerts
+      value={pluginValues?.setupContainerRegistryCerts}
       pluginValues={pluginValues}
       onChange={onChange}
       isLoading={isLoading}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds required changes to populate hosts and host-repositories mapping in container_gateway during capsule sync.
Allows accessing repo catalog for a host by providing host uuid in header request from container_gateway to populate host-repo mapping for host UUIds unknown to the capsule.
#### Considerations taken when implementing this change?
Allows for a *hack* to allow unknown host UUIDs (Hosts that register to a capsule after a capsule sync) by allowing access to host repos if proxy's request header contains a hostUUID (Derived from client container cert) which is the case when capsule requests host repositories for unknown host.

This does not yet handle the case of changing content source(CV/LCE) for an already registered host. With only these changes, a capsule sync is needed to handle it.
#### What are the testing steps for this pull request?
1. Test with the container gateway PR here:
2. Register a client with a capsule with some container repos in capsule's assigned environments. (Use "Set up container registry certs" when using registration template to set this up automatically.)
3. Perform a capsule sync to test container_gateway DB population during sync.
4. Try podman search/pull on the client against the capsule and make sure you have access and that you're limited to only LCE repos client is registered to.
5. Force re-register the client and try accessing repos again. The access should still be allowed.