### PR TITLE
Fixes #38672 - yum_or_yum_transient with defaults

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -89,7 +89,7 @@ module Katello
         prepend Overrides
 
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
-          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, :yum_or_yum_transient, to: :content_facet, allow_nil: true
+          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, to: :content_facet, allow_nil: true
 
         delegate :release_version, :purpose_role, :purpose_usage, to: :subscription_facet, allow_nil: true
 
@@ -602,6 +602,10 @@ module Katello
         entitlements = subscription_facet.candlepin_consumer.filter_entitlements(pool.cp_id)
         return nil if entitlements.empty?
         entitlements.sum { |e| e[:quantity] }
+      end
+
+      def yum_or_yum_transient
+        content_facet&.yum_or_yum_transient || "yum"
       end
 
       protected

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -199,6 +199,17 @@ module Katello
       ::SmartProxy.expects(:behind_load_balancer).with('unknown-proxy.example.com').returns([proxy_behind_lb])
       assert_equal host.remote_execution_proxies(rex_feature.name)[:registered_through], [proxy_behind_lb]
     end
+
+    def test_yum_or_yum_transient
+      assert_equal @foreman_host.yum_or_yum_transient, 'yum'
+
+      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
+      @foreman_host.content_facet.update(bootc_booted_image: 'quay.io/salami/soup')
+      assert_equal @foreman_host.yum_or_yum_transient, 'dnf --transient'
+
+      @foreman_host.content_facet.destroy!
+      assert_equal @foreman_host.reload.yum_or_yum_transient, 'yum'
+    end
   end
 
   class HostManagedExtensionsUpdateTest < HostManagedExtensionsTestBase


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Explicitly define yum_or_yum_transient in host extensions with a default rather then relying on the delegation mechanism which may return nil.

#### Considerations taken when implementing this change?
This could have also been fixed in rex, but I'd rather fix this at the source.

#### What are the testing steps for this pull request?
1) Navigate to Hosts > Templates > Job Templates > select "Package Action - Script Default"
2) In editor window header click "Preview" and select Foreman host (matches to Foreman FQDN) or any other host without a content facet
3) Check the script - line 21 - `-y $USER_INPUT[options] $USER_INPUT[action] $USER_INPUT[package]`

## Summary by Sourcery

Provide a default value for yum_or_yum_transient in host managed extensions to avoid nil and validate its behavior with new tests

Bug Fixes:
- Ensure yum_or_yum_transient defaults to "yum" instead of returning nil

Enhancements:
- Remove delegation of yum_or_yum_transient to content_facet and implement explicit fallback method

Tests:
- Add unit tests for yum_or_yum_transient covering default, transient dnf, and facet removal scenarios