### PR TITLE
Fixes #38744 - Allow redirect from aliased hostname in registry_proxies_controller

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -574,7 +574,7 @@ module Katello
       return yield
     rescue RestClient::Exception => exception
       if [301, 302, 307].include?(exception.response.code)
-        redirect_to exception.response.headers[:location]
+        redirect_to exception.response.headers[:location], allow_other_host: true
         nil
       else
         raise exception


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR allows users to pull containers from katello through a dns alias. Previously, a redirect from blob SHA address to the pulp blob address would error out on redirect since the aliased hostname would redirect to the standard hostname. Now this redirect is allowed.

#### Considerations taken when implementing this change?
- **Here's an open question**: If a host has access to `alias.example.com` but not `address.example.com`, this redirect will not work. Should we redirect to the alias hostname automatically?
  - This requires a rewrite of `app/lib/katello/resources/registry.rb:Proxy.self.get` and `app/lib/katello/resources/candlepin.rb:CandlepinResource.rest_client` to pass in the aliased domain name from the initial request. This isn't something we do anywhere else.
- There may be a small risk of a container pull on a compromised container being sent to some 3rd party address and downloading malicious files. This would (to the best of my knowledge) require a compromised pulp instance, but special care should be taken with this nonetheless.

#### What are the testing steps for this pull request?
1. Add a DNS alias to your environment:
  * Modifying /etc/hosts is a good option. Add a line like `x.x.x.x address.example.com alias.example.com`. Message Quinn James (me) if you'd like a way to do this "properly" without loopback.
2. Change foreman's config/settings.yaml file and add the following:
```
# Configure hostnames for ActionDispatch::HostAuthorization
# Only hostnames are supported. Regular expressions and IP addresses/ranges are not.
# https://guides.rubyonrails.org/v6.1/configuring.html#configuring-middleware
:hosts:  
  - alias.example.com 
```
3. Run `podman login alias.example.com --tls-verify=false`. It should work.
4. Run `podman push XXXXXX alias.example.com/org_label/product_label/repo_name --tls-verify=false`. It should work.
5. Run `podman pull alias.example.com/org_label/product_label/repo_name --tls-verify=false`. It should fail with a 500 internal server error.
6. Rerun the above step after pulling this PR. It should succeed.
