### PR TITLE
Fixes #38635 - Add static OUIA IDs to PF5 widgets on CV page

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersions.js
@@ -127,7 +127,7 @@ const ContentViewVersions = ({ cvId, details }) => {
     [dispatch],
   );
 
-  const buildCells = (cvVersion) => {
+  const buildCells = (cvVersion, rowIndex) => {
     const {
       version,
       description,
@@ -157,7 +157,7 @@ const ContentViewVersions = ({ cvId, details }) => {
 
     return [
       <Checkbox
-        ouiaId={`select-version-${versionId}`}
+        ouiaId={`select-version-row-${rowIndex}`}
         id={versionId}
         aria-label={`Select version ${versionId}`}
         isChecked={isSelected(versionId)}
@@ -208,10 +208,11 @@ const ContentViewVersions = ({ cvId, details }) => {
     version,
     id: versionId,
     environments,
-  }) =>
+  }, rowIndex) =>
     [
       {
         title: __('Promote'),
+        ouiaId: `promote-version-row-${rowIndex}`,
         onClick: () => {
           onPromote({
             cvVersionId: versionId,
@@ -222,6 +223,7 @@ const ContentViewVersions = ({ cvId, details }) => {
       },
       {
         title: __('Remove from environments'),
+        ouiaId: `remove-version-row-${rowIndex}`,
         onClick: () => {
           onRemoveFromEnv({
             cvVersionId: versionId,
@@ -233,6 +235,7 @@ const ContentViewVersions = ({ cvId, details }) => {
       },
       {
         title: __('Delete'),
+        ouiaId: `delete-version-row-${rowIndex}`,
         onClick: () => {
           selectionSet.clear();
           selectOne(true, versionId);
@@ -381,9 +384,9 @@ const ContentViewVersions = ({ cvId, details }) => {
         </Tr>
       </Thead>
       <Tbody>
-        {results?.map((cvVersion) => {
+        {results?.map((cvVersion, rowIndex) => {
           const hasHistory = !!cvVersion?.active_history?.length;
-          const cells = buildCells(cvVersion);
+          const cells = buildCells(cvVersion, rowIndex);
           return (
             <Tr key={`row-${cvVersion.id}`} ouiaId={`row-${cvVersion.id}`}>
               {cells.map((cell, index) => {
@@ -399,7 +402,7 @@ const ContentViewVersions = ({ cvId, details }) => {
               {(!hasHistory && hasActionPermissions) &&
                 <Td
                   actions={{
-                    items: rowDropdownItems(cvVersion),
+                    items: rowDropdownItems(cvVersion, rowIndex),
                   }}
                 />}
             </Tr>);

--- a/webpack/scenes/ContentViews/Table/ContentViewsTable.js
+++ b/webpack/scenes/ContentViews/Table/ContentViewsTable.js
@@ -90,18 +90,21 @@ const ContentViewTable = () => {
 
     const publishAction = {
       title: __('Publish'),
+      ouiaId: 'publish-action',
       isDisabled: generatedFor !== 'none',
       onClick: () => openPublishModal(cvInfo),
     };
 
     const promoteAction = {
       title: __('Promote'),
+      ouiaId: 'promote-action',
       isDisabled: !cvVersionCount,
       onClick: () => openPromoteModal(cvInfo),
     };
 
     const copyAction = {
       title: __('Copy'),
+      ouiaId: 'copy-action',
       onClick: () => {
         setCopy(true);
         setActionableCvId(cvInfo.id.toString());
@@ -111,6 +114,7 @@ const ContentViewTable = () => {
 
     const deleteAction = {
       title: __('Delete'),
+      ouiaId: 'delete-action',
       onClick: () => openDeleteModal(cvInfo),
     };
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added static OUIA IDs to PatternFly 5 widgets on the Content View page to fix automation test failures. 

#### Considerations taken when implementing this change?

Static IDs were chosen for unique elements while maintaining consistent naming conventions to prevent test failures.

#### What are the testing steps for this pull request?

1. Locate the widgets on browser for Contentview page -> CV -> Promote
2. Observe the static OUIA ids of the widgets.

## Summary by Sourcery

Add static OUIA IDs to PF5 widgets on the Content View page to stabilize automation tests.

Enhancements:
- Add ouiaId props to publish, promote, copy, and delete actions in the ContentViews table.
- Add dynamic ouiaId props to promote, remove from environments, and delete actions for each version in the ContentView Versions component.