### PR TITLE
Refs #38555 - Change foreman_version to test PR with specific Foreman PR

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     with:
       plugin: katello
       test_existing_database: false
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: refs/pull/10590/merge # set to the Foreman release branch after branching :)
 
   angular:
     name: Angular ${{ matrix.engine }} - NodeJS ${{ matrix.node }}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
To test PR https://github.com/Katello/katello/pull/11436 with https://github.com/theforeman/foreman/pull/10590 before merging.

#### Considerations taken when implementing this change?
Doc referenced: https://github.com/theforeman/actions/?tab=readme-ov-file#foreman-plugin-ruby-tests

#### What are the testing steps for this pull request?

## Summary by Sourcery

CI:
- Update foreman_version in ruby workflow to refs/pull/10590/merge for testing against a specific Foreman pull request