### PR TITLE
Fixes #38689 - Skip SetContent for rolling CV deletion (404 fix)

### DIFF
--- a/app/lib/actions/katello/repository/destroy.rb
+++ b/app/lib/actions/katello/repository/destroy.rb
@@ -96,8 +96,9 @@ module Actions
         end
 
         def handle_redhat_content(repository)
-          if repository.content_view.content_view_environment(repository.environment)
-            plan_action(Candlepin::Environment::SetContent, repository.content_view, repository.environment, repository.content_view.content_view_environment(repository.environment))
+          content_view_environment = repository.content_view.content_view_environment(repository.environment)
+          if content_view_environment && !repository.content_view.rolling?
+            plan_action(Candlepin::Environment::SetContent, repository.content_view, repository.environment, content_view_environment)
           end
         end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Modified the handle_redhat_content method in Repository::Destroy to skip the SetContent action for Rolling Content Views. This prevents Rolling Content Views from attempting to update Candlepin environment content associations during deletion, eliminating the 404 error caused when Red Hat repositories tried to access already-deleted Candlepin environments.

#### Considerations taken when implementing this change?

Scope limited to rolling CV deletion; other paths untouched.

#### What are the testing steps for this pull request?

1. Navigate to Satellite WebUI -> Content -> Red Hat Repositories
2. Enable any repository (e.g., rhel-8-for-x86_64-baseos-rpms)
3. Synchronize the enabled repository
4. Create a Rolling Content View and add the enabled repository to the content view
5. Navigate to Satellite WebUI -> Content -> Lifecycle -> Content Views
6. Locate the Rolling Content View, click the three vertical dots at the end of the row, and click Delete
7. The Rolling Content View should be successfully deleted without triggering errors.