### PR TITLE
Fixes #38721 - Allow env_id param only on rolling CVs

### DIFF
--- a/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
+++ b/webpack/scenes/ContentViews/Create/CreateContentViewForm.js
@@ -79,7 +79,7 @@ const CreateContentViewForm = ({ setModalOpen }) => {
   const checkedEnvIds = selectedEnvs?.map(env => env.id) ?? [];
   const onSave = () => {
     setSaving(true);
-    dispatch(createContentView({
+    let params = {
       name,
       label,
       description,
@@ -87,8 +87,11 @@ const CreateContentViewForm = ({ setModalOpen }) => {
       rolling,
       solve_dependencies: (dependencies && !(rolling || composite)),
       auto_publish: (autoPublish && composite),
-      environment_ids: (checkedEnvIds),
-    }));
+    };
+    if (rolling) {
+      params = { ...params, environment_ids: checkedEnvIds };
+    }
+    dispatch(createContentView(params));
   };
 
   useEffect(


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Only send environment_ids as create CV params when CV is rolling
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a regular/composite/rolling CV on the UI
2. Make sure you can correctly create all 3 types.

## Summary by Sourcery

Ensure environment_ids is passed only for rolling content views and add corresponding test coverage

Bug Fixes:
- Prevent environment_ids from being sent when creating regular or composite content views

Enhancements:
- Adjust CreateContentViewForm onSave to conditionally include environment_ids only for rolling views

Tests:
- Add a test for creating a rolling content view with environment_ids and update test fixtures