### PR TITLE
Fixes #38637 - Incremental content exports determine export format automatically

### DIFF
--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_library.rb
@@ -13,9 +13,8 @@ module Actions
             }.merge(opts)
             action_subject(organization)
             validate_repositories_immediate!(organization) if options[:fail_on_missing_content]
-            content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(destination_server: options[:destination_server],
+            content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_or_create_library_export_view(destination_server: options[:destination_server],
                                                                            organization: organization,
-                                                                           create_by_default: true,
                                                                            format: options[:format])
             repo_ids_in_library = organization.default_content_view_version.repositories.exportable(format: options[:format]).immediate_or_none.pluck(:id)
             content_view.update!(repository_ids: repo_ids_in_library)

--- a/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
+++ b/app/lib/actions/pulp3/orchestration/content_view_version/export_repository.rb
@@ -8,9 +8,8 @@ module Actions
             action_subject(repository)
             validate_repositories_immediate!(repository)
             validate_export_types!(repository, opts[:format])
-            content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_repository_export_view(
+            content_view = ::Katello::Pulp3::ContentViewVersion::Export.find_or_create_repository_export_view(
                                                                            repository: repository,
-                                                                           create_by_default: true,
                                                                            format: opts[:format])
             content_view.update!(repository_ids: [repository.library_instance_or_self.id])
 

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -178,5 +178,7 @@ module Katello
         _('Orphan cleanup failed to delete some Pulp repository versions. Check the logs for more details.')
       end
     end
+
+    class InvalidExportFormat < StandardError; end
   end
 end

--- a/app/services/katello/pulp3/content_view_version/export_validator.rb
+++ b/app/services/katello/pulp3/content_view_version/export_validator.rb
@@ -74,7 +74,7 @@ module Katello
           # You are trying to export between an incrementally updated content view version and regular version
           if from_content_view_version.incrementally_updated? != content_view_version.incrementally_updated?
             fail ExportValidationError,
-                 _("Cannot incrementally export from a incrementally exported version and a regular version or vice-versa. "\
+                 _("Cannot incrementally export from a incrementally updated version and a regular version or vice-versa. "\
                    " The exported Content View Version '%{content_view} %{current}' "\
                    "cannot be incrementally exported from version '%{from}.'"\
                                " Please do a full export." % { content_view: content_view_version.content_view.name,

--- a/test/services/katello/pulp3/content_view_version/export_test.rb
+++ b/test/services/katello/pulp3/content_view_version/export_test.rb
@@ -105,14 +105,8 @@ module Katello
           it 'finds the library export view correctly' do
             format = ::Katello::Pulp3::ContentViewVersion::Export::IMPORTABLE
             org = get_organization
-            assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
-                                                            create_by_default: false,
-                                                            destination_server: nil,
-                                                            format: format)
-            # now create it
             destination_server = "example.com"
-            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
-                                                        create_by_default: true,
+            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_or_create_library_export_view(organization: org,
                                                         destination_server: destination_server,
                                                         format: format)
             assert cv.generated_for_library_export?
@@ -122,14 +116,8 @@ module Katello
           it 'finds the library export view correctly for syncable' do
             format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
             org = get_organization
-            assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
-                                                            create_by_default: false,
-                                                            destination_server: nil,
-                                                            format: format)
-            # now create it
             destination_server = "example.com"
-            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_library_export_view(organization: org,
-                                                        create_by_default: true,
+            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_or_create_library_export_view(organization: org,
                                                         destination_server: destination_server,
                                                         format: format)
             assert cv.generated_for_library_export_syncable?
@@ -139,13 +127,7 @@ module Katello
           it 'finds the repository export view correctly for syncable' do
             repo = katello_repositories(:rhel_6_x86_64)
             format = ::Katello::Pulp3::ContentViewVersion::Export::SYNCABLE
-            assert_nil ::Katello::Pulp3::ContentViewVersion::Export.find_repository_export_view(repository: repo,
-                                                            create_by_default: false,
-                                                            format: format)
-            # now create it
-            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_repository_export_view(repository: repo,
-                                                        create_by_default: true,
-                                                        format: format)
+            cv = ::Katello::Pulp3::ContentViewVersion::Export.find_or_create_repository_export_view(repository: repo, format: format)
             assert cv.generated_for_repository_export_syncable?
             assert_match(/^Export-SYNCABLE-#{repo.label}/, cv.name)
           end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Currently, when running an incremental export on a content view version, library, or repository, the `--format` flag is required for syncable content. The export content format (syncable or importable) follows the default export format when a `--format` flag is not passed. 

This PR changes the behavior of incremental exports in the following ways:
- Content view version, library, and repository incremental exports determine export format (importable vs syncable) based on the `@history`'s `format` field.
- If the user supplies a `--from-history-id` param, we skip name-based lookup and infer type from this `@history` object. This was previously broken for repository and library exports in interesting ways; should be fixed now.
- The `--format` param is optional. 
  - If the user provides the param, name-based CV lookups (used for library and repository exports) only search for exports of this format. 
  - If the param is omitted, name-based lookups look for both types and use the newest-updated CV found.
  - If the user provides the param, we check to make sure the export format determined from `@view` matches the param format. This can happen when a `--from-history-id` is passed with a non-matching format (was a previous issue).
  
Complete exports should remain unaffected.

#### Considerations taken when implementing this change?
This export logic has the potential to break other content exports. I've tried to trace what I can and minimize risk to existing logic, but a fine-toothed review isn't a bad idea here. I refactored a few shared methods in this PR so there is some risk.

#### What are the testing steps for this pull request?
_Verifying the original bug is fixed_:
1. Before pulling this PR, ensure that your `default_export_format` is IMPORTABLE
2. Create a product with content, set the download policy to 'immediate', and sync it.
3. Run the following and ensure it succeeds:
```
hammer content-export complete repository --id <id> --format importable
hammer content-export incremental repository --id <id>
```
4. Run the following an see it fails:
```
hammer content-export complete repository --id <id> --format syncable
hammer content-export incremental repository --id <id>
```
5. Pull this PR and rerun steps 4 and 5. Both should succeed. Ensure exported content is of the correct type.

_Verifying new functionality for content view version export_:
1. Run complete export for a content view version using `--format importable`.
2. Run an incremental export on the content view (with no `--format` param) and see it exports to importable.
3. Run complete exports for a content view version using `--format syncable`.
4. Run an incremental export on the content view (with no `--format` param) and see it exports to syncable.
5. Run an incremental export on the first content view export using `--from-history-id`. It should export as importable.

_Verifying new functionality for library and repository export_:
1. Run complete export for a {library | repository} using `--format importable`.
2. Run an incremental export on the content (with no `--format` param) and see it exports to importable.
3. Run complete exports for the content using `--format syncable`.
4. Run an incremental export on the content (with no `--format` param) and see it exports to syncable (demonstrates export following newest updated type).
6. Run an incremental export on the first content view export using `--from-history-id`. It should export as importable. (demonstrates `--from-history-id` works).
7. Run an incremental export on the content (with no `--format` param) and see it exports to importable (demonstrates export following newest updated type).
8. Run an incremental export on the content with `--format syncable` and see it exports as syncable (demonstrates following provided `--format` when supplied).