### PR TITLE
Fixes #38555 - Fix the tests when new hosts index page becomes default

### DIFF
--- a/test/controllers/foreman/hosts_controller_test.rb
+++ b/test/controllers/foreman/hosts_controller_test.rb
@@ -117,7 +117,7 @@ class HostsControllerTest < ActionController::TestCase
       delete :destroy, params: { :id => host.name }
       assert_nil flash[:error]
       assert_not_nil flash[:success]
-      assert_redirected_to hosts_url
+      assert_redirected_to new_hosts_index_page_url
     end
 
     test 'shows an error when host can not be destroyed' do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Depends on https://github.com/theforeman/foreman/pull/10590
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
`bundle exec rake test:katello`

## Summary by Sourcery

Tests:
- Update host destroy test to assert redirect to new hosts index page URL