### PR TITLE
Fixes #38774 - Subscription page shows an error to unauthorized users

### DIFF
--- a/webpack/scenes/ContentCredentials/ContentCredentialSelectors.js
+++ b/webpack/scenes/ContentCredentials/ContentCredentialSelectors.js
@@ -1,6 +1,7 @@
 import {
   selectAPIStatus,
   selectAPIResponse,
+  selectAPIError,
 } from 'foremanReact/redux/API/APISelectors';
 import { STATUS } from 'foremanReact/constants';
 
@@ -13,3 +14,19 @@ export const selectContentCredentials = (state) => {
 
 export const selectContentCredentialsStatus = state =>
   selectAPIStatus(state, GET_CONTENT_CREDENTIALS_KEY) || STATUS.PENDING;
+
+export const selectContentCredentialsErrorMessage = (state) => {
+  const error = selectAPIError(state, GET_CONTENT_CREDENTIALS_KEY);
+  if (!error) {
+    return null;
+  }
+
+  // Check for structured error response with missing permissions
+  if (error.response.data && error.response.data.error) {
+    const errorData = error.response.data.error;
+    if (errorData.missing_permissions && errorData.missing_permissions.length > 0) {
+      return errorData;
+    }
+  }
+  return null;
+};

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -137,10 +137,17 @@ class SubscriptionsPage extends Component {
       deleteButtonDisabled, disableDeleteButton, enableDeleteButton,
       searchQuery, updateSearchQuery, hasUpstreamConnection,
       task, activePermissions, subscriptions, subscriptionTableSettings, isManifestImported,
+      contentCredentialsErrorMessage,
     } = this.props;
     // Basic permissions - should we even show this page?
     if (subscriptions.missingPermissions && subscriptions.missingPermissions.length > 0) {
       return <PermissionDenied missingPermissions={subscriptions.missingPermissions} />;
+    }
+    let missingPermissions = null;
+    if (contentCredentialsErrorMessage) {
+      if (contentCredentialsErrorMessage.missing_permissions.length > 0) {
+        missingPermissions = contentCredentialsErrorMessage.missing_permissions;
+      }
     }
     // Granular permissions
     const permissions = propsToCamelCase(activePermissions);
@@ -282,28 +289,34 @@ class SubscriptionsPage extends Component {
             />
 
             <div id="subscriptions-table" className="modal-container">
-              <SubscriptionsTable
-                canManageSubscriptionAllocations={canManageSubscriptionAllocations}
-                loadSubscriptions={this.props.loadSubscriptions}
-                tableColumns={columns}
-                updateQuantity={this.props.updateQuantity}
-                emptyState={emptyStateData}
-                subscriptions={this.props.subscriptions}
-                subscriptionDeleteModalOpen={deleteModalOpened}
-                onSubscriptionDeleteModalClose={closeDeleteModal}
-                onDeleteSubscriptions={onDeleteSubscriptions}
-                toggleDeleteButton={toggleDeleteButton}
-                task={task}
-                selectedRows={this.state.selectedRows}
-                onSelectedRowsChange={this.handleSelectedRowsChange}
-                selectionEnabled={!disableManifestActions}
-              />
-              <ModalProgressBar
-                show={!!task}
-                container={document.getElementById('subscriptions-table')}
-                title={task ? task.humanized.action : null}
-                progress={task ? Math.round(task.progress * 100) : 0}
-              />
+              {missingPermissions ? (
+                <PermissionDenied missingPermissions={missingPermissions} />
+              ) : (
+                <>
+                  <SubscriptionsTable
+                    canManageSubscriptionAllocations={canManageSubscriptionAllocations}
+                    loadSubscriptions={this.props.loadSubscriptions}
+                    tableColumns={columns}
+                    updateQuantity={this.props.updateQuantity}
+                    emptyState={emptyStateData}
+                    subscriptions={this.props.subscriptions}
+                    subscriptionDeleteModalOpen={deleteModalOpened}
+                    onSubscriptionDeleteModalClose={closeDeleteModal}
+                    onDeleteSubscriptions={onDeleteSubscriptions}
+                    toggleDeleteButton={toggleDeleteButton}
+                    task={task}
+                    selectedRows={this.state.selectedRows}
+                    onSelectedRowsChange={this.handleSelectedRowsChange}
+                    selectionEnabled={!disableManifestActions}
+                  />
+                  <ModalProgressBar
+                    show={!!task}
+                    container={document.getElementById('subscriptions-table')}
+                    title={task ? task.humanized.action : null}
+                    progress={task ? Math.round(task.progress * 100) : 0}
+                  />
+                </>
+              )}
             </div>
           </Col>
         </Row>
@@ -376,6 +389,11 @@ SubscriptionsPage.propTypes = {
   deleteButtonDisabled: PropTypes.bool,
   disableDeleteButton: PropTypes.func.isRequired,
   enableDeleteButton: PropTypes.func.isRequired,
+  contentCredentialsErrorMessage: PropTypes.shape({
+    message: PropTypes.string,
+    details: PropTypes.string,
+    missing_permissions: PropTypes.arrayOf(PropTypes.string),
+  }),
 };
 
 SubscriptionsPage.defaultProps = {
@@ -393,6 +411,7 @@ SubscriptionsPage.defaultProps = {
     can_import_manifest: false,
     can_manage_subscription_allocations: false,
   },
+  contentCredentialsErrorMessage: {},
 };
 
 export default SubscriptionsPage;

--- a/webpack/scenes/Subscriptions/index.js
+++ b/webpack/scenes/Subscriptions/index.js
@@ -5,6 +5,7 @@ import * as subscriptionActions from './SubscriptionActions';
 import * as taskActions from '../Tasks/TaskActions';
 import * as tableActions from '../Settings/Tables/TableActions';
 import * as manifestActions from './Manifest/ManifestActions';
+import * as contentCredentialActions from '../ContentCredentials/ContentCredentialActions';
 
 import {
   selectSubscriptionsState,
@@ -16,6 +17,7 @@ import {
   selectIsTaskPending,
   selectHasUpstreamConnection,
 } from './SubscriptionsSelectors';
+import { selectContentCredentialsErrorMessage } from '../ContentCredentials/ContentCredentialSelectors';
 import selectTableSettings from '../../scenes/Settings/SettingsSelectors';
 import { selectIsPollingTask } from '../Tasks/TaskSelectors';
 import { selectOrganizationState, selectIsManifestImported } from '../Organizations/OrganizationSelectors';
@@ -42,6 +44,7 @@ const mapStateToProps = (state) => {
     deleteModalOpened: selectDeleteModalOpened(state),
     deleteButtonDisabled: selectDeleteButtonDisabled(state),
     organization: selectOrganizationState(state),
+    contentCredentialsErrorMessage: selectContentCredentialsErrorMessage(state),
   };
 };
 
@@ -53,6 +56,7 @@ const actions = {
   ...tableActions,
   ...manifestActions,
   ...foremanModalActions,
+  ...contentCredentialActions,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);


### PR DESCRIPTION
- Prevent infinite loading state on Subscriptions page when user lacks permissions
- Add explicit error handling to display a "Permission Denied" message
- Ensure behavior is consistent across organizations and roles

#### What are the changes introduced in this pull request?
- Introduced explicit permission error handling for the Content > Subscriptions page.
- Instead of staying stuck in a loading state, the UI now properly shows a “Permission Denied” message when a user lacks the required permissions to view subscription data.

#### Considerations taken when implementing this change?
Handel only missing permissions error. 

#### What are the testing steps for this pull request?
1. Setup test orgs and roles

   * Create two orgs: A and B.
   * Create a user and assign them to both orgs.

2. Assign limited permissions

   * Create a role with `manage_subscription_allocations`, `view_subscriptions`, and `view_organizations`.
   * Assign this role to org A, and then assign the role to the user.

3. Reproduce unauthorized case

   * Log in as the user.
   * Switch context to org B.
   * Navigate to Content > Subscriptions.

4. Verify fix

   * Before fix: page would stay in a loading state forever.
   * After fix: page should display a “Permission Denied” error instead.

5. Verify authorized case

   * Switch back to org A (where user has permissions).
   * Ensure Subscriptions page loads normally and shows data.

6. Edge cases

   * Try with a user who has all the required permissions/with an admin user → page should load.
   * Try with a user who has no subscription permissions in any org → should consistently show “Permission Denied.”