### PR TITLE
Fixes #38476 - Fix plurality of React UI elements on the new Host details -> Content page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-hosts/views/content-hosts.html
@@ -11,7 +11,7 @@
       <span translate>Export</span>
     </a>
     <a class="btn btn-default" href="/hosts/register" ng-show="permitted('create_hosts')" translate>
-      Register Content Host
+      <span> {{table.numSelected &gt 1? 'Register Content Hosts':'Register Content Host' | translate}} </span>
     </a>
 
     <span select-action-dropdown>

--- a/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/PackagesTab/PackagesTab.js
@@ -18,6 +18,7 @@ import {
   SelectOption,
   SelectVariant,
 } from '@patternfly/react-core/deprecated';
+import { FormattedMessage } from 'react-intl';
 import { TableVariant, Thead, Tbody, Tr, Th, Td, TableText, ActionsColumn } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -402,7 +403,11 @@ export const PackagesTab = () => {
       component="button"
       onClick={handleInstallPackagesClick}
     >
-      {__('Install packages')}
+      <FormattedMessage
+        id="install-packages"
+        defaultMessage="{count, plural, one {Install package} other {Install packages}}"
+        values={{ count: selectedCount }}
+      />
     </DropdownItem>,
     <DropdownItem
       aria-label="refresh_applicability"


### PR DESCRIPTION
#### Reason of Commit
This commit fixes the plurality concern in the host details -> Content page. The UI page now displays "Install Package" when only one package is selected and "Install Packages" when multiple packages are selected. 

There is another plurality fix on the content host page with the button "Register Content Host/s"

#### Changes to note
Note the plurality change based on the selected number of packages/ hosts. 

#### What are the testing steps for this pull request?
To test this change the pages effected are on (new) host details -> Content ->Packages under the three dot menu the Install Package/s button will be found

## Summary by Sourcery

Fix UI labels to use correct singular or plural forms based on the number of selected items in errata, package, and content host views.

Bug Fixes:
- Adjust the ‘Apply Errata’ button to display ‘Apply Erratum’ when a single item is selected and ‘Apply Errata’ otherwise
- Update the ‘Install package(s)’ dropdown item to switch between singular and plural based on the number of selected packages
- Change the ‘Register Content Host(s)’ button to reflect singular or plural hosts depending on selection count