### PR TITLE
Fixes #38724 - Handle /consumers/ path in manifest apiUrl and environment variables

### DIFF
--- a/app/lib/katello/resources/candlepin/upstream_job.rb
+++ b/app/lib/katello/resources/candlepin/upstream_job.rb
@@ -5,13 +5,14 @@ module Katello
         class << self
           NOT_FINISHED_STATES = %w(CREATED WAITING PENDING RUNNING).freeze unless defined? NOT_FINISHED_STATES
           API_URL = 'https://subscription.rhsm.redhat.com/subscription'.freeze
+          SUBSCRIPTION_PATH = '/subscription'.freeze
 
           def not_finished?(job)
             NOT_FINISHED_STATES.include?(job[:state])
           end
 
           def get(id, upstream)
-            url = ENV['REDHAT_RHSM_API_URL'] || API_URL
+            url = ENV['REDHAT_RHSM_API_URL'] || subscription_path(upstream['apiUrl']) || API_URL
             response = Resources::Candlepin::UpstreamConsumer.start_upstream_export("#{url}#{path(id)}", upstream['idCert']['cert'],
               upstream['idCert']['key'], nil)
             job = JSON.parse(response)
@@ -20,6 +21,13 @@ module Katello
 
           def path(id = nil)
             "/jobs/#{id}"
+          end
+
+          def subscription_path(upstream_api_url)
+            return if upstream_api_url.blank?
+            uri = URI.parse(upstream_api_url) # https://subscription.rhsm.redhat.com/subscription/consumers/
+            uri.path = SUBSCRIPTION_PATH # https://subscription.rhsm.redhat.com/subscription
+            uri.to_s
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/upstream_job.rb
+++ b/app/lib/katello/resources/candlepin/upstream_job.rb
@@ -12,7 +12,7 @@ module Katello
           end
 
           def get(id, upstream)
-            url = ENV['REDHAT_RHSM_API_URL'] || subscription_path(upstream['apiUrl']) || API_URL
+            url = subscription_path(ENV['REDHAT_RHSM_API_URL']) || subscription_path(upstream['apiUrl']) || API_URL
             response = Resources::Candlepin::UpstreamConsumer.start_upstream_export("#{url}#{path(id)}", upstream['idCert']['cert'],
               upstream['idCert']['key'], nil)
             job = JSON.parse(response)

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -36,16 +36,16 @@ module Katello
       CONSUMERS_PATH = '/consumers/'.freeze
       API_URL = API_BASE_URL + SUBSCRIPTION_PATH + CONSUMERS_PATH # https://subscription.rhsm.redhat.com/subscription/consumers/
 
-      def url_from_manifest(upstream = {})
-        url = upstream['apiUrl'] # only take base url from the manifest; we will overwrite the path to ensure it's correct
-        return nil if url.blank?
-        uri = URI.parse(url)
+      def normalize_api_url(api_url)
+        return nil if api_url.blank?
+        uri = URI.parse(api_url)
+        # only take base url; we will overwrite the path to ensure it's correct
         uri.path = SUBSCRIPTION_PATH + CONSUMERS_PATH # https://subscription.rhsm.redhat.com/subscription/consumers/
         uri.to_s
       end
 
       def api_url(upstream = {})
-        ENV['REDHAT_RHSM_API_URL'] || url_from_manifest(upstream) || API_URL
+        ENV['REDHAT_RHSM_API_URL'] || normalize_api_url(upstream['apiUrl']) || API_URL
       end
 
       def sync

--- a/app/models/katello/glue/provider.rb
+++ b/app/models/katello/glue/provider.rb
@@ -31,10 +31,21 @@ module Katello
     end
 
     module InstanceMethods
-      API_URL = 'https://subscription.rhsm.redhat.com/subscription/consumers/'.freeze
+      API_BASE_URL = 'https://subscription.rhsm.redhat.com'.freeze
+      SUBSCRIPTION_PATH = '/subscription'.freeze
+      CONSUMERS_PATH = '/consumers/'.freeze
+      API_URL = API_BASE_URL + SUBSCRIPTION_PATH + CONSUMERS_PATH # https://subscription.rhsm.redhat.com/subscription/consumers/
+
+      def url_from_manifest(upstream = {})
+        url = upstream['apiUrl'] # only take base url from the manifest; we will overwrite the path to ensure it's correct
+        return nil if url.blank?
+        uri = URI.parse(url)
+        uri.path = SUBSCRIPTION_PATH + CONSUMERS_PATH # https://subscription.rhsm.redhat.com/subscription/consumers/
+        uri.to_s
+      end
+
       def api_url(upstream = {})
-        # Default to Red Hat
-        ENV['REDHAT_RHSM_API_URL'] || upstream['apiUrl'] || API_URL
+        ENV['REDHAT_RHSM_API_URL'] || url_from_manifest(upstream) || API_URL
       end
 
       def sync

--- a/test/models/provider_test.rb
+++ b/test/models/provider_test.rb
@@ -4,7 +4,7 @@ module Katello
   class ProviderTest < ActiveSupport::TestCase
     class OwnerUpstreamUpdateTest < ActiveSupport::TestCase
       let(:provider) { katello_providers(:redhat) }
-      let(:api_url) { 'http://theforeman.org' }
+      let(:api_url) { 'http://theforeman.org/subscription/consumers/' }
       let(:expected_url) { api_url }
 
       def setup


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Katello provides 3 ways to give a url to contact Hosted Candlepin, in order:
1. You can use the environment variable REDHAT_RHSM_API_URL. (Using env vars is for devel environments only.)
2. If your organization's upstream consumer (manifest) has a value for 'apiUrl', it uses that.
3. Finally, it falls back to hard-coded URLs.

We can see the format of the expected URL by looking at the hard-coded ones:

In Glue::Provider:
```
API_URL = 'https://subscription.rhsm.redhat.com/subscription/consumers/'.freeze
```

But in Katello::Resources::Candlepin::UpstreamJob it doesn't append '/consumers/':
```
API_URL = 'https://subscription.rhsm.redhat.com/subscription'.freeze
```

The result is that if the upstream consumer in your manifest has an apiUrl that appends the `'/consumers/'` path, calls from Glue::Provider will succeed but calls to UpstreamJob will fail. But if your manifest does NOT append the `'/consumers/'` path, calls from Glue::Provider will fail and calls to UpstreamJob will succeed.

Katello needs to handle adding or subtracting the '/consumers/' as needed.

This change will allow your apiUrl to either have or not have `'/consumers/'` at the end, and manifest refreshes should work either way.

#### Considerations taken when implementing this change?

(If you don't provide environment variables) Previously, Glue::Provider was using the url from the manifest, while UpstreamJob was using the hard-coded url. This change makes it consistent (use _all_ env vars, _all_ manifest url, or _all_ hard-coded).

#### What are the testing steps for this pull request?

Test manifest refresh.

Set env var and ensure it uses the url from your env var.
Obtain a stage manifest and ensure (a) manifest refresh succeeds; and (b) it uses the url from the manifest.
Refresh a "regular" manifest and make sure that continues to work too.


## Summary by Sourcery

Ensure Katello correctly handles apiUrl values with or without the "/consumers/" suffix by normalizing URLs in both Glue::Provider and UpstreamJob

Enhancements:
- Normalize API URL handling by always appending "/consumers/" in Glue::Provider when missing
- Strip trailing "/consumers/" in UpstreamJob.get to avoid duplicate path segments
- Introduce API_BASE_URL and CONSUMERS_PATH constants to centralize URL components
- Add url_from_manifest helper to unify manifest URL parsing in Glue::Provider

## Summary by Sourcery

Normalize manifest apiUrl handling to consistently support values with or without the '/consumers/' suffix across Glue::Provider and UpstreamJob.

Bug Fixes:
- Allow manifest apiUrl values that include or omit '/consumers/' to work uniformly for provider and upstream export calls.

Enhancements:
- Introduce API_BASE_URL and CONSUMERS_PATH constants to centralize URL components
- Add url_from_manifest helper in Glue::Provider to append '/consumers/' when missing
- Strip trailing '/consumers/' in UpstreamJob.get to avoid duplicate path segments