### PR TITLE
Fixes #38005 - Add "other" errata type on HostDetails content page

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-type.filter.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/errata-type.filter.js
@@ -25,7 +25,7 @@ angular.module('Bastion.errata').filter('errataType', ['translate', function (tr
             errataType = translate('Security Advisory');
             break;
         default:
-            errataType = type;
+            errataType = translate('Other Advisory');
         }
 
         return errataType;

--- a/engines/bastion_katello/test/errata/errata-type.filter.test.js
+++ b/engines/bastion_katello/test/errata/errata-type.filter.test.js
@@ -23,7 +23,7 @@ describe('Filter:errataType', function() {
         expect(filter('security')).toBe('Security Advisory');
     });
 
-    it("returns provided type if not found.", function() {
-        expect(filter('blah')).toBe('blah');
+    it("returns 'Other Advisory' if not found.", function() {
+        expect(filter('blah')).toBe('Other Advisory');
     });
 });

--- a/webpack/components/Errata/index.js
+++ b/webpack/components/Errata/index.js
@@ -14,6 +14,7 @@ import {
   SecurityIcon,
   EnhancementIcon,
   SquareIcon,
+  QuestionCircleIcon,
 } from '@patternfly/react-icons';
 import { TranslatedAnchor } from '../Table/components/TranslatedPlural';
 
@@ -81,6 +82,21 @@ export const ErrataSummary = ({ type, count, errataCategory }) => {
     );
     break;
   default:
+    label = __('Other');
+    ErrataIcon = QuestionCircleIcon;
+    color = '#6a6e73';
+    url = (
+      <TranslatedAnchor
+        id="errata-card-other-count"
+        style={{ marginLeft: '0.4rem' }}
+        href={`#/Content/errata?type=other&show=${errataCategory}`}
+        count={count}
+        plural="others"
+        singular="other"
+        zeroMsg="# others"
+        ariaLabel={`${count} others`}
+      />
+    );
   }
   if (!ErrataIcon) return null;
 
@@ -126,6 +142,8 @@ export const ErrataType = ({ type }) => {
     ErrataIcon = EnhancementIcon;
     break;
   default:
+    label = __('Other');
+    ErrataIcon = QuestionCircleIcon;
   }
   if (!ErrataIcon) return null;
 

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/HostErrataConstants.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/HostErrataConstants.js
@@ -5,6 +5,7 @@ export const ERRATA_TYPES = {
   SECURITY: 'Security',
   BUGFIX: 'Bugfix',
   ENHANCEMENT: 'Enhancement',
+  OTHER: 'Other',
 };
 export const ERRATA_SEVERITIES = {
   NOT_APPLICABLE: 'N/A',
@@ -18,6 +19,7 @@ export const TYPES_TO_PARAM = {
   [ERRATA_TYPES.SECURITY]: 'security',
   [ERRATA_TYPES.BUGFIX]: 'bugfix',
   [ERRATA_TYPES.ENHANCEMENT]: 'enhancement',
+  [ERRATA_TYPES.OTHER]: 'other',
 };
 
 export const SEVERITIES_TO_PARAM = {
@@ -32,6 +34,7 @@ export const PARAM_TO_FRIENDLY_NAME = {
   security: 'Security',
   bugfix: 'Bugfix',
   enhancement: 'Enhancement',
+  other: 'Other',
   none: 'N/A',
   low: 'Low',
   moderate: 'Moderate',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added the 'other' type to the errata type column and the type filter dropdown menu on the HostDetails Content Page, and added support for filtering errata by the new 'other' type in scoped search.

#### Considerations taken when implementing this change?

Consolidates handling of errata types other than security, bugfix, and enhancement into the 'other' category across the full stack. This ensures consistent classification and display of non-standard errata types from the backend API through to the frontend UI components and localization filters.

#### What are the testing steps for this pull request?

Create 'other' Errata type:

1. Install EPEL 8 on your foreman server:
    - Create a content credential GPG key from this URL: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8.
    - Create a product 'EPEL8' using the GPG key.
    - 'New Repository' named 'EPEL8 x86_64' or something similar of type 'yum'. Restrict to x86_64 and set the upstream URL to https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/. Set the download policy to 'On Demand'. You may have to set the GPG key here as well.
    - Run a sync on the repo.
2. Create a test content view and add EPEL8 to the repositories list. Publish a new version.
3. Add a filter to the CV, 'Errata by Date Range', include. Set the end date of the filter to today, and check the 'Other' field to allow for non-standard errata to be added to the filter.
4. Add another filter, 'RPM', and check 'Include all RPMs not associated with any errata'.
5. Publish a new CV version (this will take a while).
6. Go to the content view version overview page. The package and errata count should match the initial counts for V1.

Navigate to Host -> Host details -> Content -> Errata

'Other' type should be available in the errata type column and the type filter dropdown menu, and support has been added for filtering errata by the new 'other' type in scoped search.

## Summary by Sourcery

Introduce and integrate an “other” errata type for classification and filtering across the backend API and Host Details UI

New Features:
- Add “other” errata type to the API mapping, scoped search, and Host Details errata filters

Enhancements:
- Extend API filter logic to treat all non-standard errata as “other” and update the parameter documentation
- Update frontend constants and ErrataSummary/ErrataType components to display “Other” with the appropriate icon and labels
- Strip the extraneous errata_type field from auto-complete search responses for cleaner results