### PR TITLE
Fixes #38801 - Add manifest list children to the tags response json

### DIFF
--- a/app/views/katello/api/v2/docker_tags/_base.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/_base.json.rabl
@@ -16,6 +16,17 @@ end
 child :docker_manifest => :manifest do
   attributes :pulp_id => :id
   attributes :schema_version, :digest, :manifest_type
+
+  node :manifests, :if => lambda { |m| m.manifest_type == 'list' } do |manifest|
+    manifest.docker_manifests.map do |child_manifest|
+      {
+        :id => child_manifest.id,
+        :digest => child_manifest.digest,
+        :schema_version => child_manifest.schema_version,
+        :manifest_type => child_manifest.manifest_type,
+      }
+    end
+  end
 end
 
 if @organization

--- a/app/views/katello/api/v2/docker_tags/show.json.rabl
+++ b/app/views/katello/api/v2/docker_tags/show.json.rabl
@@ -5,6 +5,16 @@ extends 'katello/api/v2/docker_tags/base'
 child :docker_manifest => :manifest do
   attributes :uuid => :id
   attributes :schema_version, :digest, :manifest_type
+  node :manifests, :if => lambda { |m| m.manifest_type == 'list' } do |manifest|
+    manifest.docker_manifests.map do |child_manifest|
+      {
+        :id => child_manifest.id,
+        :digest => child_manifest.digest,
+        :schema_version => child_manifest.schema_version,
+        :manifest_type => child_manifest.manifest_type,
+      }
+    end
+  end
 end
 
 child :related_tags => :related_tags do


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add a list of manifests for any tagged manifest lists. 
#### Considerations taken when implementing this change?
We need to support expansion of tagged manifest lists in an upcoming UI redesign. This change will make the data necessary to implement that.
#### What are the testing steps for this pull request?
Sync some container repos.
Check the https://dev-box-fqdn.com/katello/api/v2/docker_tags API response
You should see children of manifest lists in the return like:
```
{
total: 13660,
subtotal: 13660,
selectable: 13660,
page: 1,
per_page: 20,
error: null,
search: null,
sort: {
by: "id",
order: "desc"
},
results: [
{
id: 13661,
name: "latest",
manifest_schema1: null,
manifest_schema2: {
id: "/pulp/api/v3/content/container/manifests/0199abc8-e558-7ee0-8f0b-d5d4c78a4727/",
schema_version: 2,
digest: "sha256:5299e0a67ea0418a9338e7dc3b546c198075b683cb0a1ac88ee8df19de78d278",
manifest_type: "list"
},
manifest: {
id: "/pulp/api/v3/content/container/manifests/0199abc8-e558-7ee0-8f0b-d5d4c78a4727/",
schema_version: 2,
digest: "sha256:5299e0a67ea0418a9338e7dc3b546c198075b683cb0a1ac88ee8df19de78d278",
manifest_type: "list",
manifests: [
{
id: 12137,
digest: "sha256:0c3b2d793c019af2b56c09c633abb427166319de95a38f96446e896fb6eeab20",
schema_version: 2,
manifest_type: "image"
},
{
id: 12138,
digest: "sha256:dc70074481985da5de43c0be4cb9455082450ec89533da158e47acc317430a45",
schema_version: 2,
manifest_type: "image"
}
]
},
repositories: [
{
id: 19,
name: "0ad",
full_path: "centos9-katello-devel-stable.example.com/default_organization/fedora_flatpak/0ad"
}
],
product: {
id: 3,
name: "fedora_flatpak"
},
environment: {
id: 1,
name: "Library"
},
content_view_version: {
id: 1,
name: "Default Organization View 1.0",
content_view_id: 1
},
upstream_name: "0ad"
}....
```
Note the child node manifests under manifest node when type is list.

Added this child node to index and show rabls for docker tags.