### PR TITLE
Release 4.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 4.16.2 Taliesin (2025-06-30)
+
+## Bug Fixes
+
+### Container
+ * Second container push set manifest size fields to -1, which breaks bootc ([#38488](https://projects.theforeman.org/issues/38488), [b627df79](https://github.com/Katello/katello.git/commit/b627df79739a64df535a5a2cc0329b633d262ea8))
+
+### Other
+ * Satellite 6.17 upgrade fails with ERROR:  duplicate key value violates unique constraint "index_katello_installed_packages_on_nvrea" ([#38504](https://projects.theforeman.org/issues/38504), [89d7c24e](https://github.com/Katello/katello.git/commit/89d7c24e2e3e8caf3510678691815c63dd1c8dbc))
+
 # 4.16.1 Taliesin (2025-04-30)
 
 ### Repositories

--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.16.1".freeze
+  VERSION = "4.16.2".freeze
 end


### PR DESCRIPTION
Release 4.16.2. Update changelog and version number.

## Summary by Sourcery

Bump version to 4.16.2 and update changelog with two bug fixes.

Bug Fixes:
- Fix manifest size fields being set to -1 on second container push, which breaks boot.
- Resolve duplicate key violation error during Satellite 6.17 upgrade.

Build:
- Update version number to 4.16.2 in lib/katello/version.rb

Documentation:
- Add 4.16.2 release entry to CHANGELOG.md