### PR TITLE
Fixes #38797 - fix upload profile job for EL7

### DIFF
--- a/app/views/foreman/job_templates/upload_profile.erb
+++ b/app/views/foreman/job_templates/upload_profile.erb
@@ -9,7 +9,12 @@ feature: katello_upload_profile
 %>
 #!/bin/sh
 <% if @host.operatingsystem.family == 'Redhat' -%>
+# Use dnf for EL 8+ and use yum for below
+  <% if @host.operatingsystem.major.to_i >= 8 -%>
 dnf uploadprofile --force-upload
+  <% else -%>
+yum uploadprofile --force-upload
+  <% end -%>
 <% elsif @host.operatingsystem.family == 'Suse' -%>
 katello-package-upload --force
 <% else -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The upload profile job now uses `yum` for EL hosts with a major version below 8.

#### Considerations taken when implementing this change?
`@host.operatingsystem.major should be safe`. We already use `family` anyway.

#### What are the testing steps for this pull request?
1. Register EL 7 and EL 8+ hosts
2. Patch in this PR, run `ForemanInternal.first.delete`, and `db:seed`
3. Run the upload profile job for both hosts (from Host details -> Content -> Packages -> Refresh package applicability)

## Summary by Sourcery

Switch upload_profile script to use yum on EL hosts with major version below 8 and dnf on EL8+.

Bug Fixes:
- Fix upload profile job on EL7 by using yum instead of dnf

Enhancements:
- Add ERB conditional in upload_profile job template to select package manager based on operating system major version