### PR TITLE
Fixes #38808 - allow nil pulp-rpm gpgcheck for n-1 proxies

### DIFF
--- a/config/initializers/monkeys.rb
+++ b/config/initializers/monkeys.rb
@@ -1,3 +1,4 @@
 #place where monkey patches are required
 require 'monkeys/ar_postgres_evr_t'
 require 'monkeys/remove_hidden_distribution'
+require 'monkeys/fix_rpm_repository_gpgcheck'

--- a/lib/monkeys/fix_rpm_repository_gpgcheck.rb
+++ b/lib/monkeys/fix_rpm_repository_gpgcheck.rb
@@ -1,0 +1,38 @@
+require 'pulp_rpm_client'
+
+# Monkey patch to allow nil values for deprecated gpgcheck and repo_gpgcheck fields
+# These fields were removed in pulp_rpm 3.30.0 but older Pulp versions return null
+# The new bindings don't allow nil, causing ArgumentError when deserializing responses
+[PulpRpmClient::RpmRpmRepositoryResponse, PulpRpmClient::RpmRpmPublicationResponse].each do |klass|
+  klass.class_eval do
+    # Custom attribute writer method with validation
+    # @param [Object] gpgcheck Value to be assigned
+    def gpgcheck=(gpgcheck)
+      # Allow nil for deprecated field - monkey patch here
+      if !gpgcheck.nil? && gpgcheck > 1
+        fail ArgumentError, 'invalid value for "gpgcheck", must be smaller than or equal to 1.'
+      end
+
+      if !gpgcheck.nil? && gpgcheck < 0
+        fail ArgumentError, 'invalid value for "gpgcheck", must be greater than or equal to 0.'
+      end
+
+      @gpgcheck = gpgcheck
+    end
+
+    # Custom attribute writer method with validation
+    # @param [Object] repo_gpgcheck Value to be assigned
+    def repo_gpgcheck=(repo_gpgcheck)
+      # Allow nil for deprecated field - monkey patch here
+      if !repo_gpgcheck.nil? && repo_gpgcheck > 1
+        fail ArgumentError, 'invalid value for "repo_gpgcheck", must be smaller than or equal to 1.'
+      end
+
+      if !repo_gpgcheck.nil? && repo_gpgcheck < 0
+        fail ArgumentError, 'invalid value for "repo_gpgcheck", must be greater than or equal to 0.'
+      end
+
+      @repo_gpgcheck = repo_gpgcheck
+    end
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a monkey patch to allow RPM smart proxy syncing to work. See the redmine for more details.

#### Considerations taken when implementing this change?
Patch should not affect normal syncs.

#### What are the testing steps for this pull request?
Perform an n-1 smart proxy sync with different repo types on a dev box. More specifically, the smart proxy should have pulp-rpm less than version 3.30.

## Summary by Sourcery

Add a monkey patch to allow nil pulp-rpm gpgcheck flags when syncing RPM repositories from older n-1 smart proxies, restoring compatibility without altering standard sync behavior.

Enhancements:
- Override the gpgcheck retrieval in RPM repositories to handle nil values from older proxies.
- Maintain existing sync behavior for proxies that provide valid gpgcheck flags.

Chores:
- Introduce a new initializer and supporting monkey patch file under lib/monkeys to apply the fix.