### PR TITLE
Bump Katello to 4.19.0-master

### DIFF
--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.18.0-master".freeze
+  VERSION = "4.19.0-master".freeze
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Bump Katello to 4.19.0-master

## Summary by Sourcery

Chores:
- Update Katello version constant from 4.18.0-master to 4.19.0-master