### PR TITLE
typo in override msg

### DIFF
--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -9,7 +9,7 @@ module Katello
 end
 
 Foreman::Application.routes.draw do
-  override_message = '{"message": "Route overriden by Katello, use the /katello API endpoint instead.  See /apidoc for more details."}'
+  override_message = '{"message": "Route overridden by Katello, use the /katello API endpoint instead.  See /apidoc for more details."}'
 
   match "/api/v2/organizations/*all", :to => proc { [404, {}, [override_message]] },
                                       :via => :put,


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
typo fix, after introduction of codespell into robottelo in https://github.com/SatelliteQE/robottelo/pull/18915, all the assertions are spelled right even if product messages aren't, hence test failures. 

#### Considerations taken when implementing this change?
maybe a case for introducing codespell also here? not sure this warrants cherrypicks, though robottelo tests still fails in older branches, so something to consider... 

#### What are the testing steps for this pull request?

## Summary by Sourcery

Bug Fixes:
- Corrected 'overriden' to 'overridden' in the route override message.