### PR TITLE
[CP] Katello 4.16.3 Cherry Picks

### DIFF
--- a/db/migrate/20240924161240_katello_recreate_evr_constructs.rb
+++ b/db/migrate/20240924161240_katello_recreate_evr_constructs.rb
@@ -165,6 +165,8 @@ class KatelloRecreateEvrConstructs < ActiveRecord::Migration[6.1]
                                                          rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
       SQL
 
+      add_index :katello_rpms, [:name, :arch, :evr]
+
       create_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
       create_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
       create_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages

--- a/db/migrate/20250714190050_add_missing_rpms_evr_index.rb
+++ b/db/migrate/20250714190050_add_missing_rpms_evr_index.rb
@@ -1,0 +1,14 @@
+class AddMissingRpmsEvrIndex < ActiveRecord::Migration[7.0]
+  def up
+    # Re-add the katello_rpms EVR index dropped erroneously by 20240924161240.
+    unless index_exists?(:katello_rpms, [:name, :arch, :evr])
+      add_index :katello_rpms, [:name, :arch, :evr]
+    end
+  end
+
+  def down
+    if index_exists?(:katello_rpms, [:name, :arch, :evr])
+      remove_index :katello_rpms, [:name, :arch, :evr]
+    end
+  end
+end


### PR DESCRIPTION
38576 - 2025-07-15 14:00:35 UTC: [fc7085e6a6378b9796e9e1f9ff1941304006c9b2] Post 4.15 upgrade katello is affected with high CPU usage and Actions::Katello::Applicability::Hosts::BulkGenerate tasks getting stuck