### PR TITLE
Fixes #38720 - Validate Flatpak remote repo product mirroring

### DIFF
--- a/app/controllers/katello/api/v2/flatpak_remote_repositories_controller.rb
+++ b/app/controllers/katello/api/v2/flatpak_remote_repositories_controller.rb
@@ -56,6 +56,7 @@ module Katello
     param :product_name, String, :desc => N_("Name of the product to mirror the remote repository to")
     param :organization_id, :number, :desc => N_("organization identifier")
     def mirror
+      validate_product_for_mirroring
       task = async_task(::Actions::Katello::Flatpak::MirrorRemoteRepository, @flatpak_remote_repository, @product)
       respond_for_async :resource => task
     end
@@ -93,6 +94,14 @@ module Katello
 
     def rejected_autocomplete_items
       ['flatpak_remote_id', 'flatpak_remote']
+    end
+
+    private
+
+    def validate_product_for_mirroring
+      return unless @product&.redhat?
+      msg = _("Flatpak repositories cannot be mirrored into Red Hat products. Please select a custom product.")
+      fail HttpErrors::UnprocessableEntity, msg
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added validation to prevent Flatpak remote repositories from being mirrored into Red Hat products. The changes include a backend validation method that throws an error when attempting to mirror into Red Hat products, and a frontend informational message in the mirror modal that clearly indicates to users that only custom products can be used for Flatpak repository mirroring.

#### Considerations taken when implementing this change?

The implementation considers user experience by providing clear upfront guidance in the UI with an informational message, while also ensuring data integrity through backend validation that prevents invalid operations.

#### What are the testing steps for this pull request?

1. Navigate to Content > Flatpak Remotes in the Satellite web UI.
2. Click on an existing Flatpak Remote.
3. From the list of remote repositories, locate a repository you want to mirror.
4. Select the Mirror action for the repository.
5. In the Mirror dialog, choose a default Red Hat product as the target.
6. Click Mirror.
7. Should produce an error with the message: "Flatpak repositories cannot be mirrored into Red Hat products. Please select a custom product."

## Summary by Sourcery

Prevent Flatpak remote repositories from being mirrored into Red Hat products by adding backend validation that raises an error and a frontend notice guiding users to select custom products.

Bug Fixes:
- Reject mirroring of Flatpak remote repositories into Red Hat products via backend validation

Enhancements:
- Display an informational message in the Flatpak mirror modal about custom-product-only mirroring