### PR TITLE
Fixes #38675 - Registry Search Parameter Default:* (search all) can return incomplete results

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -67,6 +67,9 @@
              ng-disabled="discovery.working"
              placeholder="Default: * (search all)"
              name="discoverySearch"/>
+        <h6 translate>
+          Using a search parameter will improve repository discovery. A blank search might return an incomplete list due to registry's API limits.
+        </h6>
     </div>
 
     <span class="input-group-btn">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add a note for container repo discovery that registry API limits may cause incomplete results in the returned list.
#### Considerations taken when implementing this change?
Registries can implement their search APIs differently. Ex: registry.redhat has a limit of 3000 repositories. Quay.io has pagination of 25 per page so a query-less search is not going to be a complete list. We should warn users of this since handling all registry searches is impractical.
#### What are the testing steps for this pull request?
Go to Content > Products > Repository Discovery.
Check if you see the new note below the registry search param for container type repo discovery.

## Summary by Sourcery

Enhancements:
- Add inline note below the registry search field advising users to specify a search term for complete repository discovery