### PR TITLE
Fixes #38723 - Updates katello controllers to delay actions for RH Cloud

### DIFF
--- a/app/controllers/katello/api/v2/organizations_controller.rb
+++ b/app/controllers/katello/api/v2/organizations_controller.rb
@@ -13,7 +13,7 @@ module Katello
       api_base_url "/katello/api"
     end
 
-    def self.delay_find_taxonomy_actions
+    def self.before_find_taxonomy_actions
       # used by RH Cloud to delay the execution of local_find_taxonomy
       skip_before_action :local_find_taxonomy, :only => LOCAL_FIND_TAXONOMY_ACTIONS
       yield

--- a/app/controllers/katello/api/v2/repositories_controller.rb
+++ b/app/controllers/katello/api/v2/repositories_controller.rb
@@ -35,7 +35,7 @@ module Katello
     skip_before_action :authorize, :only => [:gpg_key_content]
     skip_before_action :check_media_type, :only => [:upload_content]
 
-    def self.delay_index_actions
+    def self.before_index_actions
       # used by RH Cloud to delay the execution of find_optional_organization and find_product
       skip_before_action :find_optional_organization, :only => INDEX_ACTIONS
       skip_before_action :find_product, :only => INDEX_ACTIONS


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This pr adds methods to delay index and other organization controller actions so that those actions work with RH cloud properly setup

#### Considerations taken when implementing this change?
The foreman_rh_cloud plugin overwrites the list of methods that run local_find_taxonomy as a before_action in the Organizations controller: https://github.com/theforeman/foreman_rh_cloud/pull/1003/files#diff-d703d9179cea9d0d9bb78f9d6a1028620c7d4270479ebed553223bf4826ddc3dR227

Changed it to work via a yield mechanism

#### What are the testing steps for this pull request?

* Start katello with foreman rh cloud
* run this hammer command
```
$ hammer organization configure-cdn --id 1 --type redhat_cdn --url "https://cdn.redhat.com" ```

Before Applying this PR and RH Cloud PR
```
Could not update CDN configuration.:
  Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs.
```

After Applying this PR and RH Cloud PR

```
CDN Configuration Updated
```

## Summary by Sourcery

Enable postponing of specific before_action filters in Katello API controllers to ensure compatibility with the RH Cloud plugin

Enhancements:
- Extract index and taxonomy action lists into INDEX_ACTIONS and LOCAL_FIND_TAXONOMY_ACTIONS constants
- Add delay_index_actions and delay_find_taxonomy_actions methods to temporarily skip and reapply before_action filters