### PR TITLE
Fixes #38717 - Update Capsule, Maintenance & Utils repos to 6.18

### DIFF
--- a/app/models/katello/rhel_lifecycle_status.rb
+++ b/app/models/katello/rhel_lifecycle_status.rb
@@ -14,7 +14,9 @@ module Katello
 
     RHEL_EOS_SCHEDULE = { # dates that each support category ends
       'RHEL10' => {
-        'full_support' => nil,
+        'full_support' => end_of_day('2030-05-31'),
+        'maintenance_support' => end_of_day('2035-05-31'),
+        'extended_support' => end_of_day('2038-05-31'),
       },
       'RHEL9' => {
         'full_support' => end_of_day('2027-05-31'),

--- a/webpack/redux/actions/RedHatRepositories/helpers.js
+++ b/webpack/redux/actions/RedHatRepositories/helpers.js
@@ -40,9 +40,9 @@ const recommendedRepositoriesSatTools = [
 ];
 
 const recommendedRepositoriesMisc = [
-  'satellite-utils-6.17-for-rhel-9-x86_64-rpms',
-  'satellite-maintenance-6.17-for-rhel-9-x86_64-rpms',
-  'satellite-capsule-6.17-for-rhel-9-x86_64-rpms',
+  'satellite-utils-6.18-for-rhel-9-x86_64-rpms',
+  'satellite-maintenance-6.18-for-rhel-9-x86_64-rpms',
+  'satellite-capsule-6.18-for-rhel-9-x86_64-rpms',
 ];
 
 const recommendedRepositorySetLables = recommendedRepositoriesRHEL


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated Recommended Repositories Page to modify Satellite, Capsule and Maintainance repository from 6.17 to 6.18 for RHEL 9

#### Considerations taken when implementing this change?

Care was taken to modify only the relevant repository entries while keeping the structure intact to avoid unintended impacts.

#### What are the testing steps for this pull request?

Need to verify that RHEL 9 based repos for Capsule, Maintenance and Utils can be listed and enabled successfully on the WebUI

## Summary by Sourcery

Enhancements:
- Bump satellite-utils, satellite-maintenance, and satellite-capsule repository entries from 6.17 to 6.18 for RHEL 9