### PR TITLE
Fixes #38588 - Add functional delete action to Flatpak remotes table

### DIFF
--- a/webpack/scenes/FlatpakRemotes/Details/FlatpakRemoteDetailActions.js
+++ b/webpack/scenes/FlatpakRemotes/Details/FlatpakRemoteDetailActions.js
@@ -1,4 +1,4 @@
-import { API_OPERATIONS, get, put } from 'foremanReact/redux/API';
+import { API_OPERATIONS, APIActions, get, put } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { flatpakRemoteDetailsKey,
   UPDATE_FLATPAK_REMOTE,
@@ -29,5 +29,14 @@ export const updateFlatpakRemote = (frId, params, handleSuccess) => put({
     FAILURE: UPDATE_FLATPAK_REMOTE_FAILURE,
   },
 });
+
+export const deleteFlatpakRemote = (id, handleSuccess) => APIActions.delete({
+  type: API_OPERATIONS.DELETE,
+  key: flatpakRemoteDetailsKey(id),
+  url: api.getApiUrl(`/flatpak_remotes/${id}`),
+  handleSuccess,
+  successToast: () => __('Alternate content source deleted'),
+  errorToast: error => acsErrorToast(error),
+})
 
 export default getFlatpakRemoteDetails;

--- a/webpack/scenes/FlatpakRemotes/FlatpakRemotesPage.js
+++ b/webpack/scenes/FlatpakRemotes/FlatpakRemotesPage.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Table, Thead, Th, Tbody, Tr, Td } from '@patternfly/react-table';
 import TableIndexPage from 'foremanReact/components/PF4/TableIndexPage/TableIndexPage';
@@ -16,6 +16,7 @@ import { STATUS } from 'foremanReact/constants';
 import { selectFlatpakRemotes, selectFlatpakRemotesError, selectFlatpakRemotesStatus } from './FlatpakRemotesSelectors';
 import { truncate } from '../../utils/helpers';
 import CreateFlatpakModal from './CreateEdit/CreateFlatpakRemoteModal';
+import { deleteFlatpakRemote } from './Details/FlatpakRemoteDetailActions';
 
 const FlatpakRemotesPage = () => {
   const response = useSelector(selectFlatpakRemotes);
@@ -23,6 +24,7 @@ const FlatpakRemotesPage = () => {
   const status = useSelector(selectFlatpakRemotesStatus);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isEditModalOpen, setEditModalOpen] = useState(false);
+  const dispatch = useDispatch();
 
   const {
     results = [], subtotal, page, per_page: perPage,
@@ -51,10 +53,10 @@ const FlatpakRemotesPage = () => {
     defaultParams,
   });
 
-  const actionsWithPermissions = () => [
+  const actionsWithPermissions = (remote) => [
     { title: __('Scan'), isDisabled: true },
     { title: __('Edit'), isDisabled: false, onClick: () => { setEditModalOpen(!isEditModalOpen); } },
-    { title: __('Delete'), isDisabled: true },
+    { title: __('Delete'), isDisabled: false, onClick: () => { dispatch( deleteFlatpakRemote(remote.id, () => { onPaginationChange(); }) ); } },
   ];
 
   const {


### PR DESCRIPTION
This PR is being opened as a draft because I have not yet written the unit tests. The delete functionality works as expected.

#### What are the changes introduced in this pull request?
When selecting the 'Delete' action on an entry in the Flatpak remote details page table, the action is performed as expected. Toast messages pop up to inform the user if a delete has succeeded or failed.

#### Considerations taken when implementing this change?
n/a

#### What are the testing steps for this pull request?

1.  Create several Flatpak remotes on the new Flatpak remotes page. See that they show up in the table.
2. Attempt to delete a table entry and see that it succeeds with a green success toast message and that it refreshes the table.
3. Switch to a user without delete permissions and try to delete a table entry. Ensure the entry is not deleted and that the proper error is shown to the user.
