### PR TITLE
Fixes #38545 - Support IPv6 addresses in HTTP proxy URLs

### DIFF
--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -187,7 +187,7 @@ module Katello
         def net_http_class
           if proxy
             uri = URI(proxy.url) #Net::HTTP::Proxy ignores port as part of the url
-            Net::HTTP::Proxy("#{uri.host}", uri.port, proxy.username, proxy.password)
+            Net::HTTP::Proxy(uri.hostname, uri.port, proxy.username, proxy.password)
           else
             Net::HTTP
           end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

When using the URI class you need to use .hostname instead of .host:

```
[1] pry(main)> require 'uri'
=> true
[2] pry(main)> uri = URI('http://[::1]:3128')
=> #<URI::HTTP http://[::1]:3128>
[3] pry(main)> uri.host
=> "[::1]"
[4] pry(main)> uri.hostname
=> "::1"
```

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

1. Create an http proxy on Foreman pointing to an IPv6 URL. Example: http://[::1]:3128
2. Ensure your Foreman can't access the CDN without a proxy
3. Try loading going to Content -> Red Hat Repositories

## Summary by Sourcery

Bug Fixes:
- Fix IPv6 proxy address support by stripping brackets via URI.hostname when creating Net::HTTP::Proxy