### PR TITLE
Fixes #38701 - Handle organization validation error

### DIFF
--- a/app/controllers/katello/concerns/organizations_controller_extensions.rb
+++ b/app/controllers/katello/concerns/organizations_controller_extensions.rb
@@ -24,6 +24,9 @@ module Katello
           if taxonomy_class == Organization
             begin
               @taxonomy = Organization.new(resource_params)
+              # Raise validation error early if invalid
+              @taxonomy.validate!
+
               ::Katello::OrganizationCreator.new(@taxonomy).create!
               @taxonomy.reload
               switch_taxonomy


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
In this PR, i have added a fix  for validation issue while creating new organization with  blank data. added a validate! method to check validation before proceeding to `::Katello::OrganizationCreator.new(@taxonomy).create!` , which causes json dump error.

#### Considerations taken when implementing this change?
We must have foreman+katello environment. 

#### What are the testing steps for this pull request?
We test it by following steps:-

- In the Foreman, navigate to the Organizations page.(Administer>>Organizations)

- Click the "New Organisation" button.

- On the "Create Organisation" form, leave all fields (e.g., "Name") blank.

- Click the "Submit" button, you should see a proper validation error rather than json dump of candlepin api response

## Summary by Sourcery

Bug Fixes:
- Invoke validate! on new Organization to catch blank-data validation errors before proceeding to creation and avoid JSON dump errors.