### PR TITLE
Fixes #38537 - Add mirror action

### DIFF
--- a/app/controllers/katello/api/v2/products_controller.rb
+++ b/app/controllers/katello/api/v2/products_controller.rb
@@ -128,6 +128,24 @@ module Katello
       respond_for_async(:resource => task)
     end
 
+    def auto_complete_name
+      page_size = params[:per_page].to_i.positive? ? params[:per_page].to_i : Katello::Concerns::FilteredAutoCompleteSearch::PAGE_SIZE
+
+      query = Product.readable
+                    .where(organization_id: params.require(:organization_id))
+                    .enabled
+
+      query = query.custom if Foreman::Cast.to_bool(params[:custom])
+
+      product_names = query
+                        .where("#{Product.table_name}.name ILIKE ?", "#{params[:term]}%")
+                        .order("#{Product.table_name}.name")
+                        .limit(page_size)
+                        .pluck(:name)
+
+      render json: product_names
+    end
+
     protected
 
     def find_product(options = {})

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -331,6 +331,7 @@ Katello::Engine.routes.draw do
           end
           collection do
             get :auto_complete_search
+            get :auto_complete_name
           end
           api_resources :repository_sets, :only => [:index, :show] do
             get :auto_complete_search, :on => :collection

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -250,7 +250,7 @@ module Katello
       @plugin.permission :view_products,
                          {
                            'katello/products' => [:auto_complete, :auto_complete_search],
-                           'katello/api/v2/products' => [:index, :show, :auto_complete_search],
+                           'katello/api/v2/products' => [:index, :show, :auto_complete_search, :auto_complete_name],
                            'katello/api/v2/repositories' => [:index, :show, :repository_types, :content_types, :auto_complete_search, :cancel],
                            'katello/api/v2/packages' => [:index, :thindex, :show, :auto_complete_search, :auto_complete_name, :auto_complete_arch, :compare],
                            'katello/api/v2/srpms' => [:index, :show, :auto_complete_search, :compare],

--- a/webpack/scenes/FlatpakRemotes/Details/FlatpakRemoteDetailActions.js
+++ b/webpack/scenes/FlatpakRemotes/Details/FlatpakRemoteDetailActions.js
@@ -1,6 +1,7 @@
-import { API_OPERATIONS, get, put } from 'foremanReact/redux/API';
+import { API_OPERATIONS, get, post, put } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { flatpakRemoteDetailsKey,
+  flatpakRemoteRepositoriesKey,
   UPDATE_FLATPAK_REMOTE,
   UPDATE_FLATPAK_REMOTE_SUCCESS,
   UPDATE_FLATPAK_REMOTE_FAILURE } from '../FlatpakRemotesConstants';
@@ -13,6 +14,14 @@ const getFlatpakRemoteDetails = (id, extraParams = {}) => get({
   params: { organization_id: orgId(), include_permissions: true, ...extraParams },
   url: api.getApiUrl(`/flatpak_remotes/${id}`),
 });
+
+export const getRemoteRepositories = frId => () =>
+  get({
+    type: API_OPERATIONS.GET,
+    key: flatpakRemoteRepositoriesKey(frId),
+    url: api.getApiUrl(`/flatpak_remotes/${frId}/flatpak_remote_repositories`),
+    params: { organization_id: orgId() },
+  });
 
 export const updateFlatpakRemote = (frId, params, handleSuccess) => put({
   type: API_OPERATIONS.PUT,
@@ -29,5 +38,22 @@ export const updateFlatpakRemote = (frId, params, handleSuccess) => put({
     FAILURE: UPDATE_FLATPAK_REMOTE_FAILURE,
   },
 });
+
+export const mirrorFlatpakRepository = (
+  flatpakRepoId,
+  productName,
+  handleSuccess,
+  handleError,
+) =>
+  post({
+    type: API_OPERATIONS.POST,
+    key: flatpakRemoteRepositoriesKey(flatpakRepoId),
+    url: api.getApiUrl(`/flatpak_remote_repositories/${flatpakRepoId}/mirror`),
+    params: { product_name: productName, organization_id: orgId() },
+    handleSuccess,
+    handleError,
+    successToast: () => __('Repository mirroring task started in the background'),
+    errorToast: error => getResponseErrorMsgs(error.response),
+  });
 
 export default getFlatpakRemoteDetails;

--- a/webpack/scenes/FlatpakRemotes/Details/Mirror/MirrorRepositoryModal.js
+++ b/webpack/scenes/FlatpakRemotes/Details/Mirror/MirrorRepositoryModal.js
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { translate as __ } from 'foremanReact/common/I18n';
+import {
+  Modal,
+  ModalVariant,
+  Form,
+  FormGroup,
+  ActionGroup,
+  Button,
+  TextContent,
+  Text,
+  TextVariants,
+} from '@patternfly/react-core';
+import { orgId } from '../../../../services/api';
+import SearchText from '../../../../components/Search/SearchText';
+import { getRemoteRepositories, mirrorFlatpakRepository } from '../FlatpakRemoteDetailActions';
+
+const MirrorRepositoryModal = ({
+  frId,
+  closeModal,
+  repo,
+  onMirrorSuccess,
+}) => {
+  const dispatch = useDispatch();
+
+  const autoCompleteEndpoint = '/katello/api/v2/products/auto_complete_name';
+  const searchParams = term => ({
+    organization_id: orgId(),
+    enabled: true,
+    custom: true,
+    page: 1,
+    per_page: 5,
+    term,
+  });
+
+  const [productName, setProductName] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSearchChange = (rawValue) => {
+    setProductName(rawValue.trim());
+  };
+
+  const handleMirror = (e) => {
+    e.preventDefault();
+    if (!productName || loading) return;
+    setLoading(true);
+    dispatch(mirrorFlatpakRepository(
+      repo.id,
+      productName,
+      () => {
+        dispatch(getRemoteRepositories(frId)());
+        setLoading(false);
+        if (onMirrorSuccess) onMirrorSuccess();
+        closeModal();
+      },
+      () => {
+        setLoading(false);
+        closeModal();
+      },
+    ));
+  };
+
+  return (
+    <Modal
+      ouiaId="mirror-repo-modal"
+      title={__('Mirror Repository')}
+      variant={ModalVariant.medium}
+      isOpen
+      onClose={closeModal}
+      appendTo={document.body}
+    >
+      <TextContent>
+        <Text component={TextVariants.p} ouiaId="mirror-text-info">
+          {__('Mirroring will import the remote flatpak repository')} <strong>{repo.name}</strong>{' '}
+          {__('into a product. Details from the flatpak remote will automatically populate the repository fields. The repository will be available for syncing once it has been mirrored into a product.')}
+        </Text>
+        <Text component={TextVariants.p} ouiaId="mirror-select-product">
+          {__('Select a product to mirror the repository into')}
+        </Text>
+      </TextContent>
+      <Form onSubmit={handleMirror}>
+        <FormGroup label={__('Product')} isRequired fieldId="mirror-product">
+          <SearchText
+            value={productName}
+            data={{
+              autocomplete: {
+                url: autoCompleteEndpoint,
+                apiParams: searchParams,
+              },
+            }}
+            onSearchChange={handleSearchChange}
+            aria-label="product-search"
+          />
+        </FormGroup>
+
+        <ActionGroup>
+          <Button
+            ouiaId="confirm-mirror-btn"
+            variant="primary"
+            type="submit"
+            isLoading={loading}
+            isDisabled={!productName || loading}
+          >
+            {__('Mirror')}
+          </Button>
+          <Button
+            ouiaId="cancel-mirror-btn"
+            variant="link"
+            onClick={closeModal}
+          >
+            {__('Cancel')}
+          </Button>
+        </ActionGroup>
+      </Form>
+    </Modal>
+  );
+};
+
+MirrorRepositoryModal.propTypes = {
+  frId: PropTypes.number.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  repo: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
+  onMirrorSuccess: PropTypes.func,
+};
+
+MirrorRepositoryModal.defaultProps = {
+  onMirrorSuccess: null,
+};
+
+export default MirrorRepositoryModal;

--- a/webpack/scenes/FlatpakRemotes/Details/RemoteRepositories/RemoteRepositoriesTable.js
+++ b/webpack/scenes/FlatpakRemotes/Details/RemoteRepositories/RemoteRepositoriesTable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Table, Thead, Th, Tbody, Tr, Td } from '@patternfly/react-table';
 import { Button } from '@patternfly/react-core';
@@ -14,8 +14,11 @@ import {
 } from 'foremanReact/components/PF4/TableIndexPage/Table/TableIndexHooks';
 import LastSync from '../../../ContentViews/Details/Repositories/LastSync';
 import { flatpakRemoteRepositoriesKey } from '../../FlatpakRemotesConstants';
+import MirrorRepositoryModal from '../Mirror/MirrorRepositoryModal';
 
 const RemoteRepositoriesTable = ({ frId }) => {
+  const [selectedRepo, setSelectedRepo] = useState(null);
+
   const columnHeaders = [__('Name'), __('ID'), __('Last mirrored'), __('Mirror')];
 
   const COLUMNS_TO_SORT_PARAMS = {
@@ -62,6 +65,14 @@ const RemoteRepositoriesTable = ({ frId }) => {
 
   const onPaginationChange = (newPagination) => {
     setParamsAndAPI({ ...params, ...newPagination });
+  };
+
+  const openMirrorModal = (repo) => {
+    setSelectedRepo(repo);
+  };
+
+  const closeMirrorModal = () => {
+    setSelectedRepo(null);
   };
 
   return (
@@ -115,6 +126,7 @@ const RemoteRepositoriesTable = ({ frId }) => {
                       variant="link"
                       isInline
                       ouiaId={`mirror-button-${repo.id}`}
+                      onClick={() => openMirrorModal(repo)}
                     >
                       {__('Mirror')}
                     </Button>
@@ -133,6 +145,14 @@ const RemoteRepositoriesTable = ({ frId }) => {
             itemCount={subtotal}
             onChange={onPaginationChange}
             updateParamsByUrl
+          />
+        )}
+
+        {selectedRepo && (
+          <MirrorRepositoryModal
+            frId={frId}
+            repo={selectedRepo}
+            closeModal={closeMirrorModal}
           />
         )}
       </>

--- a/webpack/scenes/FlatpakRemotes/FlatpakRemotesPage.js
+++ b/webpack/scenes/FlatpakRemotes/FlatpakRemotesPage.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useSelector } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { Table, Thead, Th, Tbody, Tr, Td } from '@patternfly/react-table';
 import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableIndexPage';
 import {
@@ -131,7 +130,7 @@ const FlatpakRemotesPage = () => {
                 } = remote;
                 return (
                   <Tr key={id} ouiaId={`flatpak-remote-row-${id}`}>
-                    <Td><Link to={`${urlBuilder('flatpak_remotes', '')}${id}`}>{truncate(name)}</Link></Td>
+                    <Td><a href={`${urlBuilder('flatpak_remotes', '')}${id}`}>{truncate(name)}</a></Td>
                     <Td>
                       <a href={url} target="_blank" rel="noopener noreferrer">
                         {truncate(url)}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added a new “Mirror” action to the Flatpak Remote Repositories table with a button in each row that, when clicked, opens a modal allowing the user to select a target product. It also integrates the new mirror workflow end‑to‑end—triggering background mirroring jobs and surfacing success or error notifications

#### Considerations taken when implementing this change?

Ensured the mirror action reliably initiates the background mirroring job as soon as the user confirms their selection. Immediate feedback is provided via success toasts when the job is queued and error toasts if anything goes wrong, so users are always informed of the outcome.

#### What are the testing steps for this pull request?

- Navigate to Content -> Flatpak remotes
- Click on any of the available flatpak remote
- In the RemoteRepositories table click Mirror to mirror the respective remote repository
- It opens up a modal form where you can select the product you want to mirror the repositoty into and click Mirror
- The mirror repository task will be started in the background

## Summary by Sourcery

Implement end-to-end mirror functionality for Flatpak remote repositories by adding a mirror action and modal in the UI, integrating backend mirror tasks with status presenter and toasts, and introduce a detail page for managing individual flatpak remotes with inline URL editing.

New Features:
- Add Mirror action to Flatpak Remote Repositories table with modal and product selection to trigger background mirroring jobs
- Introduce Flatpak Remote Detail page with inline URL editing

Enhancements:
- Display last mirrored status in repository listings and provide success/error toasts for mirror tasks
- Extend auto-complete search to filter out specific fields in Flatpak remote repositories

Tests:
- Add unit tests for FlatpakRemoteDetails component and repository listing behavior