### PR TITLE
Fixes #38754 - Fix date_type undefined

### DIFF
--- a/app/controllers/katello/api/v2/errata_controller.rb
+++ b/app/controllers/katello/api/v2/errata_controller.rb
@@ -55,8 +55,8 @@ module Katello
           collection = collection.applicable_to_hosts(hosts)
         end
       end
-      date_type = params[:date_type].present? ? params[:date_type] : ContentViewErratumFilterRule::UPDATED
-      unless ContentViewErratumFilterRule::DATE_TYPES.include?(date_type)
+      @date_type = params[:date_type].present? ? params[:date_type] : ContentViewErratumFilterRule::UPDATED
+      unless ContentViewErratumFilterRule::DATE_TYPES.include?(@date_type)
         msg = _("Invalid params provided - date_type must be one of %s" % ContentViewErratumFilterRule::DATE_TYPES.join(","))
         fail HttpErrors::UnprocessableEntity, msg
       end
@@ -65,8 +65,8 @@ module Katello
     end
 
     def custom_index_relation_handle_type_and_time(collection)
-      collection = collection.where("#{date_type} >= ?", params[:start_date]) if params[:start_date]
-      collection = collection.where("#{date_type} <= ?", params[:end_date]) if params[:end_date]
+      collection = collection.where("#{@date_type} >= ?", params[:start_date]) if params[:start_date]
+      collection = collection.where("#{@date_type} <= ?", params[:end_date]) if params[:end_date]
       if params[:types]
         include_other = params[:types]&.include?('other')
         params[:types]&.delete('other')


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Make sure sanitized `date_type` can be used in Controller methods

#### What are the testing steps for this pull request?
Create new filter rule for Errata and select a Start Date. The filtering of the list should no longer fail.

## Summary by Sourcery

Fix undefined date_type error in the errata API filter by using an instance variable to store the sanitized date_type between controller methods.

Bug Fixes:
- Switch from a local variable to an instance variable for date_type to ensure it's accessible in subsequent filter methods
- Validate date_type against allowed values and return an unprocessable entity error if invalid