### PR TITLE
Fixes #38595 - Add a scan action on the flatpak remote table

### DIFF
--- a/webpack/scenes/FlatpakRemotes/Details/FlatpakRemoteDetailActions.js
+++ b/webpack/scenes/FlatpakRemotes/Details/FlatpakRemoteDetailActions.js
@@ -5,7 +5,8 @@ import { flatpakRemoteDetailsKey,
   UPDATE_FLATPAK_REMOTE,
   UPDATE_FLATPAK_REMOTE_SUCCESS,
   UPDATE_FLATPAK_REMOTE_FAILURE,
-  DELETE_FLATPAK_REMOTE_KEY } from '../FlatpakRemotesConstants';
+  DELETE_FLATPAK_REMOTE_KEY,
+  SCAN_FLATPAK_REMOTE_KEY } from '../FlatpakRemotesConstants';
 import api, { orgId } from '../../../services/api';
 import { getResponseErrorMsgs } from '../../../utils/helpers';
 
@@ -65,6 +66,15 @@ export const deleteFlatpakRemote = (id, handleSuccess) => APIActions.delete({
   handleSuccess,
   successToast: () => __('Flatpak remote deleted'),
   errorToast: error => __('Flatpak remote could not be deleted: ') + getResponseErrorMsgs(error.response),
+});
+
+export const scanFlatpakRemote = id => post({
+  type: API_OPERATIONS.POST,
+  key: SCAN_FLATPAK_REMOTE_KEY,
+  url: api.getApiUrl(`/flatpak_remotes/${id}/scan`),
+  successToast: () => __('Flatpak remote scanning task started in the background'),
+  errorToast: error => __('Flatpak remote scan could not be started: ') +
+    getResponseErrorMsgs(error.response),
 });
 
 export default getFlatpakRemoteDetails;

--- a/webpack/scenes/FlatpakRemotes/FlatpakRemotesConstants.js
+++ b/webpack/scenes/FlatpakRemotes/FlatpakRemotesConstants.js
@@ -7,6 +7,8 @@ export const UPDATE_FLATPAK_REMOTE = 'UPDATE_FLATPAK_REMOTE';
 export const UPDATE_FLATPAK_REMOTE_SUCCESS = 'UPDATE_FLATPAK_REMOTE_SUCCESS';
 export const UPDATE_FLATPAK_REMOTE_FAILURE = 'UPDATE_FLATPAK_REMOTE_FAILURE';
 
+export const SCAN_FLATPAK_REMOTE_KEY = 'SCAN_FLATPAK_REMOTE_KEY';
+
 export const flatpakRemoteDetailsKey = id => `${FLATPAK_REMOTES_KEY}/DETAILS/${id}`;
 export const flatpakRemoteRepositoriesKey = id => `${FLATPAK_REMOTES_KEY}/REPOSITORIES/${id}`;
 

--- a/webpack/scenes/FlatpakRemotes/FlatpakRemotesPage.js
+++ b/webpack/scenes/FlatpakRemotes/FlatpakRemotesPage.js
@@ -15,8 +15,8 @@ import { STATUS } from 'foremanReact/constants';
 import { selectFlatpakRemotes, selectFlatpakRemotesError, selectFlatpakRemotesStatus } from './FlatpakRemotesSelectors';
 import { truncate } from '../../utils/helpers';
 import CreateFlatpakModal from './CreateEdit/CreateFlatpakRemoteModal';
-import { deleteFlatpakRemote } from './Details/FlatpakRemoteDetailActions';
 import EditFlatpakModal from './CreateEdit/EditFlatpakRemotesModal';
+import { deleteFlatpakRemote, scanFlatpakRemote } from './Details/FlatpakRemoteDetailActions';
 
 const FlatpakRemotesPage = () => {
   const response = useSelector(selectFlatpakRemotes);
@@ -92,7 +92,7 @@ const FlatpakRemotesPage = () => {
   const openCreateModal = () => setIsModalOpen(true);
 
   const actionsWithPermissions = remote => [
-    { title: __('Scan'), isDisabled: true },
+    { title: __('Scan'), isDisabled: !canEdit, onClick: () => { dispatch(scanFlatpakRemote(remote.id)); } },
     {
       title: __('Edit'),
       isDisabled: !canEdit,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

## Summary by Sourcery

Add a scan action to the Flatpak remote table, wiring up the API call and UI button to start background scanning tasks.

New Features:
- Add a scanFlatpakRemote API action to allow initiating background scans of Flatpak remotes

Enhancements:
- Enable the Scan button in the Flatpak remotes table to dispatch the scan action when the user has edit permissions

Chores:
- Introduce SCAN_FLATPAK_REMOTE_KEY constant to identify scan operations