### PR TITLE
Fixes #38649 - Long container push uploads result in authentication error

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -110,9 +110,48 @@ module Katello
 
       return true if is_user_set
 
+      # For blob upload operations, try to extend expired tokens
+      if !is_user_set && blob_upload_operation? && token_expired_but_valid? && extend_expired_token
+        return true
+      end
+
       redirect_authorization_headers
       render_error('unauthorized', :status => :unauthorized)
       return false
+    end
+
+    def blob_upload_operation?
+      %w[start_upload_blob upload_blob finish_upload_blob push_manifest].include?(params[:action])
+    end
+
+    def token_expired_but_valid?
+      return false unless request.headers['Authorization']
+
+      token_type, token = request.headers['Authorization'].split
+      return false unless token_type == 'Bearer' && token
+
+      personal_token = PersonalAccessToken.find_by_token(token)
+      personal_token&.expired? && personal_token.name == 'registry'
+    end
+
+    def extend_expired_token
+      return false unless request.headers['Authorization']
+
+      token_type, token = request.headers['Authorization'].split
+      return false unless token_type == 'Bearer' && token
+
+      personal_token = PersonalAccessToken.find_by_token(token)
+      return false unless personal_token&.expired? && personal_token.name == 'registry'
+
+      begin
+        personal_token.expires_at = 1.minute.from_now
+        personal_token.save!
+        User.current = User.unscoped.find(personal_token.user_id)
+        return true if User.current
+      rescue ActiveRecord::RecordInvalid
+        return false
+      end
+      false
     end
 
     def container_push_prop_validation(props = nil)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
If token expires during a container push, extend the token expiry to be able to finish the upload.
#### What are the testing steps for this pull request?
Reproducing is a little bit of a hassle.
First, update the token expiration from `expires_at: 6.minutes.from_now` to `expires_at: 1.minutes.from_now` in the controller in token method.
Next, I used a box with a large disk to create a large container image of size 10G with:
```
FROM quay.io/jitesoft/alpine:latest
WORKDIR /app
RUN dd if=/dev/zero of=large_file bs=1M count=10240
CMD ["tail", "-f", "/dev/null"]
```
Build the image with `podman build -t large-image .`
Push the image like 
podman push $IMAGE_SHA docker://hostname/organization_label/product_label/large_image:latest

If you're not able to reproduce the authentication expiration, you can also try adding network delays.
I did it using: `sudo tc qdisc add dev enp3s0 root netem delay 100ms` where enp3s0 is the interface name from `ip a`