### PR TITLE
[CP] Katello 4.16.2 Cherry Picks

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -544,6 +544,8 @@ module Katello
 
     def check_blob
       pulp_response = Resources::Registry::Proxy.get(@_request.fullpath, 'Accept' => request.headers['Accept'])
+      response.headers['Content-Type'] = pulp_response.headers[:content_type] if pulp_response.headers[:content_type]
+      response.headers['Content-Length'] = pulp_response.headers[:content_length] if pulp_response.headers[:content_length]
       head pulp_response.code
     end
 

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -392,6 +392,25 @@ module Katello
       end
     end
 
+    describe "check blob" do
+      it "proxies headers from pulp" do
+        mock_pulp_response = mock
+        mock_pulp_response.stubs(:code).returns(200)
+        mock_pulp_response.stubs(:headers).returns({
+                                                     content_type: 'application/octet-stream',
+                                                     content_length: '127225440',
+                                                   })
+
+        Resources::Registry::Proxy.expects(:get).returns(mock_pulp_response)
+
+        head :check_blob, params: { repository: @docker_repo.name, digest: @digest }
+
+        assert_response 200
+        assert_equal 'application/octet-stream', response.headers['Content-Type']
+        assert_equal '127225440', response.headers['Content-Length']
+      end
+    end
+
     describe "docker pull" do
       it "pull manifest - protected" do
         @controller.stubs(:registry_authorize).returns(true)


### PR DESCRIPTION
Katello 4.16.2 cherry picks:

1f1f26ebfe Fixes #38488 - Pass content headers from Pulp to Podman (#11413)
90d7074afd Fixes #38504 - delete installed package dupes before evr migration