### PR TITLE
Fixes #38726 - Fix rolling CV creation without environments

### DIFF
--- a/app/lib/actions/katello/content_view/create.rb
+++ b/app/lib/actions/katello/content_view/create.rb
@@ -6,7 +6,7 @@ module Actions
           content_view.save!
           if content_view.rolling?
             new_version = content_view.create_new_version
-            if environment_ids.any?
+            if environment_ids&.any?
               ::Katello::KTEnvironment.where(id: environment_ids).each do |environment|
                 plan_action(AddToEnvironment, new_version, environment)
               end

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -167,6 +167,12 @@ module Katello
       assert_response 404
     end
 
+    def test_create_empty_rolling
+      post :create, params: { :name => "Rolling Test", :organization_id => @organization.id, :rolling => true }
+
+      assert_response :success
+    end
+
     def test_create_with_non_json_request
       @request.env['CONTENT_TYPE'] = 'application/x-www-form-urlencoded'
       post :create, params: { :name => "My View", :description => "Cool", :organization_id => @organization.id }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Rolling CV creation should not fail when the user does not supply any environment_ids to the API.

#### Considerations taken when implementing this change?

During the design phase we deliberately chose to allow the creation of rolling CVs without any environments (both via UI and API) because we did not want to default to Library (which we want to discourage as a matter of good practice, but is the only environment that is always available and thereby usable as a default value).

A rolling CV without any associated environments is functionally useless, but it is very simple to create it that way first, and then add an environment later using update.

## Summary by Sourcery

Bug Fixes:
- Prevent failure when creating a rolling content view without any environment_ids by adding a safe navigation check

## Summary by Sourcery

Allow creating rolling content views without any environment IDs supplied

Bug Fixes:
- Prevent failure when creating a rolling content view without environment_ids by adding a safe navigation check

Tests:
- Add test to verify successful creation of an empty rolling content view without environment_ids