### PR TITLE
Fixes #38778 - Populate PRN columns for Repository versions

### DIFF
--- a/app/services/katello/pulp3/api/core.rb
+++ b/app/services/katello/pulp3/api/core.rb
@@ -64,6 +64,10 @@ module Katello
           PulpcoreClient::RepositoriesApi.new(core_api_client)
         end
 
+        def core_repository_versions_api
+          PulpcoreClient::RepositoryVersionsApi.new(core_api_client)
+        end
+
         def repositories_api
           repository_type.repositories_api_class.new(api_client)
         end
@@ -234,6 +238,12 @@ module Katello
         def core_repositories_list_all(options = {})
           self.class.fetch_from_list do |page_opts|
             core_repositories_api.list(page_opts.merge(options))
+          end
+        end
+
+        def core_repository_versions_list_all(options = {})
+          self.class.fetch_from_list do |page_opts|
+            core_repository_versions_api.list(page_opts.merge(options))
           end
         end
 

--- a/db/seeds.d/111-upgrade_tasks.rb
+++ b/db/seeds.d/111-upgrade_tasks.rb
@@ -11,5 +11,6 @@ UpgradeTask.define_tasks(:katello) do
     {:name => 'katello:upgrades:4.8:fix_incorrect_providers'},
     {:name => 'katello:upgrades:4.8:regenerate_imported_repository_metadata'},
     {:name => 'katello:upgrades:4.12:update_content_access_modes'},
+    {:name => 'katello:upgrades:4.19:populate_repository_version_prns'},
   ]
 end

--- a/lib/katello/tasks/upgrades/4.19/populate_repository_version_prns.rake
+++ b/lib/katello/tasks/upgrades/4.19/populate_repository_version_prns.rake
@@ -1,0 +1,32 @@
+namespace :katello do
+  namespace :upgrades do
+    namespace '4.19' do
+      desc "Populate repository version PRNs for all repositories"
+      task :populate_repository_version_prns => ["dynflow:client", "check_ping"] do
+        User.current = User.anonymous_api_admin
+        api = ::Katello::Pulp3::Api::Core.new(SmartProxy.pulp_primary)
+        updates = []
+        api.core_repository_versions_list_all(fields: 'pulp_href,prn').each do |repo_version|
+          next if repo_version.prn.blank?
+          updates << { version_href: repo_version.pulp_href, prn: repo_version.prn }
+        end
+
+        return if updates.empty?
+
+        updates.each_slice(10_000) do |batch|
+          when_clauses = batch.map do |update|
+            version_href = ::Katello::Repository.connection.quote_string(update[:version_href])
+            prn = ::Katello::Repository.connection.quote_string(update[:prn])
+            "WHEN '#{version_href}' THEN '#{prn}'"
+          end
+
+          version_hrefs = batch.map { |u| u[:version_href] }
+          case_statement = "CASE version_href #{when_clauses.join(' ')} END"
+
+          ::Katello::Repository.where(version_href: version_hrefs)
+                               .update_all("version_prn = #{case_statement}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a rake task to populate repository version PRN field.
#### Considerations taken when implementing this change?

A rake task is needed since we can't run this during db:migration on an upgrade when all services including pulp are down.

This task will be run as part of post upgrade task and there will not be a not null constraint on the field for atleast the next supported product release.

This is also expected to block upgrade if version_prns are not populated as in the task fails.

#### What are the testing steps for this pull request?
In rails console:
Check: Katello::Repository.where(version_prn: nil).count
Exit console.
Run `bundle exec rails katello:populate_repository_version_prns`
In rails console:
Check: Katello::Repository.where(version_prn: nil).count should be 0

Do some spot checks using pulp cli to test correctness of href->prn on the versions.

## Summary by Sourcery

Add a rake task to populate the version_prn column for all repositories using the Pulp3 API

New Features:
- Introduce katello:populate_repository_version_prns rake task to fetch and apply PRNs for repository versions

Enhancements:
- Add core_repository_versions_api and core_repository_versions_list_all methods to the Pulp3 API client for listing repository versions