### PR TITLE
Refs #38614 - fix snapshots because of react-bootstrap version change

### DIFF
--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -13,4 +13,4 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
     with:
       plugin: katello
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: refs/pull/10624/head # set to the Foreman release branch after branching :)

--- a/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
+++ b/webpack/components/Content/Details/__tests__/__snapshots__/ContentDetails.test.js.snap
@@ -7,7 +7,7 @@ exports[`Content Details Info should render and contain appropriate components 1
     loadingText="Loading"
     timeout={300}
   >
-    <Uncontrolled(TabContainer)
+    <ForwardRef
       defaultActiveKey={1}
       id="content-tabs-container"
       style={
@@ -137,7 +137,7 @@ exports[`Content Details Info should render and contain appropriate components 1
           </TabPane>
         </TabContent>
       </Grid>
-    </Uncontrolled(TabContainer)>
+    </ForwardRef>
   </LoadingState>
 </div>
 `;

--- a/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
+++ b/webpack/scenes/Subscriptions/Details/__tests__/__snapshots__/SubscriptionDetails.test.js.snap
@@ -27,7 +27,7 @@ exports[`subscriptions details page should render and contain appropiate compone
       }
     }
   />
-  <Uncontrolled(TabContainer)
+  <ForwardRef
     defaultActiveKey={1}
     id="subscription-tabs-container"
   >
@@ -531,6 +531,6 @@ exports[`subscriptions details page should render and contain appropiate compone
         </Grid>
       </LoadingState>
     </div>
-  </Uncontrolled(TabContainer)>
+  </ForwardRef>
 </div>
 `;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This reverts the change that had been done in 40a442032d34798d04dc34509edd26402d8532bf to accomodate for a pinned version of react-bootstrap. The pin is gone now and so the snapshots need to match the "original" again.

#### Considerations taken when implementing this change?

`<insert colorful language about JS>`

#### What are the testing steps for this pull request?

CI is sufficient