### PR TITLE
Fixes #38672 - yum_or_yum_transient with defaults (#11476)

### DIFF
--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -89,7 +89,7 @@ module Katello
         prepend Overrides
 
         delegate :content_source_id, :single_content_view, :single_lifecycle_environment, :default_environment?, :single_content_view_environment?, :multi_content_view_environment?, :kickstart_repository_id, :bound_repositories,
-          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, :yum_or_yum_transient, to: :content_facet, allow_nil: true
+          :content_view_environment_labels, :installable_errata, :installable_rpms, :image_mode_host?, to: :content_facet, allow_nil: true
 
         delegate :release_version, :purpose_role, :purpose_usage, to: :subscription_facet, allow_nil: true
 
@@ -602,6 +602,10 @@ module Katello
         entitlements = subscription_facet.candlepin_consumer.filter_entitlements(pool.cp_id)
         return nil if entitlements.empty?
         entitlements.sum { |e| e[:quantity] }
+      end
+
+      def yum_or_yum_transient
+        content_facet&.yum_or_yum_transient || "yum"
       end
 
       protected

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -199,6 +199,17 @@ module Katello
       ::SmartProxy.expects(:behind_load_balancer).with('unknown-proxy.example.com').returns([proxy_behind_lb])
       assert_equal host.remote_execution_proxies(rex_feature.name)[:registered_through], [proxy_behind_lb]
     end
+
+    def test_yum_or_yum_transient
+      assert_equal @foreman_host.yum_or_yum_transient, 'yum'
+
+      Support::HostSupport.attach_content_facet(@foreman_host, @view, @library)
+      @foreman_host.content_facet.update(bootc_booted_image: 'quay.io/salami/soup')
+      assert_equal @foreman_host.yum_or_yum_transient, 'dnf --transient'
+
+      @foreman_host.content_facet.destroy!
+      assert_equal @foreman_host.reload.yum_or_yum_transient, 'yum'
+    end
   end
 
   class HostManagedExtensionsUpdateTest < HostManagedExtensionsTestBase


### PR DESCRIPTION
The call got delegated to a facet which may not have existed, in which case a nil was returned

(cherry picked from commit f4eb4c748bc736c61ff6aa25079d92dbd75018ad)

A 4.18 cherry-pick of #11476

## Summary by Sourcery

Provide a default fallback for yum_or_yum_transient so it never returns nil when the content facet is missing, and add tests to verify default and transient behavior.

Bug Fixes:
- Ensure yum_or_yum_transient falls back to "yum" when content_facet is nil instead of returning nil.

Tests:
- Add test_yum_or_yum_transient to verify default return value, transient dnf behavior, and behavior after content_facet removal.