### PR TITLE
Fixes #37910 - move css import from vendor to foreman

### DIFF
--- a/webpack/components/OptionTooltip/OptionTooltip.scss
+++ b/webpack/components/OptionTooltip/OptionTooltip.scss
@@ -1,4 +1,4 @@
-@import "~@theforeman/vendor/scss/variables";
+@import "foremanReact/common/variables";
 
 .option-tooltip {
   ul {

--- a/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.scss
+++ b/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.scss
@@ -1,4 +1,4 @@
-@import "~@theforeman/vendor/scss/variables";
+@import "foremanReact/common/variables";
 
 .recommended-repositories-toggler-container {
 

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -1,4 +1,4 @@
-@import "~@theforeman/vendor/scss/variables";
+@import "foremanReact/common/variables";
 
 .row-eq-height {
   display: -webkit-box;

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.scss
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.scss
@@ -1,4 +1,4 @@
-@import '~@theforeman/vendor/scss/variables';
+@import 'foremanReact/common/variables';
 
 #subscriptions-page {
   .editable {


### PR DESCRIPTION
css imports were moved in https://github.com/theforeman/foreman/pull/10345 already
and will break after https://github.com/theforeman/foreman/pull/10342 is merged.
This pr is only for the css import and can be merged now

## Summary by Sourcery

Fix broken SCSS imports by updating the path for shared variables to the new foremanReact/common location

Bug Fixes:
- Update SCSS import in OptionTooltip to use foremanReact/common/variables
- Update SCSS import in RecommendedRepositorySetsToggler to use foremanReact/common/variables
- Update SCSS import in RedHatRepositories scene to use foremanReact/common/variables
- Update SCSS import in SubscriptionsPage to use foremanReact/common/variables