### PR TITLE
Add breaks-robottelo workflow as per theforeman/foreman PR 10568

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,0 +1,15 @@
+name: Label a PR `breaks-robottelo` on appropriate comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  breaks-robottelo:
+    uses: theforeman/actions/.github/workflows/breaks-robottelo.yml@v0
+    permissions:
+      pull-requests: write
+    with:
+      repo: ${{ github.repository }}
+      issue: ${{ github.event.issue.number }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Before merging, `breaks-robottelo` label needs to be added to the repo manually by a maintainer

## Summary by Sourcery

Add a new GitHub Actions workflow to automatically label PRs with 'breaks-robottelo' on issue comment triggers.

New Features:
- Introduce .github/workflows/test-breaking.yaml to run theforeman/actions breaks-robottelo composite action on new issue comments.

Chores:
- Require maintainers to manually add the 'breaks-robottelo' label to the repository before merging.