### PR TITLE
Remove usage of ForemanModal

### DIFF
--- a/webpack/scenes/Subscriptions/Manifest/index.js
+++ b/webpack/scenes/Subscriptions/Manifest/index.js
@@ -1,7 +1,6 @@
 import { bindActionCreators } from 'redux';
 
 import { connect } from 'react-redux';
-import * as foremanModalActions from 'foremanReact/components/ForemanModal/ForemanModalActions';
 import * as manifestActions from './ManifestActions';
 import * as organizationActions from '../../Organizations/OrganizationActions';
 import * as contentCredentialActions from '../../ContentCredentials/ContentCredentialActions';
@@ -21,7 +20,6 @@ const mapStateToProps = state => ({
   organization: state.katello.organization,
   manifestHistory: state.katello.manifestHistory,
   isManifestImported: selectIsManifestImported(state),
-  deleteManifestModalExists: !!state.foremanModals.deleteManifestModal,
   manifestActionStarted: selectManifestActionStarted(state),
   updatingCdnConfiguration: selectUpdatingCdnConfiguration(state),
   contentCredentials: selectContentCredentials(state),
@@ -32,7 +30,6 @@ const actions = {
   ...manifestActions,
   ...organizationActions,
   ...tasksActions,
-  ...foremanModalActions,
   ...contentCredentialActions,
 };
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.js
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.js
@@ -11,7 +11,6 @@ import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import ModalProgressBar from 'foremanReact/components/common/ModalProgressBar';
 import PermissionDenied from 'foremanReact/components/PermissionDenied';
 import ManageManifestModal from './Manifest/';
-import { MANAGE_MANIFEST_MODAL_ID } from './Manifest/ManifestConstants';
 import { SubscriptionsTable } from './components/SubscriptionsTable';
 import SubscriptionsToolbar from './components/SubscriptionsToolbar';
 import { filterRHSubscriptions } from './SubscriptionHelpers';
@@ -49,7 +48,6 @@ const SubscriptionsPage = ({
   searchQuery,
   updateSearchQuery,
   activePermissions,
-  setModalOpen,
   uploadManifest,
   deleteManifest,
   refreshManifest,
@@ -58,6 +56,7 @@ const SubscriptionsPage = ({
   createColumns,
   updateColumns,
 }) => {
+  const [isManageManifestModalOpen, setIsManageManifestModalOpen] = useState(false);
   const [selectedRows, setSelectedRows] = useState([]);
   const [availableQuantitiesLoaded, setAvailableQuantitiesLoaded] = useState(false);
   const prevPropsRef = useRef({});
@@ -177,8 +176,6 @@ const SubscriptionsPage = ({
   } = permissions;
   const disableManifestActions = !!task || !hasUpstreamConnection;
 
-  const openManageManifestModal = () => setModalOpen({ id: MANAGE_MANIFEST_MODAL_ID });
-
   const tableColumns = Immutable.asMutable(subscriptions.tableColumns, { deep: true });
   const onSearch = (search) => {
     loadSubscriptions({ search });
@@ -232,7 +229,7 @@ const SubscriptionsPage = ({
       header: __('There are no Subscriptions to display'),
       description: __('Import a subscription manifest to give hosts access to Red Hat content.'),
       action: {
-        onClick: () => openManageManifestModal(),
+        onClick: () => setIsManageManifestModalOpen(true),
         title: __('Import a Manifest'),
       },
     };
@@ -284,7 +281,7 @@ const SubscriptionsPage = ({
             updateSearchQuery={updateSearchQuery}
             onDeleteButtonClick={openDeleteModal}
             onSearch={onSearch}
-            onManageManifestButtonClick={openManageManifestModal}
+            onManageManifestButtonClick={() => setIsManageManifestModalOpen(true)}
             onExportCsvButtonClick={() => { api.open('/subscriptions.csv', csvParams); }}
             tableColumns={tableColumns}
             toolTipOnChange={toolTipOnChange}
@@ -301,6 +298,8 @@ const SubscriptionsPage = ({
             upload={uploadManifest}
             delete={deleteManifest}
             refresh={refreshManifest}
+            isOpen={isManageManifestModalOpen}
+            closeModal={() => setIsManageManifestModalOpen(false)}
           />
 
           <div id="subscriptions-table" className="modal-container">
@@ -395,13 +394,12 @@ SubscriptionsPage.propTypes = {
   refreshManifest: PropTypes.func.isRequired,
   searchQuery: PropTypes.string,
   updateSearchQuery: PropTypes.func.isRequired,
-  setModalOpen: PropTypes.func.isRequired,
-  deleteModalOpened: PropTypes.bool,
-  openDeleteModal: PropTypes.func.isRequired,
-  closeDeleteModal: PropTypes.func.isRequired,
   deleteButtonDisabled: PropTypes.bool,
   disableDeleteButton: PropTypes.func.isRequired,
   enableDeleteButton: PropTypes.func.isRequired,
+  deleteModalOpened: PropTypes.bool,
+  openDeleteModal: PropTypes.func.isRequired,
+  closeDeleteModal: PropTypes.func.isRequired,
 };
 
 SubscriptionsPage.defaultProps = {

--- a/webpack/scenes/Subscriptions/index.js
+++ b/webpack/scenes/Subscriptions/index.js
@@ -1,6 +1,5 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import * as foremanModalActions from 'foremanReact/components/ForemanModal/ForemanModalActions';
 import * as subscriptionActions from './SubscriptionActions';
 import * as taskActions from '../Tasks/TaskActions';
 import * as tableActions from '../Settings/Tables/TableActions';
@@ -9,12 +8,12 @@ import * as manifestActions from './Manifest/ManifestActions';
 import {
   selectSubscriptionsState,
   selectSearchQuery,
-  selectDeleteModalOpened,
   selectDeleteButtonDisabled,
   selectSubscriptionsTask,
   selectActivePermissions,
   selectIsTaskPending,
   selectHasUpstreamConnection,
+  selectDeleteModalOpened,
 } from './SubscriptionsSelectors';
 import selectTableSettings from '../../scenes/Settings/SettingsSelectors';
 import { selectIsPollingTask } from '../Tasks/TaskSelectors';
@@ -52,7 +51,6 @@ const actions = {
   ...taskActions,
   ...tableActions,
   ...manifestActions,
-  ...foremanModalActions,
 };
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);


### PR DESCRIPTION
Remove usage of ForemanModal component from core with it's PF5 variant

## Summary by Sourcery

Replace Foreman-specific modal usage with PatternFly 5 modal components in the subscriptions manifest management flow.

Enhancements:
- Switch manage manifest and delete manifest dialogs from ForemanModal to PatternFly Modal with local open/close state management.
- Remove dependency on global foremanModals Redux actions and state from subscriptions manifest components.
- Update subscriptions page wiring and tests to reflect the new modal implementation and removed ForemanModal usage.