### PR TITLE
Support IPv6 addresses for HTTP proxies in yum repo discovery

### DIFF
--- a/app/lib/katello/resources/discovery/yum.rb
+++ b/app/lib/katello/resources/discovery/yum.rb
@@ -46,7 +46,7 @@ module Katello
           details = {}
 
           if proxy
-            details[:host] = proxy_host
+            details[:host] = proxy_hostname
             details[:port] = proxy_port
             details[:user] = proxy.username
             details[:password] = proxy.password

--- a/app/lib/katello/util/http_proxy.rb
+++ b/app/lib/katello/util/http_proxy.rb
@@ -22,6 +22,10 @@ module Katello
       end
 
       def proxy_host
+        URI(proxy.url).hostname
+      end
+
+      def proxy_hostname
         URI(proxy.url).host
       end
 


### PR DESCRIPTION
Incomplete, but so I can share this patch.

#### What are the changes introduced in this pull request?

Fixes: d609612833b6 ("Fixes #38545 - Support IPv6 addresses in HTTP proxy URLs (#11432)")

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?