### PR TITLE
Fixes #38652 - Show preset CV filter rule values on edit

### DIFF
--- a/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
+++ b/webpack/scenes/ContentViews/Details/Filters/Rules/Package/AddEditPackageRuleModal.js
@@ -164,6 +164,7 @@ const AddEditPackageRuleModal = ({
               },
             }}
             onSearchChange={setName}
+            initialQuery={name}
           />
         </FormGroup>
         <FormGroup label={__('Architecture')} fieldId="architecture">
@@ -175,6 +176,7 @@ const AddEditPackageRuleModal = ({
               },
             }}
             onSearchChange={setArchitecture}
+            initialQuery={architecture}
           />
         </FormGroup>
         <FormGroup label={__('Version')} fieldId="version_comparator">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Values that were initially added to a CV filter rule are shown again

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Go to Content --> Lifecycle --> Content Views
Click any content view with rpm packages included
Go to Filters --> Create Filter --> Create filter of content type rpm
Click on the new filter
Add any RPM rule with package and architecture
Edit rule