### PR TITLE
Fixes #38666 - update Dropdown in host details actions

### DIFF
--- a/webpack/components/extensions/HostDetails/ActionsBar/index.js
+++ b/webpack/components/extensions/HostDetails/ActionsBar/index.js
@@ -2,8 +2,8 @@ import React, { useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   DropdownItem,
-  DropdownSeparator,
-} from '@patternfly/react-core/deprecated';
+  Divider,
+} from '@patternfly/react-core';
 import { CubeIcon, UndoIcon, RedoIcon } from '@patternfly/react-icons';
 
 import { translate as __ } from 'foremanReact/common/I18n';
@@ -51,12 +51,12 @@ const HostActionsBar = () => {
       <DropdownItem
         ouiaId="katello-legacy-contenthost-ui"
         key="katello-legacy-contenthost-ui"
-        href={foremanUrl(`/content_hosts/${hostDetails?.id}`)}
+        to={foremanUrl(`/content_hosts/${hostDetails?.id}`)}
         icon={<UndoIcon />}
       >
         {__('Legacy content host UI')}
       </DropdownItem>
-      <DropdownSeparator key="separator" ouiaId="katello-separator" />
+      <Divider key="separator" />
       {showRecalculate && (
         <DropdownItem
           ouiaId="katello-refresh-applicability"
@@ -72,7 +72,7 @@ const HostActionsBar = () => {
         <DropdownItem
           ouiaId="katello-change-host-content-source"
           key="katello-change-host-content-source"
-          href={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}&initialContentSourceId=${hostDetails?.content_facet_attributes?.content_source_id}`)}
+          to={foremanUrl(`/change_host_content_source?host_id=${hostDetails?.id}&initialContentSourceId=${hostDetails?.content_facet_attributes?.content_source_id}`)}
           icon={<CubeIcon />}
         >
           {__('Change content source')}


### PR DESCRIPTION
should be merged with https://github.com/theforeman/foreman/pull/10650

## Summary by Sourcery

Update host details actions dropdown to use internal routing via `to` prop and replace the separator with the `Divider` component.

Bug Fixes:
- Use `to` prop in DropdownItem instead of `href` for correct internal navigation

Enhancements:
- Replace DropdownSeparator with Divider in the HostActionsBar dropdown