### PR TITLE
Fixes #38687 - Limit Bulk Errata Wizard errata to installable

### DIFF
--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
@@ -51,7 +51,7 @@ export const useErrataHostsBulkSelect = ({ initialSelectedHosts, modalIsOpen }) 
   };
 };
 
-export const ERRATA_URL = `${katelloApi.getApiUrl('/errata')}?per_page=7&include_permissions=true`;
+export const ERRATA_URL = `${katelloApi.getApiUrl('/errata')}?per_page=7&include_permissions=true&errata_restrict_installable=true`;
 
 const BulkErrataWizard = () => {
   const { modalOpen, setModalClosed: closeModal } = useForemanModal({ id: 'bulk-errata-wizard' });


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Limit the Errata displayed in the Bulk Errata Wizard on new Hosts Overview page to the ones installable (on any host).

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
Have one or multiple hosts on a Content View Version so that there are Upgradable Errata as well as Installable Errata.
Select the Hosts on the new Hosts Overview page and select 'Manage Content -> Errata' from the Kebab menu.

**Expected:** 
- Installable Errata are displayed
- Errata that have already been installed on all hosts are **not shown**
- Errata that are applicable and not installable on any host are **not shown**

## Summary by Sourcery

Bug Fixes:
- Filter out non-installable errata by adding the "errata_restrict_installable=true" parameter to the errata API URL