### PR TITLE
Check against 10701 again

### DIFF
--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -25,6 +25,7 @@ module ::Actions::Katello::CapsuleContent
       SmartProxy.any_instance.stubs(:ping_pulp).returns({})
       SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
       SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+      SmartProxy.any_instance.stubs(:verify_ueber_certs).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:list).returns(nil)
       ::Katello::Pulp3::Api::ContentGuard.any_instance.stubs(:create).returns(nil)
     end

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -88,7 +88,8 @@ module Katello
       User.current = users(:restricted)
       key = katello_activation_keys(:simple_key)
       setup_current_user_with_permissions({ :name => "view_activation_keys",
-                                            :search => "environment = #{key.environment}" })
+                                            :search => "environment = #{key.environment}" },
+                                          organizations: [key.organization])
 
       @options = { :resource_class => Katello::ActivationKey }
       keys = @controller.scoped_search(ActivationKey.readable, @default_sort[0], @default_sort[1], @options)

--- a/test/controllers/api/v2/capsule_content_controller_test.rb
+++ b/test/controllers/api/v2/capsule_content_controller_test.rb
@@ -35,7 +35,7 @@ module Katello
     end
 
     def test_lifecycle_environments_protected
-      assert_protected_action(:lifecycle_environments, view_allowed_perms, denied_perms, [@repository.organization]) do
+      assert_protected_action(:lifecycle_environments, view_allowed_perms, denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         get :lifecycle_environments, params: { :id => proxy_with_pulp.id }
       end
     end
@@ -46,7 +46,7 @@ module Katello
     end
 
     def test_available_lifecycle_environments_protected
-      assert_protected_action(:available_lifecycle_environments, view_allowed_perms, denied_perms, [@repository.organization]) do
+      assert_protected_action(:available_lifecycle_environments, view_allowed_perms, denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         get :available_lifecycle_environments, params: { :id => proxy_with_pulp.id }
       end
     end
@@ -57,7 +57,7 @@ module Katello
     end
 
     def test_add_lifecycle_environment_protected
-      assert_protected_action(:add_lifecycle_environment, [[:view_capsule_content, :manage_capsule_content, :view_lifecycle_environments]], denied_perms, [@repository.organization]) do
+      assert_protected_action(:add_lifecycle_environment, [[:view_capsule_content, :manage_capsule_content, :view_lifecycle_environments]], denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         post :add_lifecycle_environment, params: { :id => proxy_with_pulp.id, :environment_id => environment.id }
       end
     end
@@ -70,7 +70,7 @@ module Katello
     end
 
     def test_remove_lifecycle_environment_protected
-      assert_protected_action(:remove_lifecycle_environment, [[:view_capsule_content, :manage_capsule_content, :view_lifecycle_environments]], denied_perms, [@repository.organization]) do
+      assert_protected_action(:remove_lifecycle_environment, [[:view_capsule_content, :manage_capsule_content, :view_lifecycle_environments]], denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         delete :remove_lifecycle_environment, params: { :id => proxy_with_pulp.id, :environment_id => environment.id }
       end
     end
@@ -106,7 +106,7 @@ module Katello
     end
 
     def test_sync_protected
-      assert_protected_action(:sync, allowed_perms, denied_perms, [@repository.organization]) do
+      assert_protected_action(:sync, allowed_perms, denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         post :sync, params: { :id => proxy_with_pulp.id, :environment_id => environment.id }
       end
     end
@@ -117,7 +117,7 @@ module Katello
     end
 
     def test_sync_status_protected
-      assert_protected_action(:sync, view_allowed_perms, denied_perms, [@repository.organization]) do
+      assert_protected_action(:sync, view_allowed_perms, denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         get :sync_status, params: { :id => proxy_with_pulp.id }
       end
     end
@@ -128,7 +128,7 @@ module Katello
     end
 
     def test_cancel_sync_protected
-      assert_protected_action(:sync, allowed_perms, denied_perms, [@repository.organization]) do
+      assert_protected_action(:sync, allowed_perms, denied_perms, [proxy_with_pulp.organizations.first], [proxy_with_pulp.locations.first]) do
         get :cancel_sync, params: { :id => proxy_with_pulp.id }
       end
     end

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -189,7 +189,7 @@ module Katello
       allowed_perms = [{:name => "edit_host_collections", :search => "name=\"#{@host_collection.name}\"" }]
       denied_perms = [{:name => "edit_host_collections", :search => "name=\"some_name\"" }]
 
-      assert_protected_object(:put, allowed_perms, denied_perms) do
+      assert_protected_object(:put, allowed_perms, denied_perms, [@host_collection.organization]) do
         put :update, params: { :id => @host_collection.id }
       end
     end

--- a/test/controllers/api/v2/sync_plans_controller_test.rb
+++ b/test/controllers/api/v2/sync_plans_controller_test.rb
@@ -130,7 +130,7 @@ module Katello
       allowed_perms = [{:name => @view_permission, :search => "name=\"#{@sync_plan.name}\"" }]
       denied_perms = [{:name => @view_permission, :search => "name=\"some_name\"" }]
 
-      assert_protected_object(:show, allowed_perms, denied_perms) do
+      assert_protected_object(:show, allowed_perms, denied_perms, [@organization]) do
         get :show, params: { :id => @sync_plan.id }
       end
     end

--- a/test/support/capsule_support.rb
+++ b/test/support/capsule_support.rb
@@ -15,6 +15,8 @@ module Support
             proxy.features << pulp_feature
           end
         end
+        proxy.organizations = [get_organization]
+        proxy.locations = [taxonomies(:location1)]
         proxy.smart_proxy_features.where(:feature_id => @pulp3_feature.id).update(:capabilities => [:core])
       end
     end


### PR DESCRIPTION
Successor to https://github.com/Katello/katello/pull/11512, I could have sworn the whole suite was green before.

## Summary by Sourcery

CI:
- Set foreman_version to pull/10701/head in the Ruby workflow

## Summary by Sourcery

Update tests to use proper proxy context and enhance permission checks, and point CI to Foreman pull request head.

Build:
- Set foreman_version to refs/pull/10701/head in the Ruby GitHub Actions workflow

Tests:
- Refactor CapsuleContentController tests to use @proxy with associated organization and location contexts
- Add organization and location parameters to protected action tests for CapsuleContentController
- Include organization in scoped_search permissions for activation key tests
- Add organization context to protected tests in HostCollectionsController and SyncPlansController