### PR TITLE
Fixes #38546 - Do not run unnecessary Repository::CapsuleSync tasks

### DIFF
--- a/app/lib/actions/helpers/smart_proxy_sync_helper.rb
+++ b/app/lib/actions/helpers/smart_proxy_sync_helper.rb
@@ -1,0 +1,12 @@
+module Actions
+  module Helpers
+    module SmartProxySyncHelper
+      def schedule_async_repository_proxy_sync(repository)
+        return unless Setting[:foreman_proxy_content_auto_sync]
+        if SmartProxy.unscoped.pulpcore_proxies_with_environment(repository.environment).exists?
+          ForemanTasks.async_task(::Actions::Katello::Repository::CapsuleSync, repository)
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/katello/content_view/add_rolling_repo_clone.rb
+++ b/app/lib/actions/katello/content_view/add_rolling_repo_clone.rb
@@ -2,6 +2,8 @@ module Actions
   module Katello
     module ContentView
       class AddRollingRepoClone < Actions::EntryAction
+        include Helpers::SmartProxySyncHelper
+
         def plan(content_view, repository_ids)
           library = content_view.organization.library
           clone_ids = []
@@ -27,10 +29,8 @@ module Actions
         end
 
         def run
-          if Setting[:foreman_proxy_content_auto_sync]
-            ::Katello::Repository.where(id: input[:repository_ids]).each do |repo|
-              ForemanTasks.async_task(::Actions::Katello::Repository::CapsuleSync, repo)
-            end
+          ::Katello::Repository.where(id: input[:repository_ids]).each do |repository|
+            schedule_async_repository_proxy_sync(repository)
           end
         end
       end

--- a/app/lib/actions/katello/repository/sync.rb
+++ b/app/lib/actions/katello/repository/sync.rb
@@ -6,6 +6,7 @@ module Actions
         extend ApipieDSL::Class
         include Helpers::Presenter
         include Helpers::RollingCVRepos
+        include Helpers::SmartProxySyncHelper
         include ::Actions::ObservableAction
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
 
@@ -72,7 +73,7 @@ module Actions
             update_rolling_content_views_async(repo, input[:contents_changed])
           end
           repo.clear_smart_proxy_sync_histories if input[:contents_changed]
-          ForemanTasks.async_task(Repository::CapsuleSync, repo) if Setting[:foreman_proxy_content_auto_sync]
+          schedule_async_repository_proxy_sync(repo)
         rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 

--- a/app/lib/actions/katello/repository/upload_files.rb
+++ b/app/lib/actions/katello/repository/upload_files.rb
@@ -7,6 +7,7 @@ module Actions
     module Repository
       class UploadFiles < Actions::EntryAction
         include Helpers::RollingCVRepos
+        include Helpers::SmartProxySyncHelper
 
         def plan(repository, files, content_type = nil, options = {})
           action_subject(repository)
@@ -52,7 +53,7 @@ module Actions
 
         def run
           repository = ::Katello::Repository.find(input[:repository][:id])
-          ForemanTasks.async_task(Repository::CapsuleSync, repository) if Setting[:foreman_proxy_content_auto_sync]
+          schedule_async_repository_proxy_sync(repository)
         rescue ::Katello::Errors::CapsuleCannotBeReached # skip any capsules that cannot be connected to
         end
 

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -313,6 +313,9 @@ module ::Actions::Katello::ContentView
       Katello::Repository.any_instance.expects(:clear_smart_proxy_sync_histories)
       ForemanTasks.expects(:async_task).with(::Actions::Katello::ContentView::RefreshRollingRepo,
                                             clone_rpm, true)
+      mocked_query = mock
+      mocked_query.stubs(:exists?).returns(true)
+      SmartProxy.expects(:pulpcore_proxies_with_environment).with(clone_rpm.environment).returns(mocked_query)
       ForemanTasks.expects(:async_task).with(::Actions::Katello::Repository::CapsuleSync, clone_rpm)
       action.finalize
     end


### PR DESCRIPTION
This makes `ForemanTasks.async_task(::Actions::Katello::Repository::CapsuleSync, repo)` conditional on there actually being any proxies that use an environment used by `repo`.

That way we do not schedule unnecessary noop `Repository::CapsuleSync` tasks, which have in some cases been observed to fail for no apparent reason.

## Summary by Sourcery

Run Repository::CapsuleSync tasks only when there are smart proxies in the repository’s environment to avoid scheduling unnecessary no-op tasks.

Bug Fixes:
- Avoid scheduling CapsuleSync tasks when no smart proxies are present in the repository environment.

Enhancements:
- Add an environment proxy existence check before triggering CapsuleSync in upload_files, import_upload, repository sync, and add_rolling_repo_clone actions.