### PR TITLE
Fixes #38577 - Fix snapshots

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,6 @@ module.exports = {
   ],
   moduleDirectories: [
     `${foremanFull}/node_modules`,
-    `${foremanFull}/node_modules/@theforeman/vendor-core/node_modules`,
     'node_modules',
     'webpack/test-utils',
   ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "nock": "^12.0.3",
     "react-test-renderer": "^16.0.0"
   },
-  "_comment": "We don't include @theforeman/vendor because it's assumed to be present in Foreman",
   "dependencies": {
     "angular": "1.8.2",
     "bootstrap-select": "1.13.18",

--- a/webpack/.eslintrc.js
+++ b/webpack/.eslintrc.js
@@ -1,8 +1,6 @@
 const path = require('path');
 const { foremanLocation, foremanRelativePath } = require('@theforeman/find-foreman');
 const foremanFull = foremanLocation();
-const foremanVendorRelative = './node_modules/@theforeman/vendor-core/';
-const foremanVendorDir = foremanRelativePath(foremanVendorRelative);
 
 module.exports = {
   env: {
@@ -39,7 +37,7 @@ module.exports = {
       "error",
       {
         // Need to check Katello, Foreman, and Foreman's meta package for dependencies
-        "packageDir": [path.join(__dirname, '../../katello'), foremanFull, foremanVendorDir]
+        "packageDir": [path.join(__dirname, '../../katello'), foremanFull]
       }
     ],
     'jsx-a11y/anchor-is-valid': [

--- a/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
+++ b/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
@@ -7,7 +7,7 @@ exports[`Content Details Info should render and contain appropriate components 1
     loadingText="Loading"
     timeout={300}
   >
-    <ForwardRef
+    <Uncontrolled(TabContainer)
       defaultActiveKey={1}
       id="content-tabs-container"
       style={
@@ -137,7 +137,7 @@ exports[`Content Details Info should render and contain appropriate components 1
           </TabPane>
         </TabContent>
       </Grid>
-    </ForwardRef>
+    </Uncontrolled(TabContainer)>
   </LoadingState>
 </div>
 `;

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -27,7 +27,7 @@ exports[`subscriptions details page should render and contain appropiate compone
       }
     }
   />
-  <ForwardRef
+  <Uncontrolled(TabContainer)
     defaultActiveKey={1}
     id="subscription-tabs-container"
   >
@@ -531,6 +531,6 @@ exports[`subscriptions details page should render and contain appropiate compone
         </Grid>
       </LoadingState>
     </div>
-  </ForwardRef>
+  </Uncontrolled(TabContainer)>
 </div>
 `;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

For some reason, Katello JS snapshots are broken with https://github.com/theforeman/foreman/pull/10598
Also removes references to @theforeman/vendor which isn't a thing anymore.

#### Considerations taken when implementing this change?

I'm still not sure if this is caused by the scalprum changes, or some coincidence with a PF update or something.

#### What are the testing steps for this pull request?

see that CI passes

## Summary by Sourcery

Regenerate broken Katello JS snapshots to restore passing tests

Bug Fixes:
- Update ContentDetails snapshot to reflect current component output
- Update SubscriptionDetails snapshot to reflect current component output

Tests:
- Refresh snapshot tests for ContentDetails and SubscriptionDetails