### PR TITLE
Fixes #38602 - replace react-ellipsis-with-tooltip

### DIFF
--- a/webpack/components/pf3Table/formatters/ellipsisCellFormatter.js
+++ b/webpack/components/pf3Table/formatters/ellipsisCellFormatter.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
+import { Truncate } from '@patternfly/react-core';
+
 import cellFormatter from './cellFormatter';
 
-export default value => cellFormatter(<EllipsisWithTooltip>{value}</EllipsisWithTooltip>);
+export default value => cellFormatter(<Truncate content={value} />);


### PR DESCRIPTION
relates to https://github.com/theforeman/foreman/pull/10620
we want to remove the react-ellipsis-with-tooltip package

## Summary by Sourcery

Remove the react-ellipsis-with-tooltip package by updating the ellipsis cell formatter to use PatternFly's Truncate component.

Enhancements:
- Replace EllipsisWithTooltip with PatternFly's Truncate component in ellipsisCellFormatter

Chores:
- Remove react-ellipsis-with-tooltip dependency usage