### PR TITLE
Refs #38685 - Clean duplicate erratum packages as a migration

### DIFF
--- a/db/migrate/20250613210050_use_big_int_for_erratum_packages_id.rb
+++ b/db/migrate/20250613210050_use_big_int_for_erratum_packages_id.rb
@@ -1,5 +1,6 @@
 class UseBigIntForErratumPackagesId < ActiveRecord::Migration[7.0]
   def up
+    cleanup_duplicate_erratum_packages
     execute 'ALTER SEQUENCE katello_erratum_packages_id_seq AS bigint;'
     change_column :katello_erratum_packages, :id, :bigint
   end
@@ -7,5 +8,56 @@ class UseBigIntForErratumPackagesId < ActiveRecord::Migration[7.0]
   def down
     change_column :katello_erratum_packages, :id, :integer
     execute 'ALTER SEQUENCE katello_erratum_packages_id_seq AS integer;'
+  end
+
+  def cleanup_duplicate_erratum_packages
+    duplicate_groups = Katello::ErratumPackage
+                        .select(:nvrea, :erratum_id, :name, :filename)
+                        .group(:nvrea, :erratum_id, :name, :filename)
+                        .having('COUNT(*) > 1')
+
+    return if duplicate_groups.empty?
+
+    ids_to_delete = []
+    update_mappings = {}
+
+    duplicate_groups.each do |group|
+      duplicate_ids = Katello::ErratumPackage
+                       .where(
+                        nvrea: group.nvrea,
+                        erratum_id: group.erratum_id,
+                        name: group.name,
+                        filename: group.filename
+                       )
+                       .order(:id)
+                       .pluck(:id)
+
+      id_to_keep = duplicate_ids.first
+      ids_to_remove = duplicate_ids[1..]
+
+      ids_to_delete.concat(ids_to_remove)
+      ids_to_remove.each { |id| update_mappings[id] = id_to_keep }
+    end
+
+    return if ids_to_delete.empty?
+
+    update_mappings.each_slice(1000) do |batch|
+      batch.each do |old_id, new_id|
+        Katello::ModuleStreamErratumPackage
+         .where(erratum_package_id: old_id)
+         .where(
+          module_stream_id: Katello::ModuleStreamErratumPackage
+                             .where(erratum_package_id: new_id)
+                             .select(:module_stream_id)
+         )
+         .delete_all
+
+        Katello::ModuleStreamErratumPackage
+         .where(erratum_package_id: old_id)
+         .update_all(erratum_package_id: new_id)
+      end
+    end
+  
+    Katello::ErratumPackage.where(id: ids_to_delete).delete_all
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
We introduced a rake task as part of: https://github.com/Katello/katello/pull/11480 .. However, to properly run the upgrade without depending on the rake task as upstream doesn't have f-m and the pre-upgrade hook in f-m can't access the rake task without backporting the task in time, a migration file change would be the change easier to deliver.
#### Considerations taken when implementing this change?
Transfer rake task logic to migration file for bigint migration which in a case triggered the bad index error.
#### What are the testing steps for this pull request?
Refer to steps in https://github.com/Katello/katello/pull/11480#issue-3340229956.

However, you'll want to run bundle exec rails db:rollback before/after you've created all the test data to be able to rerun the updated migration file with bundle exec rails db:migrate.

## Summary by Sourcery

Incorporate duplicate erratum package cleanup into the bigint migration to ensure a smooth upgrade without relying on an external rake task

Enhancements:
- Embed cleanup_duplicate_erratum_packages method in UseBigIntForErratumPackagesId migration
- Detect and consolidate duplicate erratum package records by merging related module_stream associations
- Remove redundant erratum package entries before altering the id column to bigint