### PR TITLE
Fixes #39054 - Improve empty deb metadata handling

### DIFF
--- a/app/lib/actions/pulp3/orchestration/repository/create.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/create.rb
@@ -6,8 +6,8 @@ module Actions
           def plan(repository, smart_proxy, force = false)
             sequence do
               create_action = plan_action(Actions::Pulp3::Repository::Create, repository, smart_proxy, force)
-              if repository.deb? && repository.library_instance?
-                response = plan_action(Pulp3::Repository::Initialize, repository, smart_proxy)
+              if repository.deb?
+                response = plan_action(Pulp3::Repository::Initialize, repository, smart_proxy, repository_details: create_action.output[:response])
                 plan_action(Actions::Pulp3::Repository::SaveVersion, repository, tasks: response.output[:pulp_tasks])
               else
                 plan_action(Actions::Pulp3::Repository::SaveVersion, repository, repository_details: create_action.output[:response])

--- a/app/lib/actions/pulp3/orchestration/repository/sync.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/sync.rb
@@ -6,6 +6,9 @@ module Actions
           include Actions::Helpers::OutputPropagator
           def plan(repository, smart_proxy, options)
             sequence do
+              if repository.deb?
+                plan_action(Pulp3::Repository::DebRemoveEmptyMetadata, repository, smart_proxy)
+              end
               plan_action(Actions::Pulp3::Repository::RefreshRemote, repository, smart_proxy)
               action_output = plan_action(Actions::Pulp3::Repository::Sync, repository, smart_proxy, options).output
 

--- a/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
+++ b/app/lib/actions/pulp3/orchestration/repository/upload_content.rb
@@ -7,6 +7,7 @@ module Actions
           def plan(repository, smart_proxy, file, unit_type_id)
             sequence do
               if repository.deb?
+                plan_action(Pulp3::Repository::DebRemoveEmptyMetadata, repository, smart_proxy)
                 upload_action_output = plan_action(Pulp3::Repository::UploadFile, repository, smart_proxy, file[:path]).output
                 artifact_action_output = plan_action(Pulp3::Repository::SaveArtifact, file, repository, smart_proxy, upload_action_output[:pulp_tasks], unit_type_id).output
               else

--- a/app/lib/actions/pulp3/repository/deb_remove_empty_metadata.rb
+++ b/app/lib/actions/pulp3/repository/deb_remove_empty_metadata.rb
@@ -1,0 +1,19 @@
+module Actions
+  module Pulp3
+    module Repository
+      class DebRemoveEmptyMetadata < Pulp3::AbstractAsyncTask
+        def plan(repository, smart_proxy)
+          if repository.deb? && repository.version_href.ends_with?("/1/")
+            plan_self(repository_id: repository.id,
+                      smart_proxy_id: smart_proxy.id)
+          end
+        end
+
+        def invoke_external_task
+          repository = ::Katello::Repository.find(input[:repository_id])
+          output[:pulp_tasks] = repository.backend_service(smart_proxy).remove_empty_metadata
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/repository/initialize.rb
+++ b/app/lib/actions/pulp3/repository/initialize.rb
@@ -2,14 +2,17 @@ module Actions
   module Pulp3
     module Repository
       class Initialize < Pulp3::AbstractAsyncTask
-        def plan(repository, smart_proxy)
+        def plan(repository, smart_proxy, options = {})
           plan_self(repository_id: repository.id,
-                    smart_proxy_id: smart_proxy.id)
+                    smart_proxy_id: smart_proxy.id,
+                    repository_details: options[:repository_details])
         end
 
         def invoke_external_task
-          repository = ::Katello::Repository.find(input[:repository_id])
-          output[:pulp_tasks] = repository.backend_service(smart_proxy).initialize_empty
+          if input[:repository_details]
+            repository = ::Katello::Repository.find(input[:repository_id])
+            output[:pulp_tasks] = repository.backend_service(smart_proxy).initialize_empty
+          end
         end
       end
     end

--- a/app/lib/katello/errors.rb
+++ b/app/lib/katello/errors.rb
@@ -182,5 +182,17 @@ module Katello
     class InvalidExportFormat < StandardError; end
 
     class InvalidConfiguration < StandardError; end
+
+    class MissingDebEntityError < StandardError
+      attr_reader :entity_name, :repo_name, :version_href
+
+      def initialize(entity_name, repo_name, version_href)
+        @entity_name, @repo_name, @version_href = entity_name, repo_name, version_href
+        message = _(
+          "The referenced Pulp repo version '%{version}' for 'deb' repository '%{name}' should contain at least one %{entity}."
+        ) % { entity: entity_name, name: repo_name, version: version_href }
+        super(message)
+      end
+    end
   end
 end

--- a/test/actions/katello/repository_test.rb
+++ b/test/actions/katello/repository_test.rb
@@ -767,6 +767,7 @@ module ::Actions::Katello::Repository
     end
 
     it 'plans pulp3 orchestration actions with apt repo' do
+      repository_apt_pulp3.version_href = "/pulp/api/v3/repositories/deb/apt/019c22e3-8afe-78cd-bf6d-c3d408a76db5/versions/3/"
       action = create_action pulp3_action_class
       action.stubs(:action_subject).with(repository_apt_pulp3)
       plan_action action, repository_apt_pulp3, proxy, {}

--- a/test/actions/pulp3/orchestration/deb_upload_test.rb
+++ b/test/actions/pulp3/orchestration/deb_upload_test.rb
@@ -37,7 +37,7 @@ module ::Actions::Pulp3
         repository_reference = Katello::Pulp3::RepositoryReference.find_by(
             :root_repository_id => @repo.root.id,
             :content_view_id => @repo.content_view.id)
-        assert_equal repository_reference.repository_href + "versions/2/", @repo.version_href
+        assert_equal repository_reference.repository_href + "versions/3/", @repo.version_href
 
         upload_action = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::UploadContent, @repo, @primary, @file2, 'deb')
         assert_equal "success", upload_action.result
@@ -47,7 +47,7 @@ module ::Actions::Pulp3
         repository_reference = Katello::Pulp3::RepositoryReference.find_by(
           :root_repository_id => @repo.root.id,
           :content_view_id => @repo.content_view.id)
-        assert_equal repository_reference.repository_href + "versions/3/", @repo.version_href
+        assert_equal repository_reference.repository_href + "versions/4/", @repo.version_href
         assert_equal @repo.debs.count, deb_count + 1
       end
     end
@@ -65,7 +65,7 @@ module ::Actions::Pulp3
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
           :root_repository_id => @repo.root.id,
           :content_view_id => @repo.content_view.id)
-      assert_equal repository_reference.repository_href + "versions/2/", @repo.version_href
+      assert_equal repository_reference.repository_href + "versions/3/", @repo.version_href
 
       VCR.use_cassette(cassette_name + '_binary_duplicate', :match_requests_on => [:method, :path, :params]) do
         action_result = ForemanTasks.sync_task(::Actions::Pulp3::Orchestration::Repository::UploadContent, @repo, @primary, @file1, 'deb')
@@ -75,7 +75,7 @@ module ::Actions::Pulp3
       repository_reference = Katello::Pulp3::RepositoryReference.find_by(
           :root_repository_id => @repo.root.id,
           :content_view_id => @repo.content_view.id)
-      assert_equal repository_reference.repository_href + "versions/2/", @repo.version_href
+      assert_equal repository_reference.repository_href + "versions/3/", @repo.version_href
     end
   end
 end

--- a/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/duplicate_upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/duplicate_upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,21 +43,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c3d48f109eec47e6ace2991165819024
+      - 37cc7fb0d2304406adfa8cece21ebb9f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI0OjM4LjI2NTEzMloiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1LjE5MzI1NloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -184,10 +184,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=Debian_10
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=Debian_10
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -208,7 +208,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -228,20 +228,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0f9b692755bf402ab1ce8a808292bb3a
+      - e4a89e3669b24ed88093f8953b4f6f07
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=Debian_10
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=Debian_10
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,7 +262,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -282,20 +282,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 88048b2d045a44c59eeaf444de891706
+      - db661775b72f492aa100ae58c8c11603
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=Debian_10
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=Debian_10
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -316,7 +316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -336,20 +336,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f369107b7542498099e7b8610ffaa54c
+      - 8c8547d46746424ca0917cd82470fde6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_10_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_10_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -390,20 +390,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 37da425158ad42e785ba1d8e481bcc4e
+      - 7c7e686b11744fbabb044a876dd17322
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
@@ -435,13 +435,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/deb/apt/019c4ece-e483-7e78-a4c9-a685e3392813/"
+      - "/pulp/api/v3/remotes/deb/apt/019caf0b-f22c-74a5-bf88-3faa268e80fc/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -457,20 +457,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f8fa0cebeb9c4eb2a9f7c91860d4982d
+      - ae5dbe9aa17844e68c3fa87b7ca9ad65
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAx
-        OWM0ZWNlLWU0ODMtN2U3OC1hNGM5LWE2ODVlMzM5MjgxMy8iLCJwcm4iOiJw
-        cm46ZGViLmFwdHJlbW90ZTowMTljNGVjZS1lNDgzLTdlNzgtYTRjOS1hNjg1
-        ZTMzOTI4MTMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjA3
-        LjcxNTQwNFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDItMTFUMjI6
-        MjU6MDcuNzE1NDEyWiIsIm5hbWUiOiJEZWJpYW5fMTAiLCJ1cmwiOiJodHRw
+        OWNhZjBiLWYyMmMtNzRhNS1iZjg4LTNmYWEyNjhlODBmYy8iLCJwcm4iOiJw
+        cm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi1mMjJjLTc0YTUtYmY4OC0zZmFh
+        MjY4ZTgwZmMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIx
+        LjY0NDQ4M1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6
+        NTU6MjEuNjQ0NDk3WiIsIm5hbWUiOiJEZWJpYW5fMTAiLCJ1cmwiOiJodHRw
         Oi8vbXlyZXBvLmNvbSIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0Ijpu
         dWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJw
         dWxwX2xhYmVscyI6e30sImRvd25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJt
@@ -488,10 +488,10 @@ http_interactions:
         eW5jX2luc3RhbGxlciI6ZmFsc2UsImdwZ2tleSI6IkFERiNGQ1NGQVNERiRA
         JEBaRkREU0ckIyUjJUFEUyIsImlnbm9yZV9taXNzaW5nX3BhY2thZ2VfaW5k
         aWNlcyI6ZmFsc2V9
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiRGViaWFuXzEwIn0=
@@ -514,13 +514,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:07 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/deb/apt/019c4ece-e555-774d-b8f0-00dc38e61c7e/"
+      - "/pulp/api/v3/repositories/deb/apt/019caf0b-f2b3-748a-92b1-5b77abf42e97/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -536,38 +536,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 69d32baf09434ded8e95e9409c9c29a8
+      - 8078c623821e4ff5a19e041b43c24bdb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2UtZTU1NS03NzRkLWI4ZjAtMDBkYzM4ZTYxYzdlLyIsInBy
-        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljNGVjZS1lNTU1LTc3NGQt
-        YjhmMC0wMGRjMzhlNjFjN2UiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTEx
-        VDIyOjI1OjA3LjkyNjE4MVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
-        MDItMTFUMjI6MjU6MDcuOTMwNjQxWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2UtZTU1NS03
-        NzRkLWI4ZjAtMDBkYzM4ZTYxYzdlL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cHQvMDE5Y2FmMGItZjJiMy03NDhhLTkyYjEtNWI3N2FiZjQyZTk3LyIsInBy
+        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi1mMmIzLTc0OGEt
+        OTJiMS01Yjc3YWJmNDJlOTciLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjIxLjc3OTkyMFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
+        MDMtMDJUMTQ6NTU6MjEuNzg4OTMzWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItZjJiMy03
+        NDhhLTkyYjEtNWI3N2FiZjQyZTk3L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZS1lNTU1LTc3NGQtYjhmMC0wMGRj
-        MzhlNjFjN2UvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGViaWFuXzEwIiwiZGVz
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi1mMmIzLTc0OGEtOTJiMS01Yjc3
+        YWJmNDJlOTcvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGViaWFuXzEwIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsInB1Ymxpc2hfdXBzdHJlYW1fcmVsZWFzZV9maWVsZHMi
         OnRydWUsInNpZ25pbmdfc2VydmljZSI6bnVsbCwic2lnbmluZ19zZXJ2aWNl
         X3JlbGVhc2Vfb3ZlcnJpZGVzIjp7fX0=
-  recorded_at: Wed, 11 Feb 2026 22:25:07 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/release_components/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNlLWU1NTUtNzc0ZC1iOGYwLTAwZGMzOGU2MWM3ZS8iLCJj
+        YXB0LzAxOWNhZjBiLWYyYjMtNzQ4YS05MmIxLTViNzdhYmY0MmU5Ny8iLCJj
         b21wb25lbnQiOiJlbXB0eSIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8ifQ==
     headers:
       Content-Type:
@@ -586,7 +586,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:08 GMT
+      - Mon, 02 Mar 2026 14:55:21 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -606,20 +606,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f2cf3d6759f24371bd40f7cd430e1584
+      - b353922006c2417e8098f2db2c0f59c4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWU1Y2YtNzEw
-        YS04OWQwLWUzY2VmZmU4M2RlMS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:08 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLWYzMWQtNzJj
+        ZS04OTkyLTljN2FkZDc0NzU1Yi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:21 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ece-e5cf-710a-89d0-e3ceffe83de1/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-f31d-72ce-8992-9c7add74755b/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -627,7 +627,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -640,7 +640,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:08 GMT
+      - Mon, 02 Mar 2026 14:55:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -660,41 +660,41 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab66c98ac56c476dafe34c282bd39795
+      - 9fefb0f42fb74bd69bb834590d04af7a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2UtZTVj
-        Zi03MTBhLTg5ZDAtZTNjZWZmZTgzZGUxLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2UtZTVjZi03MTBhLTg5ZDAtZTNjZWZmZTgzZGUxIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNTowOC4wNDk0MDFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjA4LjA0NzUxN1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItZjMx
+        ZC03MmNlLTg5OTItOWM3YWRkNzQ3NTViLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItZjMxZC03MmNlLTg5OTItOWM3YWRkNzQ3NTViIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyMS44ODc3OThaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIxLjg4NTQyNloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZjJjZjNk
-        Njc1OWYyNDM3MWJkNDBmN2NkNDMwZTE1ODQiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMi0x
-        MVQyMjoyNTowOC4wNjk3MzZaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjU6MDguMTA1MzIzWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyNTowOC4zNDkyMDNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhYWItN2VkMi1hMDRiLWU2MmVi
-        MTRkMDJkZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYjM1Mzky
+        MjAwNmMyNDE3ZTgwOThmMmRiMmMwZjU5YzQiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NToyMS45MDE3MjdaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjEuOTUwMjY0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NToyMi4yMTA1MjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYmYtNzRlMC1hN2RiLWJmZTY3
+        MDIzOGVhOS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
-        ZWIvYXB0LzAxOWM0ZWNlLWU1NTUtNzc0ZC1iOGYwLTAwZGMzOGU2MWM3ZS92
+        ZWIvYXB0LzAxOWNhZjBiLWYyYjMtNzQ4YS05MmIxLTViNzdhYmY0MmU5Ny92
         ZXJzaW9ucy8xLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9yZWxlYXNl
-        X2NvbXBvbmVudHMvMDE5YzRlY2QtOTc1YS03ZjkzLTgzYzItN2U4ZjZiYTky
-        NTEyLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
-        YXB0cmVwb3NpdG9yeTowMTljNGVjZS1lNTU1LTc3NGQtYjhmMC0wMGRjMzhl
-        NjFjN2UiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYxMWMzLTIwNmMt
-        NDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:08 GMT
+        X2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNjODZjMWNk
+        OTUzLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
+        YXB0cmVwb3NpdG9yeTowMTljYWYwYi1mMmIzLTc0OGEtOTJiMS01Yjc3YWJm
+        NDJlOTciLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4YmE4LTdiMWEt
+        NDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ece-e555-774d-b8f0-00dc38e61c7e/versions/1/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-f2b3-748a-92b1-5b77abf42e97/versions/1/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -715,7 +715,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:08 GMT
+      - Mon, 02 Mar 2026 14:55:22 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -735,20 +735,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 637fb94e5ea141e6811c7f6180599419
+      - 0c0f7aea430d4f43934d319252c8d748
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZS1l
-        Njk3LTdlZjgtODFlMy05ODIxNjc0ZTMyOTgifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:08 GMT
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi1m
+        M2Y4LTczMGUtOTg0OS02MmExZTM5NDZhYWMifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/019c4ece-e483-7e78-a4c9-a685e3392813/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/019caf0b-f22c-74a5-bf88-3faa268e80fc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -769,7 +769,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:11 GMT
+      - Mon, 02 Mar 2026 14:55:24 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -789,20 +789,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 406b275f364246a381ce239350237919
+      - f2c853866af1446d882851f6f7557c86
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWY0NjQtNzRl
-        NC1hMTY0LWJiZGRmY2JjZDU5NC8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:11 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLWZmMzctNzU3
+        Mi05MmRhLTczYWM2NGQxMzUzMi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ece-f464-74e4-a164-bbddfcbcd594/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-ff37-7572-92da-73ac64d13532/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -810,7 +810,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -823,7 +823,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:11 GMT
+      - Mon, 02 Mar 2026 14:55:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -843,37 +843,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0900ecea950f4a21bfcbcd88d3488ee5'
+      - d9fc926346fe4ed48e0e691c1b933aa3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2UtZjQ2
-        NC03NGU0LWExNjQtYmJkZGZjYmNkNTk0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2UtZjQ2NC03NGU0LWExNjQtYmJkZGZjYmNkNTk0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxMS43ODI5OTRaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjExLjc4MDczNFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItZmYz
+        Ny03NTcyLTkyZGEtNzNhYzY0ZDEzNTMyLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItZmYzNy03NTcyLTkyZGEtNzNhYzY0ZDEzNTMyIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNC45ODYzNDhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI0Ljk4NDIxN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjQwNmIy
-        NzVmMzY0MjQ2YTM4MWNlMjM5MzUwMjM3OTE5IiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjU6MTEuODA2MDEzWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjI1OjExLjg0MTQyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjU6MTEuODgyNDA5WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYWI0LTc5YmMtOTQ0Yi1jM2Ri
-        ZjMwOThiOGYvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImYyYzg1
+        Mzg2NmFmMTQ0NmQ4ODI4NTFmNmY3NTU3Yzg2IiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTU6MjUuMDAxOTkzWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjI1LjA0NjczOFoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjUuMDg4NzI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMGJmLTc0ZTAtYTdkYi1iZmU2
+        NzAyMzhlYTkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljNGVjZS1lNDgzLTdlNzgtYTRj
-        OS1hNjg1ZTMzOTI4MTMiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYx
-        MWMzLTIwNmMtNDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:11 GMT
+        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi1mMjJjLTc0YTUtYmY4
+        OC0zZmFhMjY4ZTgwZmMiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4
+        YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:25 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ece-e555-774d-b8f0-00dc38e61c7e/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-f2b3-748a-92b1-5b77abf42e97/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -894,7 +894,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -914,20 +914,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3eec1d5f833d49368db42b26df355474
+      - ea20d773e05c4e8bb89135789eebb701
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWY1OTEtN2Vk
-        YS04NTk1LWIwOTZkMTQ1ZWQ5Zi8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTAwNTUtNzE0
+        Ni04ZTQ5LTY0MjA5ZDg1ZmFmMy8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:25 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ece-f591-7eda-8595-b096d145ed9f/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-0055-7146-8e49-64209d85faf3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -935,7 +935,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -948,7 +948,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:25 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -968,32 +968,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5c5047245bcd4916934281047e444467
+      - 1e230bcd07194fafbdcbc36fa7d80ed9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2UtZjU5
-        MS03ZWRhLTg1OTUtYjA5NmQxNDVlZDlmLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2UtZjU5MS03ZWRhLTg1OTUtYjA5NmQxNDVlZDlmIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxMi4wODQxMjNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjEyLjA4MjMyNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMDA1
+        NS03MTQ2LThlNDktNjQyMDlkODVmYWYzLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMDA1NS03MTQ2LThlNDktNjQyMDlkODVmYWYzIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNS4yNzE4NTNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI1LjI3MDAzOVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjNlZWMx
-        ZDVmODMzZDQ5MzY4ZGI0MmIyNmRmMzU1NDc0IiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjU6MTIuMTAzMDg3WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjI1OjEyLjE0Mjg2OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjU6MTIuMjEzOTc4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYWFiLTdlZDItYTA0Yi1lNjJl
-        YjE0ZDAyZGQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImVhMjBk
+        NzczZTA1YzRlOGJiODkxMzU3ODllZWJiNzAxIiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTU6MjUuMjgyNTI0WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjI1LjMyMzg4NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjUuMzg2NzU0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMmExLTc1OGEtOGIxYi05MTkx
+        YzdlNGYxNzEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5YzRlY2UtZTU1NS03NzRk
-        LWI4ZjAtMDBkYzM4ZTYxYzdlIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjow
-        ZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAiXX0=
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
-recorded_with: VCR 6.4.0
+        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGItZjJiMy03NDhh
+        LTkyYjEtNWI3N2FiZjQyZTk3Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5
+        OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:25 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/duplicate_upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/duplicate_upload_binary.yml
@@ -5446,68 +5446,6 @@ http_interactions:
         Yjc4LTdlODUtOGVjYy1iMzk3MzI1YWRhMWYifQ==
   recorded_at: Wed, 11 Feb 2026 20:26:59 GMT
 - request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoyMTIwfQ==
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:08 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/019c4ece-e970-7db5-9c0c-c9559996e1ef/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '242'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 0b1377727751465b9a11e2528a26c935
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljNGVjZS1l
-        OTcwLTdkYjUtOWMwYy1jOTU1OTk5NmUxZWYvIiwicHJuIjoicHJuOmNvcmUu
-        dXBsb2FkOjAxOWM0ZWNlLWU5NzAtN2RiNS05YzBjLWM5NTU5OTk2ZTFlZiIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDguOTc3MDk2WiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNTowOC45Nzcx
-        MDZaIiwic2l6ZSI6MjEyMH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:08 GMT
-- request:
     method: put
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/019c4ece-e970-7db5-9c0c-c9559996e1ef/
     body:
@@ -5623,60 +5561,6 @@ http_interactions:
         InB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDguOTc3MDk2WiIs
         InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNTowOC45Nzcx
         MDZaIiwic2l6ZSI6MjEyMH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:09 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 22e095aa5eb74a65abfc46c64f5e24ed
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
   recorded_at: Wed, 11 Feb 2026 22:25:09 GMT
 - request:
     method: post
@@ -5805,149 +5689,6 @@ http_interactions:
         cmNlc19yZWNvcmQiOlsicHJuOmNvcmUudXBsb2FkOjAxOWM0ZWNlLWU5NzAt
         N2RiNS05YzBjLWM5NTU5OTk2ZTFlZiIsInNoYXJlZDpwcm46Y29yZS5kb21h
         aW46MGQyNjExYzMtMjA2Yy00MDE2LWJiNTctYzRiMDU5ZTFkYzQwIl19
-  recorded_at: Wed, 11 Feb 2026 22:25:09 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '835'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 000fcf12b27b4d94abd57a147cf8b488
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVhMjNlYjg1LyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOWM0ZWNlLWVhNzUtNzQxZC1hOWU1LTU4NzVl
-        YTIzZWI4NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDku
-        MjM4NjY4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        NTowOS4yMzg2NzhaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
-        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
-        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
-        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
-        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
-        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
-        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
-        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
-        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
-        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
-        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
-        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
-        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:09 GMT
-- request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTVlOTU3ODA5ZmE0NjQ1
-        MWFhODc1NGI1MzhkY2E4NzhhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZS1lNTU1LTc3NGQtYjhmMC0wMGRj
-        MzhlNjFjN2UvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNWU5
-        NTc4MDlmYTQ2NDUxYWE4NzU0YjUzOGRjYTg3OGENCkNvbnRlbnQtRGlzcG9z
-        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
-        aS92My9hcnRpZmFjdHMvMDE5YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVh
-        MjNlYjg1Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTVlOTU3
-        ODA5ZmE0NjQ1MWFhODc1NGI1MzhkY2E4NzhhDQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
-        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTVlOTU3ODA5ZmE0
-        NjQ1MWFhODc1NGI1MzhkY2E4NzhhDQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
-        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
-        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtNWU5NTc4MDlmYTQ2NDUxYWE4NzU0
-        YjUzOGRjYTg3OGEtLQ0K
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-5e957809fa46451aa8754b538dca878a
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '690'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:09 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 950703c755d04af79de81fbe6807b951
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWViNTQtN2Y4
-        Yi1iNzVkLTA4YzdlNDI2ZTc3OC8ifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:09 GMT
 - request:
     method: get
@@ -6084,4 +5825,835 @@ http_interactions:
         eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZS1l
         YzczLTcyNjYtYWNmYy1lN2NmYjU4NmViMTkifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
-recorded_with: VCR 6.4.0
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?component=empty&distribution=katello&repository_version=/pulp/api/v3/repositories/deb/apt/019caf0b-f2b3-748a-92b1-5b77abf42e97/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '421'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 220bc5c17b8d41d8b2cd399143089a3a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNj
+        ODZjMWNkOTUzLyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi01YTA1LTc2Y2ItOTc2Yi1lM2M4NmMxY2Q5NTMiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQyLjY5NTI5M1oiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDIuNjk1MzA1WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        ImVtcHR5IiwiZGlzdHJpYnV0aW9uIjoia2F0ZWxsbyIsInBsYWluX2NvbXBv
+        bmVudCI6ImVtcHR5In1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-f2b3-748a-92b1-5b77abf42e97/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLzAxOWNhZjBiLTVhMDUtNzZjYi05
+        NzZiLWUzYzg2YzFjZDk1My8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 999331ad5e4746d7ab09d69f57b155b8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLWY1ZTMtNzEy
+        OS04OGY1LWViZjVlY2Q0NzM0MC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-f5e3-7129-88f5-ebf5ecd47340/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '937'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 43d24710a7dd498bb6401879edbdbea7
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItZjVl
+        My03MTI5LTg4ZjUtZWJmNWVjZDQ3MzQwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItZjVlMy03MTI5LTg4ZjUtZWJmNWVjZDQ3MzQwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyMi42MDAxMzFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIyLjU5NTQ1MVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        OTk5MzMxYWQ1ZTQ3NDZkN2FiMDlkNjlmNTdiMTU1YjgiLCJjcmVhdGVkX2J5
+        IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
+        Ni0wMy0wMlQxNDo1NToyMi42MTUwMzFaIiwic3RhcnRlZF9hdCI6IjIwMjYt
+        MDMtMDJUMTQ6NTU6MjIuNjUxMzgyWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
+        My0wMlQxNDo1NToyMi43NDAwMTlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYjQtNzQwOS1iODI0
+        LWI0NzZlY2I2N2ZlMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
+        XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBiLWYyYjMtNzQ4YS05MmIxLTViNzdhYmY0
+        MmU5Ny92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbInBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi1mMmIzLTc0OGEt
+        OTJiMS01Yjc3YWJmNDJlOTciLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5
+        OTg4YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoyMTIwfQ==
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/019caf0b-f6ce-7aa0-8238-e54c068fee71/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - aa38d47237c14e9e95e42148774f0fcd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYi1m
+        NmNlLTdhYTAtODIzOC1lNTRjMDY4ZmVlNzEvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBiLWY2Y2UtN2FhMC04MjM4LWU1NGMwNjhmZWU3MSIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjIuODMxNTI1WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyMi44MzE1
+        NzBaIiwic2l6ZSI6MjEyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0b-f6ce-7aa0-8238-e54c068fee71/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTM1NjU0YjZhYWQzMWJl
+        ZjFiNjhiNDQ2YmVkNDJiNmJkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNjAz
+        MDItMTE0MDAteTNqcXBjIg0KQ29udGVudC1MZW5ndGg6IDIxMjANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24veC1kZWJpYW4tcGFja2FnZQ0KQ29udGVu
+        dC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCiE8YXJjaD4KZGViaWFu
+        LWJpbmFyeSAgIDE3MDAxNTY2NDggIDAgICAgIDAgICAgIDEwMDY0NCAgNCAg
+        ICAgICAgIGAKMi4wCmNvbnRyb2wudGFyLnh6ICAxNzAwMTU2NjQ4ICAwICAg
+        ICAwICAgICAxMDA2NDQgIDUzMiAgICAgICBgCv03elhaAAAE5ta0RgTA1AOA
+        UCEBFgAAAAAAAAB7vaGp4Cf/AcxdABcLvBx9AZXAHUo+eRXCzCajXhkmHeIX
+        O6fbeQG9bAANmdiTpnkVq/IrMBqgo9/hV77SAMRbyx6vZJ8fCjqkil5VAAR3
+        J8RkW3OejWLGKN7oTSiPs6jMAhxJAkgbJ2r0SYPjLt9wkOp864rfL8mAi4Lw
+        8YUpyMPUrh+UpF0nJQrIJVD9yvTL36CDI4tXWr4i7bL5VA8H80qADzFeKFmT
+        1r8THN7lwH3pZrsdtrVA/7sU3Q8Hr+4FQh2+r9H4qm8QY0YDD7vVM+cBKNCt
+        j04+Jt+MBktzWaHEznEkQQyLizN5CDtjKKMqttfHCKk3DjQloyEtS74ZWdWx
+        LLlJu+un0GaahYuheKdbps5qeMPVHi9wsefHXpIJsyPW0CFU2wQrtXdjrGdK
+        1lx+HdA3s+BAwWEIU8xS4fmbxAIHGWjEkFEVM8mqyuNZxhNkgTG42cmTwnJr
+        HW3PoesvFpaCsWQdF+8nuVd6wxBcJ6u6LzDaEPdD7POpoU6HklbJemIxujWM
+        j/US7U9igW3Ye9ybHld2cATcUN2/pkpmcdjFiW7p9VTtb3GKbF7xUxWw8gxs
+        3gBVqXqIlOiTrmwkViGIOPeNXovzJUVb0oEEdYmaIAAAScx2BL0XgD4AAfAD
+        gFAAAJ8vghCxxGf7AgAAAAAEWVpkYXRhLnRhci54eiAgICAgMTcwMDE1NjY0
+        OCAgMCAgICAgMCAgICAgMTAwNjQ0ICAxMzk2ICAgICAgYAr9N3pYWgAABObW
+        tEYEwLIKgFAhARYAAAAAAAAADHMrWuAn/wUqXQAXC7wcfQGVwB1KPnkVwswm
+        o14ZJh3iFzun23kBvWwADZnYk6Z5FavyKzAaoKPf4Ve+0gDEW8ser2WpRmq/
+        lgJr86jpA4JJoXsT/GyBvNifAwtq1FwZXqvBkvJgKnJh1LMUG8Jn4pOUsxn3
+        1k78N+8jwc/HACSKQvrGSQWLBhFLBDcfjcXKEIi6QQsxp5lNfoQg8PwBm1nH
+        BBVmBcLmP9qFgNX7JyRODJbpBk4rMU3GwePu1mgHfNwQ6XcLf54wmXVet+z6
+        dK13NI5IWcJFCp5w5QEZvucsSP0pJI1C4AsutB1AVQz1MFQC0yPEoVOMlxKG
+        Iy92DN6fDhBnWOK50seZvYQ/X1sklWG7lILIJlIKPvxI6vEp3punBDSmD77X
+        FRhR4xKJvdXEwE86IzUXMS4DrwoHOuUJ2jpWD7bO+6zRB3yuBIQuF73QDDW/
+        Is68PNn5ZA23plMU1iw3gXwV+gn+vmxEPk1gd72jfIkI5VrGx+iCStWiwxYa
+        Mb+PcLg1LVyIi1XtmgoxMIfnCQRzT3Z/m0GPJXFoVeEX76Bem32ApnZvHORJ
+        heNHOqRHR0mWdqnbY1Qep/WdetmKDPmzuuBj6sjxmyaIXmWBNzt+hHs1l5dH
+        gLMNFN17GX7EKVRtLqjq3KMHNWjlkBPccNWDjVZ+nHJK10vJSBT9OSpJKZ5w
+        wx8SAmmxW0y0JYP+lpW8rYjiuwWW5sDmMFJozmsB0+8cdEC1T+dOAJgCiVLJ
+        7RK95KExMJWPQ5exXLsaTtWD8pfacg/s40QZBlMiWHR5fYKwfnWAihizzPCg
+        /+WwjvbV+bhrEqefVtnkvDcQTnb/6UcfNbfzE7MihkBeH2kP+Esh5vKGyBds
+        N0QTBO3Ul2mPy+7aPmYFOP5bA8G7htZVUHs+h7XgkSmMyPf4P51BHcon45cP
+        pmqL+swHPpO0vKBEC3OxzRC3b36zXK1iYfTHbN5/Es8QD/lQGXn8Uq7VEndk
+        OyHuVYQLuJasEiEerMrTy0JyZlSPgUkZRCSucMo8cTZBN7l4HkkvvI0ODmvC
+        JqKPG77ZsZXD/COIH6AW25PZKi81Rl/XD2K1mBwaghByNTzGfjlMtDyTWxKf
+        54emyKGvrA3omrpfOnsUwg2Ny43KmM0qphwyoZSUTFwRz+q/TlSkQp+NtcOV
+        HQv0NK39ta/caU6ADA8Ry2/qMQ4gRgSvFvqYrIthXgqfVL+QN0lNxZnUBj/z
+        G5bUNvb3sJbvV6jHokpUB62OY32EmrtdA9gW07UKpwUA06nChx+Z3gnWjnNM
+        SrZAvph3y4TZz33hODZcJy7vGVxyB3Dow69Dw1tYNO9LDoXAcpT/Yl0XUfgF
+        HsseZPrmkoAzSuoboYorSL/LcQjCjCClAaWK7NhwFHLuw1ZO9oZpB3VzmzWR
+        JCZgCOopA+EKhipQKHbmFLtyOiA2CbJTA/HubJTiFzHmw/fvoiBuN61HuTQP
+        fa8RQNzNzAjXJLAy1372Td1bKeTgIGXT0LSMsBa5z9Kp82YZtHLu5KnMNmqT
+        hIBNz5eiYO5cPtimd79JFneK6KKAAxBoWMGCUob8zRA3+htTi1Cf7PJnx2RZ
+        3rtTdApDjVAshmVaE6CBSvh79JoHWdAI1ZdLijE6m2fJ00qH+G/GPaUt6hWG
+        Ku48+TqixYNG22uFPt0J6eEic3elB+pmfR//Ot4Pt0OjvbRrpsU5YqJ6et9o
+        1COZJ3MfW1nKLKUD15iwrOryN0QpI9DFjY2ouNf3w340GBl9KJEDH7qrnYVr
+        MAAAAFBgbxPoKbtQAAHOCoBQAAAzK+IjscRn+wIAAAAABFlaDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtMzU2NTRiNmFhZDMxYmVmMWI2OGI0
+        NDZiZWQ0MmI2YmQtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-35654b6aad31bef1b68b446bed42b6bd
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-2119/2120
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '2445'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1d32d952d9c443d288392702893572e9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYi1m
+        NmNlLTdhYTAtODIzOC1lNTRjMDY4ZmVlNzEvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBiLWY2Y2UtN2FhMC04MjM4LWU1NGMwNjhmZWU3MSIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjIuODMxNTI1WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyMi44MzE1
+        NzBaIiwic2l6ZSI6MjEyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - dd029c97ce69499ba06c353eec512854
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0b-f6ce-7aa0-8238-e54c068fee71/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiJkZDk3NjJkZDk4MjhhNTY3MjNlYThiNzYyZWE3MzdmYWE4
+        NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFkMWM5NGU1In0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:22 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6eb35da6ff124610b98bf424a623145d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLWY3NDQtNzdl
+        ZS1hMjgwLWIzM2YyMjdlMzExMS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:22 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-f744-77ee-a280-b33f227e3111/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '897'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e3707c8631624bea87f20dcc54a9ad13
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItZjc0
+        NC03N2VlLWEyODAtYjMzZjIyN2UzMTExLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItZjc0NC03N2VlLWEyODAtYjMzZjIyN2UzMTExIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyMi45NTA5MjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIyLjk0ODk1MFoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MudXBsb2FkLmNvbW1pdCIsImxvZ2dpbmdfY2lkIjoiNmViMzVkYTZmZjEy
+        NDYxMGI5OGJmNDI0YTYyMzE0NWQiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBp
+        L3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0wMlQxNDo1
+        NToyMi45NjA1NTBaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJUMTQ6NTU6
+        MjIuOTk3MTMwWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQxNDo1NToy
+        My4wMzcyMDRaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92
+        My93b3JrZXJzLzAxOWNhZTIyLWEwYjQtNzQwOS1iODI0LWI0NzZlY2I2N2Zl
+        MC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNr
+        X2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9y
+        ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wMTljYWYwYi1m
+        Nzg3LTdkNzgtYjNjZi1kZTAyMTc5NGNlZTkvIl0sInJlc2VydmVkX3Jlc291
+        cmNlc19yZWNvcmQiOlsicHJuOmNvcmUudXBsb2FkOjAxOWNhZjBiLWY2Y2Ut
+        N2FhMC04MjM4LWU1NGMwNjhmZWU3MSIsInNoYXJlZDpwcm46Y29yZS5kb21h
+        aW46OTk5ODhiYTgtN2IxYS00MGI5LWE2MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:55:23 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '835'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1bb2ec0099e046f5a4112a53c6c5c2b8
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3OTRjZWU5LyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOWNhZjBiLWY3ODctN2Q3OC1iM2NmLWRlMDIx
+        Nzk0Y2VlOSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMu
+        MDE1OTMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NToyMy4wMTU5NDRaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
+        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
+        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
+        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
+        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
+        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
+        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
+        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
+        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
+        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
+        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
+        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
+        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:23 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWVhNGZkNDA1ZTNlNDg4
+        ZWViNjFjNjM0YzljMzYwNTJkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi1mMmIzLTc0OGEtOTJiMS01Yjc3
+        YWJmNDJlOTcvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtZWE0
+        ZmQ0MDVlM2U0ODhlZWI2MWM2MzRjOWMzNjA1MmQNCkNvbnRlbnQtRGlzcG9z
+        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDE5Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3
+        OTRjZWU5Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWVhNGZk
+        NDA1ZTNlNDg4ZWViNjFjNjM0YzljMzYwNTJkDQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
+        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWVhNGZkNDA1ZTNl
+        NDg4ZWViNjFjNjM0YzljMzYwNTJkDQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
+        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtZWE0ZmQ0MDVlM2U0ODhlZWI2MWM2
+        MzRjOWMzNjA1MmQtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-ea4fd405e3e488eeb61c634c9c36052d
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '690'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7ed39f864c68480b8755aa17e0075073
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLWY4NDEtNzY2
+        YS04ZjRhLTZmMzcxYTIxMzNmNy8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:23 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-f841-766a-8f4a-6f371a2133f7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1268'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 60e9309fc8274f6c90585318908975cb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItZjg0
+        MS03NjZhLThmNGEtNmYzNzFhMjEzM2Y3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItZjg0MS03NjZhLThmNGEtNmYzNzFhMjEzM2Y3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyMy4yMDM2NjFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjIwMTg5M1oi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiN2VkMzlm
+        ODY0YzY4NDgwYjg3NTVhYTE3ZTAwNzUwNzMiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NToyMy4yMTQ3NzVaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjMuMjU2NjI0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NToyMy41NDgwNjNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYmYtNzRlMC1hN2RiLWJmZTY3
+        MDIzOGVhOS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
+        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
+        ZWIvYXB0LzAxOWNhZjBiLWYyYjMtNzQ4YS05MmIxLTViNzdhYmY0MmU5Ny92
+        ZXJzaW9ucy8zLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdl
+        cy8wMTljYWYwYi1mOGU5LTc0NDUtYTU4OC05YWYyMmY1M2Y0ZWIvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfY29tcG9uZW50cy8wMTlj
+        YWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQvIiwiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0dXJlcy8wMTljYWYw
+        Yi1mOTAwLTdjMTQtOTMwNi05ZmM4MDZhNGI1ZWQvIiwiL3B1bHAvYXBpL3Yz
+        L2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25lbnRzLzAxOWNh
+        ZjBiLWY5MDYtN2YxNi1iYmM5LTA1M2QwOTE3MWI2Yi8iXSwicmVzZXJ2ZWRf
+        cmVzb3VyY2VzX3JlY29yZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5
+        Y2FmMGItZjJiMy03NDhhLTkyYjEtNWI3N2FiZjQyZTk3Iiwic2hhcmVkOnBy
+        bjpjb3JlLmRvbWFpbjo5OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJm
+        MTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:23 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-f2b3-748a-92b1-5b77abf42e97/versions/3/?fields=prn
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:23 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '73'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 50e3cdd194ec4eb58455ae44436d3531
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi1m
+        OTBkLTc1YWQtYWEyYy0zMjUwZTkxYjEzOTUifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:23 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/duplicate_upload_binary_duplicate.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/duplicate_upload_binary_duplicate.yml
@@ -4045,68 +4045,6 @@ http_interactions:
         OWU4OS03MmE0NGNlYzQ1NWYiXX0=
   recorded_at: Wed, 11 Feb 2026 20:27:00 GMT
 - request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoyMTIwfQ==
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/019c4ece-efc3-7ab4-bda3-a44341fe038c/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '242'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - a6d433f765cb429f8145e799bbc193d0
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljNGVjZS1l
-        ZmMzLTdhYjQtYmRhMy1hNDQzNDFmZTAzOGMvIiwicHJuIjoicHJuOmNvcmUu
-        dXBsb2FkOjAxOWM0ZWNlLWVmYzMtN2FiNC1iZGEzLWE0NDM0MWZlMDM4YyIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MTAuNTk1NTQ0WiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxMC41OTU1
-        NTFaIiwic2l6ZSI6MjEyMH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
-- request:
     method: put
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/019c4ece-efc3-7ab4-bda3-a44341fe038c/
     body:
@@ -4224,77 +4162,6 @@ http_interactions:
         NTFaIiwic2l6ZSI6MjEyMH0=
   recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
 - request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '835'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 5eaa1a1a751a4427836bae9f55577a1c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVhMjNlYjg1LyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOWM0ZWNlLWVhNzUtNzQxZC1hOWU1LTU4NzVl
-        YTIzZWI4NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDku
-        MjM4NjY4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        NTowOS4yMzg2NzhaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
-        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
-        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
-        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
-        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
-        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
-        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
-        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
-        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
-        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
-        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
-        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
-        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
-- request:
     method: delete
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/019c4ece-efc3-7ab4-bda3-a44341fe038c/
     body:
@@ -4341,149 +4208,6 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: ''
-  recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '835'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - '09a261357d784b689d014370b860ce9f'
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVhMjNlYjg1LyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOWM0ZWNlLWVhNzUtNzQxZC1hOWU1LTU4NzVl
-        YTIzZWI4NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDku
-        MjM4NjY4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        NTowOS4yMzg2NzhaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
-        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
-        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
-        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
-        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
-        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
-        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
-        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
-        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
-        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
-        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
-        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
-        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
-- request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTNhNTdmYjUyMTc0NmEy
-        YTZkNzg4ZDE5YTAzZTk3YTM1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZS1lNTU1LTc3NGQtYjhmMC0wMGRj
-        MzhlNjFjN2UvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtM2E1
-        N2ZiNTIxNzQ2YTJhNmQ3ODhkMTlhMDNlOTdhMzUNCkNvbnRlbnQtRGlzcG9z
-        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
-        aS92My9hcnRpZmFjdHMvMDE5YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVh
-        MjNlYjg1Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTNhNTdm
-        YjUyMTc0NmEyYTZkNzg4ZDE5YTAzZTk3YTM1DQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
-        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTNhNTdmYjUyMTc0
-        NmEyYTZkNzg4ZDE5YTAzZTk3YTM1DQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
-        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
-        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtM2E1N2ZiNTIxNzQ2YTJhNmQ3ODhk
-        MTlhMDNlOTdhMzUtLQ0K
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-3a57fb521746a2a6d788d19a03e97a35
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '690'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:10 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - '02225834d8814554a02d27d69d1f27c9'
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWYwZTYtNzY1
-        Ni1iNmQxLWQ4ZTM0ZjlkOTE4My8ifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:10 GMT
 - request:
     method: get
@@ -4558,4 +4282,518 @@ http_interactions:
         Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowZDI2MTFjMy0yMDZjLTQwMTYt
         YmI1Ny1jNGIwNTllMWRjNDAiXX0=
   recorded_at: Wed, 11 Feb 2026 22:25:11 GMT
-recorded_with: VCR 6.4.0
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoyMTIwfQ==
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/019caf0b-fb8d-77b7-92c2-128950500436/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4046ea511b284a89866296eb1ac191b3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYi1m
+        YjhkLTc3YjctOTJjMi0xMjg5NTA1MDA0MzYvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBiLWZiOGQtNzdiNy05MmMyLTEyODk1MDUwMDQzNiIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjQuMDQ2MDIxWiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNC4wNDYw
+        MzFaIiwic2l6ZSI6MjEyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0b-fb8d-77b7-92c2-128950500436/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA4N2ViMzg5YTVjZGRh
+        Y2JkMjNhODE2MzRmNmJmNWI4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNjAz
+        MDItMTE0MDAtZW80aGFzIg0KQ29udGVudC1MZW5ndGg6IDIxMjANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24veC1kZWJpYW4tcGFja2FnZQ0KQ29udGVu
+        dC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCiE8YXJjaD4KZGViaWFu
+        LWJpbmFyeSAgIDE3MDAxNTY2NDggIDAgICAgIDAgICAgIDEwMDY0NCAgNCAg
+        ICAgICAgIGAKMi4wCmNvbnRyb2wudGFyLnh6ICAxNzAwMTU2NjQ4ICAwICAg
+        ICAwICAgICAxMDA2NDQgIDUzMiAgICAgICBgCv03elhaAAAE5ta0RgTA1AOA
+        UCEBFgAAAAAAAAB7vaGp4Cf/AcxdABcLvBx9AZXAHUo+eRXCzCajXhkmHeIX
+        O6fbeQG9bAANmdiTpnkVq/IrMBqgo9/hV77SAMRbyx6vZJ8fCjqkil5VAAR3
+        J8RkW3OejWLGKN7oTSiPs6jMAhxJAkgbJ2r0SYPjLt9wkOp864rfL8mAi4Lw
+        8YUpyMPUrh+UpF0nJQrIJVD9yvTL36CDI4tXWr4i7bL5VA8H80qADzFeKFmT
+        1r8THN7lwH3pZrsdtrVA/7sU3Q8Hr+4FQh2+r9H4qm8QY0YDD7vVM+cBKNCt
+        j04+Jt+MBktzWaHEznEkQQyLizN5CDtjKKMqttfHCKk3DjQloyEtS74ZWdWx
+        LLlJu+un0GaahYuheKdbps5qeMPVHi9wsefHXpIJsyPW0CFU2wQrtXdjrGdK
+        1lx+HdA3s+BAwWEIU8xS4fmbxAIHGWjEkFEVM8mqyuNZxhNkgTG42cmTwnJr
+        HW3PoesvFpaCsWQdF+8nuVd6wxBcJ6u6LzDaEPdD7POpoU6HklbJemIxujWM
+        j/US7U9igW3Ye9ybHld2cATcUN2/pkpmcdjFiW7p9VTtb3GKbF7xUxWw8gxs
+        3gBVqXqIlOiTrmwkViGIOPeNXovzJUVb0oEEdYmaIAAAScx2BL0XgD4AAfAD
+        gFAAAJ8vghCxxGf7AgAAAAAEWVpkYXRhLnRhci54eiAgICAgMTcwMDE1NjY0
+        OCAgMCAgICAgMCAgICAgMTAwNjQ0ICAxMzk2ICAgICAgYAr9N3pYWgAABObW
+        tEYEwLIKgFAhARYAAAAAAAAADHMrWuAn/wUqXQAXC7wcfQGVwB1KPnkVwswm
+        o14ZJh3iFzun23kBvWwADZnYk6Z5FavyKzAaoKPf4Ve+0gDEW8ser2WpRmq/
+        lgJr86jpA4JJoXsT/GyBvNifAwtq1FwZXqvBkvJgKnJh1LMUG8Jn4pOUsxn3
+        1k78N+8jwc/HACSKQvrGSQWLBhFLBDcfjcXKEIi6QQsxp5lNfoQg8PwBm1nH
+        BBVmBcLmP9qFgNX7JyRODJbpBk4rMU3GwePu1mgHfNwQ6XcLf54wmXVet+z6
+        dK13NI5IWcJFCp5w5QEZvucsSP0pJI1C4AsutB1AVQz1MFQC0yPEoVOMlxKG
+        Iy92DN6fDhBnWOK50seZvYQ/X1sklWG7lILIJlIKPvxI6vEp3punBDSmD77X
+        FRhR4xKJvdXEwE86IzUXMS4DrwoHOuUJ2jpWD7bO+6zRB3yuBIQuF73QDDW/
+        Is68PNn5ZA23plMU1iw3gXwV+gn+vmxEPk1gd72jfIkI5VrGx+iCStWiwxYa
+        Mb+PcLg1LVyIi1XtmgoxMIfnCQRzT3Z/m0GPJXFoVeEX76Bem32ApnZvHORJ
+        heNHOqRHR0mWdqnbY1Qep/WdetmKDPmzuuBj6sjxmyaIXmWBNzt+hHs1l5dH
+        gLMNFN17GX7EKVRtLqjq3KMHNWjlkBPccNWDjVZ+nHJK10vJSBT9OSpJKZ5w
+        wx8SAmmxW0y0JYP+lpW8rYjiuwWW5sDmMFJozmsB0+8cdEC1T+dOAJgCiVLJ
+        7RK95KExMJWPQ5exXLsaTtWD8pfacg/s40QZBlMiWHR5fYKwfnWAihizzPCg
+        /+WwjvbV+bhrEqefVtnkvDcQTnb/6UcfNbfzE7MihkBeH2kP+Esh5vKGyBds
+        N0QTBO3Ul2mPy+7aPmYFOP5bA8G7htZVUHs+h7XgkSmMyPf4P51BHcon45cP
+        pmqL+swHPpO0vKBEC3OxzRC3b36zXK1iYfTHbN5/Es8QD/lQGXn8Uq7VEndk
+        OyHuVYQLuJasEiEerMrTy0JyZlSPgUkZRCSucMo8cTZBN7l4HkkvvI0ODmvC
+        JqKPG77ZsZXD/COIH6AW25PZKi81Rl/XD2K1mBwaghByNTzGfjlMtDyTWxKf
+        54emyKGvrA3omrpfOnsUwg2Ny43KmM0qphwyoZSUTFwRz+q/TlSkQp+NtcOV
+        HQv0NK39ta/caU6ADA8Ry2/qMQ4gRgSvFvqYrIthXgqfVL+QN0lNxZnUBj/z
+        G5bUNvb3sJbvV6jHokpUB62OY32EmrtdA9gW07UKpwUA06nChx+Z3gnWjnNM
+        SrZAvph3y4TZz33hODZcJy7vGVxyB3Dow69Dw1tYNO9LDoXAcpT/Yl0XUfgF
+        HsseZPrmkoAzSuoboYorSL/LcQjCjCClAaWK7NhwFHLuw1ZO9oZpB3VzmzWR
+        JCZgCOopA+EKhipQKHbmFLtyOiA2CbJTA/HubJTiFzHmw/fvoiBuN61HuTQP
+        fa8RQNzNzAjXJLAy1372Td1bKeTgIGXT0LSMsBa5z9Kp82YZtHLu5KnMNmqT
+        hIBNz5eiYO5cPtimd79JFneK6KKAAxBoWMGCUob8zRA3+htTi1Cf7PJnx2RZ
+        3rtTdApDjVAshmVaE6CBSvh79JoHWdAI1ZdLijE6m2fJ00qH+G/GPaUt6hWG
+        Ku48+TqixYNG22uFPt0J6eEic3elB+pmfR//Ot4Pt0OjvbRrpsU5YqJ6et9o
+        1COZJ3MfW1nKLKUD15iwrOryN0QpI9DFjY2ouNf3w340GBl9KJEDH7qrnYVr
+        MAAAAFBgbxPoKbtQAAHOCoBQAAAzK+IjscRn+wIAAAAABFlaDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtMDg3ZWIzODlhNWNkZGFjYmQyM2E4
+        MTYzNGY2YmY1YjgtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-087eb389a5cddacbd23a81634f6bf5b8
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-2119/2120
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '2445'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e01e4e12aa254112938aa399ccbfdd35
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYi1m
+        YjhkLTc3YjctOTJjMi0xMjg5NTA1MDA0MzYvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBiLWZiOGQtNzdiNy05MmMyLTEyODk1MDUwMDQzNiIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjQuMDQ2MDIxWiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNC4wNDYw
+        MzFaIiwic2l6ZSI6MjEyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '835'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1a07876867ae466db3a2db28eb8d6394
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3OTRjZWU5LyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOWNhZjBiLWY3ODctN2Q3OC1iM2NmLWRlMDIx
+        Nzk0Y2VlOSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMu
+        MDE1OTMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NToyMy4wMTU5NDRaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
+        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
+        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
+        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
+        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
+        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
+        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
+        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
+        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
+        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
+        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
+        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
+        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+- request:
+    method: delete
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0b-fb8d-77b7-92c2-128950500436/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 64370205312e4c6aa76f43a276ec5e1e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: ''
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '835'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - b52abf93fe814d17859a4fab25b42651
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3OTRjZWU5LyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOWNhZjBiLWY3ODctN2Q3OC1iM2NmLWRlMDIx
+        Nzk0Y2VlOSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMu
+        MDE1OTMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NToyMy4wMTU5NDRaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
+        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
+        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
+        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
+        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
+        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
+        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
+        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
+        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
+        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
+        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
+        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
+        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJjY2I1ZTk3MTUxODdh
+        ZDIxZjQ0MWEzNzMwMWMzNGM0DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi1mMmIzLTc0OGEtOTJiMS01Yjc3
+        YWJmNDJlOTcvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMmNj
+        YjVlOTcxNTE4N2FkMjFmNDQxYTM3MzAxYzM0YzQNCkNvbnRlbnQtRGlzcG9z
+        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDE5Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3
+        OTRjZWU5Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJjY2I1
+        ZTk3MTUxODdhZDIxZjQ0MWEzNzMwMWMzNGM0DQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
+        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTJjY2I1ZTk3MTUx
+        ODdhZDIxZjQ0MWEzNzMwMWMzNGM0DQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
+        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtMmNjYjVlOTcxNTE4N2FkMjFmNDQx
+        YTM3MzAxYzM0YzQtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-2ccb5e9715187ad21f441a37301c34c4
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '690'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 658c635a120646d6a6a5a9eda4db193d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLWZjODMtNzk1
+        NC1iYzE0LTU2MjY4OTEwOTFkMi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-fc83-7954-bc14-5626891091d2/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:24 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '920'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0fed0aa4fd0844699be073f691263ab3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItZmM4
+        My03OTU0LWJjMTQtNTYyNjg5MTA5MWQyLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItZmM4My03OTU0LWJjMTQtNTYyNjg5MTA5MWQyIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNC4yOTM5NzFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI0LjI5MjI3MVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNjU4YzYz
+        NWExMjA2NDZkNmE2YTVhOWVkYTRkYjE5M2QiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NToyNC4zMTI4ODJaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjQuMzQ0MzI3WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NToyNC42MTU0NzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyOGMtNzUzYy05N2ZmLTVlOTUw
+        NTFkNmM0Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
+        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3Bh
+        Y2thZ2VzLzAxOWNhZjBiLWY4ZTktNzQ0NS1hNTg4LTlhZjIyZjUzZjRlYi8i
+        XSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46ZGViLmFwdHJl
+        cG9zaXRvcnk6MDE5Y2FmMGItZjJiMy03NDhhLTkyYjEtNWI3N2FiZjQyZTk3
+        Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5OTk4OGJhOC03YjFhLTQwYjkt
+        YTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:24 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/upload.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/upload.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,21 +43,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 630fce55d73f42788e13360b8ae4bea6
+      - 183965617d8444ac95ed2cc15dbcde5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI0OjM4LjI2NTEzMloiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1LjE5MzI1NloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -184,10 +184,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=Debian_10
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=Debian_10
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -208,7 +208,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -228,20 +228,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1cccff5b762e46f590d17fa6ec9d4b01
+      - 71e3419934fe48309dd5fefc10c030c3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=Debian_10
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=Debian_10
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,7 +262,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -282,20 +282,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a9262124915943188bc964fdb450acdf
+      - b8d0d40c06524eb5839630df035ad8d4
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=Debian_10
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=Debian_10
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -316,7 +316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -336,20 +336,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7e3fd552414849d9b3d2110e0557c90b
+      - 244ba781f93d472abff0780eda502bec
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_10_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_10_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:12 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -390,20 +390,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 8555b36e8355462cb640b04a3c4fdf32
+      - c93d51f7d50648ba9a6ac8a6c2eb23fe
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:12 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
@@ -435,13 +435,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:13 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/deb/apt/019c4ece-f9cf-7ff9-ad10-10c067c4a531/"
+      - "/pulp/api/v3/remotes/deb/apt/019caf0c-046a-742d-82fa-073a70175f82/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -457,20 +457,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 604019f2ff6a4224ad9e0045115a5b4e
+      - 436b19b8a1cf4f65a64bcc9c0bb315c7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAx
-        OWM0ZWNlLWY5Y2YtN2ZmOS1hZDEwLTEwYzA2N2M0YTUzMS8iLCJwcm4iOiJw
-        cm46ZGViLmFwdHJlbW90ZTowMTljNGVjZS1mOWNmLTdmZjktYWQxMC0xMGMw
-        NjdjNGE1MzEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjEz
-        LjE2NzQ3MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDItMTFUMjI6
-        MjU6MTMuMTY3NDc5WiIsIm5hbWUiOiJEZWJpYW5fMTAiLCJ1cmwiOiJodHRw
+        OWNhZjBjLTA0NmEtNzQyZC04MmZhLTA3M2E3MDE3NWY4Mi8iLCJwcm4iOiJw
+        cm46ZGViLmFwdHJlbW90ZTowMTljYWYwYy0wNDZhLTc0MmQtODJmYS0wNzNh
+        NzAxNzVmODIiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI2
+        LjMxNDY3NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6
+        NTU6MjYuMzE0Njg2WiIsIm5hbWUiOiJEZWJpYW5fMTAiLCJ1cmwiOiJodHRw
         Oi8vbXlyZXBvLmNvbSIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0Ijpu
         dWxsLCJ0bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJw
         dWxwX2xhYmVscyI6e30sImRvd25sb2FkX2NvbmN1cnJlbmN5IjpudWxsLCJt
@@ -488,10 +488,10 @@ http_interactions:
         eW5jX2luc3RhbGxlciI6ZmFsc2UsImdwZ2tleSI6IkFERiNGQ1NGQVNERiRA
         JEBaRkREU0ckIyUjJUFEUyIsImlnbm9yZV9taXNzaW5nX3BhY2thZ2VfaW5k
         aWNlcyI6ZmFsc2V9
-  recorded_at: Wed, 11 Feb 2026 22:25:13 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiRGViaWFuXzEwIn0=
@@ -514,13 +514,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:13 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/deb/apt/019c4ece-faa4-7036-bf6c-1844e9ff3394/"
+      - "/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -536,38 +536,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 036a3bdce2904c28a84d5a3734e20b88
+      - d8bf1458b94041beadaa023481a37dfb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2UtZmFhNC03MDM2LWJmNmMtMTg0NGU5ZmYzMzk0LyIsInBy
-        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljNGVjZS1mYWE0LTcwMzYt
-        YmY2Yy0xODQ0ZTlmZjMzOTQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTEx
-        VDIyOjI1OjEzLjM4MTM3OFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
-        MDItMTFUMjI6MjU6MTMuMzg1OTYzWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2UtZmFhNC03
-        MDM2LWJmNmMtMTg0NGU5ZmYzMzk0L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxLyIsInBy
+        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYy0wNGQ0LTc3NDYt
+        YmI1My1lNGI5YzNkODMyZDEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjI2LjQyMTM5NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
+        MDMtMDJUMTQ6NTU6MjYuNDI2NTU0WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03
+        NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZS1mYWE0LTcwMzYtYmY2Yy0xODQ0
-        ZTlmZjMzOTQvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGViaWFuXzEwIiwiZGVz
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiRGViaWFuXzEwIiwiZGVz
         Y3JpcHRpb24iOm51bGwsInJldGFpbl9yZXBvX3ZlcnNpb25zIjpudWxsLCJy
         ZW1vdGUiOm51bGwsInB1Ymxpc2hfdXBzdHJlYW1fcmVsZWFzZV9maWVsZHMi
         OnRydWUsInNpZ25pbmdfc2VydmljZSI6bnVsbCwic2lnbmluZ19zZXJ2aWNl
         X3JlbGVhc2Vfb3ZlcnJpZGVzIjp7fX0=
-  recorded_at: Wed, 11 Feb 2026 22:25:13 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/release_components/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNlLWZhYTQtNzAzNi1iZjZjLTE4NDRlOWZmMzM5NC8iLCJj
+        YXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS8iLCJj
         b21wb25lbnQiOiJlbXB0eSIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8ifQ==
     headers:
       Content-Type:
@@ -586,7 +586,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:13 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -606,20 +606,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ba6cd796a59a489fa71bdbcb636c3e6c
+      - 7f9f6e22b4fa4136b2251332f1cca557
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWZiMWQtNzY0
-        Yy1iOWI3LTVhZDNiYTQ3NGFhNS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:13 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTA1MjMtNzM5
+        OC1hMTliLTBlNzIyYzkzNjlhYy8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ece-fb1d-764c-b9b7-5ad3ba474aa5/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-0523-7398-a19b-0e722c9369ac/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -627,7 +627,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -640,7 +640,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:13 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -660,41 +660,41 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 274e13686491489ba9d7c4fcc3e8fa70
+      - 55cbb0136db94f57899d567021fd9b17
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2UtZmIx
-        ZC03NjRjLWI5YjctNWFkM2JhNDc0YWE1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2UtZmIxZC03NjRjLWI5YjctNWFkM2JhNDc0YWE1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxMy41MDQzOThaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjEzLjUwMjMyN1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMDUy
+        My03Mzk4LWExOWItMGU3MjJjOTM2OWFjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMDUyMy03Mzk4LWExOWItMGU3MjJjOTM2OWFjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNi41MDEzNjhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI2LjQ5OTY3Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYmE2Y2Q3
-        OTZhNTlhNDg5ZmE3MWJkYmNiNjM2YzNlNmMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMi0x
-        MVQyMjoyNToxMy41MjMwNDBaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjU6MTMuNTYxMzk1WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyNToxMy44Mjc1MjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhYjQtNzliYy05NDRiLWMzZGJm
-        MzA5OGI4Zi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiN2Y5ZjZl
+        MjJiNGZhNDEzNmIyMjUxMzMyZjFjY2E1NTciLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NToyNi41MTUxNzdaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjYuNTUyMjgzWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NToyNi43NDA0NjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYjQtNzQwOS1iODI0LWI0NzZl
+        Y2I2N2ZlMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
-        ZWIvYXB0LzAxOWM0ZWNlLWZhYTQtNzAzNi1iZjZjLTE4NDRlOWZmMzM5NC92
+        ZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92
         ZXJzaW9ucy8xLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9yZWxlYXNl
-        X2NvbXBvbmVudHMvMDE5YzRlY2QtOTc1YS03ZjkzLTgzYzItN2U4ZjZiYTky
-        NTEyLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
-        YXB0cmVwb3NpdG9yeTowMTljNGVjZS1mYWE0LTcwMzYtYmY2Yy0xODQ0ZTlm
-        ZjMzOTQiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYxMWMzLTIwNmMt
-        NDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:13 GMT
+        X2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNjODZjMWNk
+        OTUzLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
+        YXB0cmVwb3NpdG9yeTowMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNk
+        ODMyZDEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4YmE4LTdiMWEt
+        NDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ece-faa4-7036-bf6c-1844e9ff3394/versions/1/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/1/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -715,7 +715,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:13 GMT
+      - Mon, 02 Mar 2026 14:55:26 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -735,20 +735,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9b068cd6bfed469b83ca41670f3f99ed
+      - 81064b74d2034b5faf34855eab38bae5
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZS1m
-        YmY5LTcyNWQtODM4Yi03YjliYzE4MTRjMGQifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:13 GMT
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYy0w
+        NWQxLTc1NTYtYmVmZC0zNjAxYjkxMTAzNGYifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:26 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/019c4ecf-13b4-7162-ba0e-04b5c9288c26/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/019caf0c-1755-72c6-b9f7-3f79e9537c77/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -769,7 +769,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:21 GMT
+      - Mon, 02 Mar 2026 14:55:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -789,20 +789,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a44f8b4a3f1e41eab8d9573192486b05
+      - 902e1d0ce2b449c28f58fa9d6bc05a46
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNmLTE5NTEtN2Fk
-        ZC1iZmQ3LTllYTRmNDZmYzUzYS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTFjODYtNzUz
+        ZS1iOWQyLTMwZDcxNWNhYTUzMC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:32 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/019c4ecf-0cce-7fb9-94a1-ef670a0e68ef/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0c-1302-7273-8fee-1d57e648d6f7/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -823,7 +823,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:21 GMT
+      - Mon, 02 Mar 2026 14:55:32 GMT
       Server:
       - gunicorn
       Vary:
@@ -839,18 +839,18 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5549e8fb30b844018cb6c3ee2b58cbf6
+      - 16386c375b4e4acb98735b3491d4f296
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: ''
-  recorded_at: Wed, 11 Feb 2026 22:25:21 GMT
+  recorded_at: Mon, 02 Mar 2026 14:55:32 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/019c4ece-f9cf-7ff9-ad10-10c067c4a531/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/019caf0c-046a-742d-82fa-073a70175f82/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -871,7 +871,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:21 GMT
+      - Mon, 02 Mar 2026 14:55:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -891,20 +891,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5afe4047bd1740c4a671eefe059a3582
+      - dc1b60462c5f42ffa5adb6176d6a2b25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNmLTFiMGUtNzNh
-        MC05NzBjLWE4MGM5YzkzZTljOS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTFkODgtNzNl
+        MC1iZTcxLTNlOTQxZjU5OGY3Ny8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:32 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecf-1b0e-73a0-970c-a80c9c93e9c9/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-1d88-73e0-be71-3e941f598f77/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -912,7 +912,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -925,7 +925,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:21 GMT
+      - Mon, 02 Mar 2026 14:55:32 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -945,37 +945,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a5729ce193af4998bdd870dbcd5e9626
+      - bc2853429a4f4415954411dc171ed504
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2YtMWIw
-        ZS03M2EwLTk3MGMtYTgwYzljOTNlOWM5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2YtMWIwZS03M2EwLTk3MGMtYTgwYzljOTNlOWM5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToyMS42ODA5MTNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjIxLjY3OTA3Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMWQ4
+        OC03M2UwLWJlNzEtM2U5NDFmNTk4Zjc3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMWQ4OC03M2UwLWJlNzEtM2U5NDFmNTk4Zjc3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NTozMi43NDcwNzFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjMyLjc0NDgwNloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjVhZmU0
-        MDQ3YmQxNzQwYzRhNjcxZWVmZTA1OWEzNTgyIiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjU6MjEuNzAwMTgwWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjI1OjIxLjczNjA0NFoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjU6MjEuNzc2OTgyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYWFiLTdlZDItYTA0Yi1lNjJl
-        YjE0ZDAyZGQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImRjMWI2
+        MDQ2MmM1ZjQyZmZhNWFkYjYxNzZkNmEyYjI1IiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTU6MzIuNzYwNzgzWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjMyLjgyMTk4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MzIuODY4MDI3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMGJmLTc0ZTAtYTdkYi1iZmU2
+        NzAyMzhlYTkvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljNGVjZS1mOWNmLTdmZjktYWQx
-        MC0xMGMwNjdjNGE1MzEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYx
-        MWMzLTIwNmMtNDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:21 GMT
+        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljYWYwYy0wNDZhLTc0MmQtODJm
+        YS0wNzNhNzAxNzVmODIiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4
+        YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:32 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ece-faa4-7036-bf6c-1844e9ff3394/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -996,7 +996,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:21 GMT
+      - Mon, 02 Mar 2026 14:55:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1016,20 +1016,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b919f9cfa434869b5e50a0e4dd6b4e0
+      - 84f9daa804944bccb2f9156426ce7091
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNmLTFjMzMtNzNi
-        NS05NzRhLTQzMTIwMDQwOGUxNy8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:21 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTFlOWUtN2I0
+        OC1hYWIxLWU2NDgyMGEzOTI1MC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:33 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecf-1c33-73b5-974a-431200408e17/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-1e9e-7b48-aab1-e64820a39250/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1037,7 +1037,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1050,7 +1050,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:25:22 GMT
+      - Mon, 02 Mar 2026 14:55:33 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1070,32 +1070,32 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b44f258d7cf4d3998b63303629e6a19
+      - 8bf1e29bcc1c441393155a3c3db357cc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2YtMWMz
-        My03M2I1LTk3NGEtNDMxMjAwNDA4ZTE3LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2YtMWMzMy03M2I1LTk3NGEtNDMxMjAwNDA4ZTE3IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToyMS45NzQxNTNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjIxLjk3MjI5OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMWU5
+        ZS03YjQ4LWFhYjEtZTY0ODIwYTM5MjUwLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMWU5ZS03YjQ4LWFhYjEtZTY0ODIwYTM5MjUwIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NTozMy4wMjU1NjdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjMzLjAyMzE1Nloi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjNiOTE5
-        ZjljZmE0MzQ4NjliNWU1MGEwZTRkZDZiNGUwIiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjU6MjEuOTkyMjI3WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjI1OjIyLjAyNzk5MVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjU6MjIuMDg5NDIyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYTNmLTc5MTItOWM0NS1lMWIy
-        ZGE5OWRiMTAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6Ijg0Zjlk
+        YWE4MDQ5NDRiY2NiMmY5MTU2NDI2Y2U3MDkxIiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTU6MzMuMDQ1NTAzWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjMzLjA3NzA2MloiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MzMuMTQ4NzUyWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMjhjLTc1M2MtOTdmZi01ZTk1
+        MDUxZDZjNGIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5YzRlY2UtZmFhNC03MDM2
-        LWJmNmMtMTg0NGU5ZmYzMzk0Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjow
-        ZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAiXX0=
-  recorded_at: Wed, 11 Feb 2026 22:25:22 GMT
-recorded_with: VCR 6.4.0
+        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGMtMDRkNC03NzQ2
+        LWJiNTMtZTRiOWMzZDgzMmQxIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5
+        OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:33 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/upload_binary.yml
+++ b/test/fixtures/vcr_cassettes/actions/pulp3/deb_upload/upload_binary.yml
@@ -35691,68 +35691,6 @@ http_interactions:
         InBsYWluX2NvbXBvbmVudCI6ImVtcHR5In1dfQ==
   recorded_at: Wed, 11 Feb 2026 20:27:10 GMT
 - request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoyMTIwfQ==
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/019c4ece-fe94-727a-958f-3cacc045a0d2/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '242'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 466d6451779549969690c1a187a95951
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljNGVjZS1m
-        ZTk0LTcyN2EtOTU4Zi0zY2FjYzA0NWEwZDIvIiwicHJuIjoicHJuOmNvcmUu
-        dXBsb2FkOjAxOWM0ZWNlLWZlOTQtNzI3YS05NThmLTNjYWNjMDQ1YTBkMiIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MTQuMzg4ODE0WiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxNC4zODg4
-        MjNaIiwic2l6ZSI6MjEyMH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:14 GMT
-- request:
     method: put
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/019c4ece-fe94-727a-958f-3cacc045a0d2/
     body:
@@ -35870,77 +35808,6 @@ http_interactions:
         MjNaIiwic2l6ZSI6MjEyMH0=
   recorded_at: Wed, 11 Feb 2026 22:25:14 GMT
 - request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '835'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - dbeae8ae4087464282d024e90a85a25d
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVhMjNlYjg1LyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOWM0ZWNlLWVhNzUtNzQxZC1hOWU1LTU4NzVl
-        YTIzZWI4NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDku
-        MjM4NjY4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        NTowOS4yMzg2NzhaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
-        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
-        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
-        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
-        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
-        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
-        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
-        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
-        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
-        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
-        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
-        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
-        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:14 GMT
-- request:
     method: delete
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/019c4ece-fe94-727a-958f-3cacc045a0d2/
     body:
@@ -35987,149 +35854,6 @@ http_interactions:
     body:
       encoding: UTF-8
       base64_string: ''
-  recorded_at: Wed, 11 Feb 2026 22:25:14 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '835'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - ccaf8d9544bb485680834da692e15a54
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVhMjNlYjg1LyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOWM0ZWNlLWVhNzUtNzQxZC1hOWU1LTU4NzVl
-        YTIzZWI4NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MDku
-        MjM4NjY4WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        NTowOS4yMzg2NzhaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
-        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
-        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
-        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
-        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
-        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
-        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
-        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
-        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
-        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
-        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
-        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
-        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:14 GMT
-- request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWE3ZWMzNDg5N2MyYmMz
-        YjhjNzQ5NWMwODEyOGUyMzg3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZS1mYWE0LTcwMzYtYmY2Yy0xODQ0
-        ZTlmZjMzOTQvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtYTdl
-        YzM0ODk3YzJiYzNiOGM3NDk1YzA4MTI4ZTIzODcNCkNvbnRlbnQtRGlzcG9z
-        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
-        aS92My9hcnRpZmFjdHMvMDE5YzRlY2UtZWE3NS03NDFkLWE5ZTUtNTg3NWVh
-        MjNlYjg1Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWE3ZWMz
-        NDg5N2MyYmMzYjhjNzQ5NWMwODEyOGUyMzg3DQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
-        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWE3ZWMzNDg5N2My
-        YmMzYjhjNzQ5NWMwODEyOGUyMzg3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
-        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
-        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtYTdlYzM0ODk3YzJiYzNiOGM3NDk1
-        YzA4MTI4ZTIzODctLQ0K
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-a7ec34897c2bc3b8c7495c08128e2387
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '690'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:14 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1316704c01ce4e05946cc680bd4fcdf2
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNlLWZmYmUtNzJj
-        YS1iYjA1LTVhMzM4MTliNTRmZi8ifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:14 GMT
 - request:
     method: get
@@ -36261,68 +35985,6 @@ http_interactions:
         MDk4LTdhZjMtYWQ5Yy0xZWM3YWM5MWUyMDMifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:15 GMT
 - request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/
-    body:
-      encoding: UTF-8
-      base64_string: 'eyJzaXplIjoyMjIwfQ==
-
-        '
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 201
-      message: Created
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Location:
-      - "/pulp/api/v3/uploads/019c4ecf-03fe-7058-899b-5dfc7b813dc9/"
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '242'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6b08164f4ef542cd8ac3b2f1d2787ac5
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljNGVjZi0w
-        M2ZlLTcwNTgtODk5Yi01ZGZjN2I4MTNkYzkvIiwicHJuIjoicHJuOmNvcmUu
-        dXBsb2FkOjAxOWM0ZWNmLTAzZmUtNzA1OC04OTliLTVkZmM3YjgxM2RjOSIs
-        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MTUuNzc0OTQ0WiIs
-        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxNS43NzQ5
-        NTZaIiwic2l6ZSI6MjIyMH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:15 GMT
-- request:
     method: put
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/uploads/019c4ecf-03fe-7058-899b-5dfc7b813dc9/
     body:
@@ -36440,60 +36102,6 @@ http_interactions:
         InB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MTUuNzc0OTQ0WiIs
         InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyNToxNS43NzQ5
         NTZaIiwic2l6ZSI6MjIyMH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:15 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=7e64996f3bc4cc3f5ff8177ab656e915ed8f5243527c19e38dc016113ee34d22
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:15 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 74f55d15de084ad190eaa320ed90d045
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
   recorded_at: Wed, 11 Feb 2026 22:25:15 GMT
 - request:
     method: post
@@ -36622,149 +36230,6 @@ http_interactions:
         cmNlc19yZWNvcmQiOlsicHJuOmNvcmUudXBsb2FkOjAxOWM0ZWNmLTAzZmUt
         NzA1OC04OTliLTVkZmM3YjgxM2RjOSIsInNoYXJlZDpwcm46Y29yZS5kb21h
         aW46MGQyNjExYzMtMjA2Yy00MDE2LWJiNTctYzRiMDU5ZTFkYzQwIl19
-  recorded_at: Wed, 11 Feb 2026 22:25:16 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/artifacts/?sha256=7e64996f3bc4cc3f5ff8177ab656e915ed8f5243527c19e38dc016113ee34d22
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:16 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '835'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 10f9621144de436aaa2bcef7df89b93c
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
-        YzRlY2YtMDUxYy03NDZhLTkxY2MtOWNjZGM1MmU1MTEyLyIsInBybiI6InBy
-        bjpjb3JlLmFydGlmYWN0OjAxOWM0ZWNmLTA1MWMtNzQ2YS05MWNjLTljY2Rj
-        NTJlNTExMiIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjU6MTYu
-        MDYxODIzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        NToxNi4wNjE4MzZaIiwiZmlsZSI6ImFydGlmYWN0LzdlLzY0OTk2ZjNiYzRj
-        YzNmNWZmODE3N2FiNjU2ZTkxNWVkOGY1MjQzNTI3YzE5ZTM4ZGMwMTYxMTNl
-        ZTM0ZDIyIiwic2l6ZSI6MjIyMCwibWQ1IjpudWxsLCJzaGExIjoiNzFlNTdk
-        MzliYTZjZjhiMzdlZTdhNzgwZmY5N2U2YTZmMmY4NWM5NSIsInNoYTIyNCI6
-        IjIxNzM1YTU2MWJiOWJkODkzMzQ0MzA4Y2M4Yjk2NjAyYjI3ZWU1YmQ5YWU5
-        NGNhMGU3ODc5ZDUzIiwic2hhMjU2IjoiN2U2NDk5NmYzYmM0Y2MzZjVmZjgx
-        NzdhYjY1NmU5MTVlZDhmNTI0MzUyN2MxOWUzOGRjMDE2MTEzZWUzNGQyMiIs
-        InNoYTM4NCI6IjIyYmU1OTIzMTgyZGJlNDUxMjNlYTA3YWVjYjU4OWNhYmZj
-        MGM3ZmYxMThhNjQwYTBiNjUyOWI5YzUwZTc3ODZhNTZkYjBkNzNiYmM4ODZh
-        OTQ2YTM5NzY3MmNmYzYzZCIsInNoYTUxMiI6IjIyMjU5YWRkZGFhNGI5MzY2
-        M2U3ZTdjMWFhNTQwNjExOTE0YTlmYTVlMDAyY2Y4ZjEzYTQzNmM3N2I2OWNi
-        YWVkZjE0NDkwMTE3ODFhNWRiMWIxYzJhMTI0Mjg2ZmYxMTFmZDAzY2QxZmQx
-        OTAzZGE4OTAzZGQ4YjlmMDBkN2YxIn1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:16 GMT
-- request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/packages/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA0MDc4YjM5NWU1ODNm
-        MGU0NGFjNGFhYTQ0NWM0ZGJiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
-        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZS1mYWE0LTcwMzYtYmY2Yy0xODQ0
-        ZTlmZjMzOTQvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtMDQw
-        NzhiMzk1ZTU4M2YwZTQ0YWM0YWFhNDQ1YzRkYmINCkNvbnRlbnQtRGlzcG9z
-        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
-        aS92My9hcnRpZmFjdHMvMDE5YzRlY2YtMDUxYy03NDZhLTkxY2MtOWNjZGM1
-        MmU1MTEyLw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA0MDc4
-        YjM5NWU1ODNmMGU0NGFjNGFhYTQ0NWM0ZGJiDQpDb250ZW50LURpc3Bvc2l0
-        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
-        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTA0MDc4YjM5NWU1
-        ODNmMGU0NGFjNGFhYTQ0NWM0ZGJiDQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
-        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
-        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtMDQwNzhiMzk1ZTU4M2YwZTQ0YWM0
-        YWFhNDQ1YzRkYmItLQ0K
-    headers:
-      Content-Type:
-      - multipart/form-data; boundary=-----------RubyMultipartPost-04078b395e583f0e44ac4aaa445c4dbb
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Content-Length:
-      - '690'
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:16 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - c488ecc48ed24c19afdaf6f78a852bcf
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNmLTA2MDQtNzhi
-        My1iMTlkLTBhMjk4ODUxNmM0OS8ifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:16 GMT
 - request:
     method: get
@@ -37239,60 +36704,6 @@ http_interactions:
   recorded_at: Wed, 11 Feb 2026 22:25:17 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/signing-services/?name=katello_deb_sign
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - d2e61ed0ca6643f09b35adaaeee60d8b
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:17 GMT
-- request:
-    method: get
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ece-faa4-7036-bf6c-1844e9ff3394/versions/3/
     body:
       encoding: US-ASCII
@@ -37381,64 +36792,6 @@ http_interactions:
         L2FwaS92My92dWxuX3JlcG9ydC8/cmVwb192ZXJzaW9ucz1wcm46Y29yZS5y
         ZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZi0wNzJhLTc4NzctYWNmNy03YTU2
         MDJiOWFmZDIifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:17 GMT
-- request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2RlYi9hcHQvMDE5YzRlY2UtZmFhNC03MDM2LWJmNmMtMTg0NGU5ZmYz
-        Mzk0L3ZlcnNpb25zLzMvIiwic2ltcGxlIjpmYWxzZSwic3RydWN0dXJlZCI6
-        dHJ1ZX0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:17 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 85ba3ec274af45238d770fc0bb42d723
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNmLTBjODYtNzQx
-        ZC04NTdlLWFlYmUyY2JjYzZiOS8ifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:17 GMT
 - request:
     method: get
@@ -37654,191 +37007,6 @@ http_interactions:
       base64_string: |
         eyJwcm4iOiJwcm46ZGViLmFwdHB1YmxpY2F0aW9uOjAxOWM0ZWNmLTBjY2Ut
         N2ZiOS05NGExLWVmNjcwYTBlNjhlZiJ9
-  recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '5960'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 94353071a54e4f4fb4ba8c2649894b11
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI0OjM4LjI2NTEzMloiLCJu
-        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
-        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
-        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
-        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
-        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
-        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
-        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
-        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
-        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
-        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
-        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
-        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
-        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
-        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
-        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
-        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
-        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
-        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
-        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
-        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
-        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
-        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
-        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
-        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
-        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
-        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
-        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
-        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
-        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
-        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
-        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
-        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
-        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
-        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
-        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
-        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
-        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
-        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
-        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
-        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
-        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
-        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
-        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
-        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
-        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
-        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
-        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
-        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
-        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
-        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
-        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
-        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
-        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
-        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
-        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
-        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
-        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
-        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
-        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
-        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
-        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
-        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
-        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
-        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
-        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
-        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
-        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
-        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
-        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
-        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
-        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
-        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
-        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
-        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
-        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
-        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
-        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
-        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
-        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
-        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
-        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
-        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
-        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
-        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
-        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
-        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
-        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
-        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
-        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
-        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
-        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
-        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
-        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
-        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
-        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
-        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
-        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
-        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
-        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
-        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
-        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
-        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
-        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
-        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
-        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
-        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
-        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
-        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
-        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
-        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
-        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
-        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
-        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
-        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
-        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
-        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
   recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
 - request:
     method: patch
@@ -38148,191 +37316,6 @@ http_interactions:
         OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
         amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
         RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '5960'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - f169688cb78349258e16c0555b487e45
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjI1OjE5LjE4Njc4MFoiLCJu
-        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
-        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
-        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
-        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
-        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
-        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
-        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
-        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
-        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
-        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
-        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
-        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
-        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
-        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
-        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
-        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
-        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
-        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
-        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
-        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
-        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
-        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
-        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
-        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
-        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
-        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
-        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
-        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
-        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
-        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
-        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
-        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
-        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
-        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
-        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
-        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
-        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
-        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
-        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
-        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
-        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
-        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
-        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
-        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
-        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
-        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
-        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
-        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
-        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
-        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
-        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
-        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
-        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
-        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
-        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
-        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
-        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
-        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
-        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
-        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
-        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
-        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
-        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
-        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
-        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
-        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
-        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
-        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
-        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
-        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
-        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
-        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
-        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
-        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
-        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
-        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
-        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
-        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
-        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
-        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
-        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
-        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
-        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
-        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
-        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
-        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
-        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
-        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
-        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
-        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
-        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
-        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
-        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
-        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
-        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
-        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
-        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
-        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
-        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
-        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
-        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
-        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
-        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
-        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
-        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
-        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
-        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
-        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
-        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
-        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
-        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
-        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
-        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
-        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
-        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
-        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
   recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
 - request:
     method: patch
@@ -38645,60 +37628,6 @@ http_interactions:
   recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_10_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '52'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1221466bb10047f681e001dcce0a8da7
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
-- request:
-    method: get
     uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/019c4ecf-0cce-7fb9-94a1-ef670a0e68ef/
     body:
       encoding: US-ASCII
@@ -38760,66 +37689,6 @@ http_interactions:
         MTljNGVjZS1mYWE0LTcwMzYtYmY2Yy0xODQ0ZTlmZjMzOTQvIiwic2ltcGxl
         IjpmYWxzZSwic3RydWN0dXJlZCI6dHJ1ZSwiY2hlY2twb2ludCI6ZmFsc2Us
         InNpZ25pbmdfc2VydmljZSI6bnVsbH0=
-  recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
-- request:
-    method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZGViaWFu
-        XzEwX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1h
-        MGY3LThjYWZmNWMyZGQzZi8iLCJuYW1lIjoiRGViaWFuXzEwIiwicHVibGlj
-        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2RlYi9hcHQvMDE5
-        YzRlY2YtMGNjZS03ZmI5LTk0YTEtZWY2NzBhMGU2OGVmLyJ9
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 202
-      message: Accepted
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:25:19 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '67'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 6cb06af87d9f4648b147d966df9e785a
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNmLTEyYjEtNzQ5
-        Yi04MDEyLTE4MThmYzQ1OTc1MS8ifQ==
   recorded_at: Wed, 11 Feb 2026 22:25:19 GMT
 - request:
     method: get
@@ -39608,4 +38477,4065 @@ http_interactions:
         ImNvbXBvbmVudCI6ImVtcHR5IiwiZGlzdHJpYnV0aW9uIjoia2F0ZWxsbyIs
         InBsYWluX2NvbXBvbmVudCI6ImVtcHR5In1dfQ==
   recorded_at: Wed, 11 Feb 2026 22:25:20 GMT
-recorded_with: VCR 6.4.0
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?component=empty&distribution=katello&repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '421'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a91409432cb14cbeaaf2ec3701c480c5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNj
+        ODZjMWNkOTUzLyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi01YTA1LTc2Y2ItOTc2Yi1lM2M4NmMxY2Q5NTMiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQyLjY5NTI5M1oiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDIuNjk1MzA1WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        ImVtcHR5IiwiZGlzdHJpYnV0aW9uIjoia2F0ZWxsbyIsInBsYWluX2NvbXBv
+        bmVudCI6ImVtcHR5In1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLzAxOWNhZjBiLTVhMDUtNzZjYi05
+        NzZiLWUzYzg2YzFjZDk1My8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ba04a2bab41c4aa2ac871503ee75e847
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTA3OGUtNzU5
+        Yy1hNjllLTVjYzIxYTAzNGU2Ny8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-078e-759c-a69e-5cc21a034e67/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '937'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 44c501e76d7541168a4925ca64509078
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMDc4
+        ZS03NTljLWE2OWUtNWNjMjFhMDM0ZTY3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMDc4ZS03NTljLWE2OWUtNWNjMjFhMDM0ZTY3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNy4xMjA1NjVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI3LjExODkzMloi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        YmEwNGEyYmFiNDFjNGFhMmFjODcxNTAzZWU3NWU4NDciLCJjcmVhdGVkX2J5
+        IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
+        Ni0wMy0wMlQxNDo1NToyNy4xMzAzNzVaIiwic3RhcnRlZF9hdCI6IjIwMjYt
+        MDMtMDJUMTQ6NTU6MjcuMTY0MzAzWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
+        My0wMlQxNDo1NToyNy4yNTk1NDdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYmYtNzRlMC1hN2Ri
+        LWJmZTY3MDIzOGVhOS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
+        XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4
+        MzJkMS92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbInBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYy0wNGQ0LTc3NDYt
+        YmI1My1lNGI5YzNkODMyZDEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5
+        OTg4YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoyMTIwfQ==
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/019caf0c-08ac-749d-b4d8-bb2fd61ea592/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9633874d7a2340a9bc623380a6323e76
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYy0w
+        OGFjLTc0OWQtYjRkOC1iYjJmZDYxZWE1OTIvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBjLTA4YWMtNzQ5ZC1iNGQ4LWJiMmZkNjFlYTU5MiIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjcuNDA0NTIyWiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNy40MDQ1
+        NTRaIiwic2l6ZSI6MjEyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0c-08ac-749d-b4d8-bb2fd61ea592/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LWE4MDY0N2E3N2NhOWRj
+        MGIxZTU3NjkyODQ5Zjc2YTUyDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNjAz
+        MDItMTE0MDAtZXA4YW5hIg0KQ29udGVudC1MZW5ndGg6IDIxMjANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24veC1kZWJpYW4tcGFja2FnZQ0KQ29udGVu
+        dC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCiE8YXJjaD4KZGViaWFu
+        LWJpbmFyeSAgIDE3MDAxNTY2NDggIDAgICAgIDAgICAgIDEwMDY0NCAgNCAg
+        ICAgICAgIGAKMi4wCmNvbnRyb2wudGFyLnh6ICAxNzAwMTU2NjQ4ICAwICAg
+        ICAwICAgICAxMDA2NDQgIDUzMiAgICAgICBgCv03elhaAAAE5ta0RgTA1AOA
+        UCEBFgAAAAAAAAB7vaGp4Cf/AcxdABcLvBx9AZXAHUo+eRXCzCajXhkmHeIX
+        O6fbeQG9bAANmdiTpnkVq/IrMBqgo9/hV77SAMRbyx6vZJ8fCjqkil5VAAR3
+        J8RkW3OejWLGKN7oTSiPs6jMAhxJAkgbJ2r0SYPjLt9wkOp864rfL8mAi4Lw
+        8YUpyMPUrh+UpF0nJQrIJVD9yvTL36CDI4tXWr4i7bL5VA8H80qADzFeKFmT
+        1r8THN7lwH3pZrsdtrVA/7sU3Q8Hr+4FQh2+r9H4qm8QY0YDD7vVM+cBKNCt
+        j04+Jt+MBktzWaHEznEkQQyLizN5CDtjKKMqttfHCKk3DjQloyEtS74ZWdWx
+        LLlJu+un0GaahYuheKdbps5qeMPVHi9wsefHXpIJsyPW0CFU2wQrtXdjrGdK
+        1lx+HdA3s+BAwWEIU8xS4fmbxAIHGWjEkFEVM8mqyuNZxhNkgTG42cmTwnJr
+        HW3PoesvFpaCsWQdF+8nuVd6wxBcJ6u6LzDaEPdD7POpoU6HklbJemIxujWM
+        j/US7U9igW3Ye9ybHld2cATcUN2/pkpmcdjFiW7p9VTtb3GKbF7xUxWw8gxs
+        3gBVqXqIlOiTrmwkViGIOPeNXovzJUVb0oEEdYmaIAAAScx2BL0XgD4AAfAD
+        gFAAAJ8vghCxxGf7AgAAAAAEWVpkYXRhLnRhci54eiAgICAgMTcwMDE1NjY0
+        OCAgMCAgICAgMCAgICAgMTAwNjQ0ICAxMzk2ICAgICAgYAr9N3pYWgAABObW
+        tEYEwLIKgFAhARYAAAAAAAAADHMrWuAn/wUqXQAXC7wcfQGVwB1KPnkVwswm
+        o14ZJh3iFzun23kBvWwADZnYk6Z5FavyKzAaoKPf4Ve+0gDEW8ser2WpRmq/
+        lgJr86jpA4JJoXsT/GyBvNifAwtq1FwZXqvBkvJgKnJh1LMUG8Jn4pOUsxn3
+        1k78N+8jwc/HACSKQvrGSQWLBhFLBDcfjcXKEIi6QQsxp5lNfoQg8PwBm1nH
+        BBVmBcLmP9qFgNX7JyRODJbpBk4rMU3GwePu1mgHfNwQ6XcLf54wmXVet+z6
+        dK13NI5IWcJFCp5w5QEZvucsSP0pJI1C4AsutB1AVQz1MFQC0yPEoVOMlxKG
+        Iy92DN6fDhBnWOK50seZvYQ/X1sklWG7lILIJlIKPvxI6vEp3punBDSmD77X
+        FRhR4xKJvdXEwE86IzUXMS4DrwoHOuUJ2jpWD7bO+6zRB3yuBIQuF73QDDW/
+        Is68PNn5ZA23plMU1iw3gXwV+gn+vmxEPk1gd72jfIkI5VrGx+iCStWiwxYa
+        Mb+PcLg1LVyIi1XtmgoxMIfnCQRzT3Z/m0GPJXFoVeEX76Bem32ApnZvHORJ
+        heNHOqRHR0mWdqnbY1Qep/WdetmKDPmzuuBj6sjxmyaIXmWBNzt+hHs1l5dH
+        gLMNFN17GX7EKVRtLqjq3KMHNWjlkBPccNWDjVZ+nHJK10vJSBT9OSpJKZ5w
+        wx8SAmmxW0y0JYP+lpW8rYjiuwWW5sDmMFJozmsB0+8cdEC1T+dOAJgCiVLJ
+        7RK95KExMJWPQ5exXLsaTtWD8pfacg/s40QZBlMiWHR5fYKwfnWAihizzPCg
+        /+WwjvbV+bhrEqefVtnkvDcQTnb/6UcfNbfzE7MihkBeH2kP+Esh5vKGyBds
+        N0QTBO3Ul2mPy+7aPmYFOP5bA8G7htZVUHs+h7XgkSmMyPf4P51BHcon45cP
+        pmqL+swHPpO0vKBEC3OxzRC3b36zXK1iYfTHbN5/Es8QD/lQGXn8Uq7VEndk
+        OyHuVYQLuJasEiEerMrTy0JyZlSPgUkZRCSucMo8cTZBN7l4HkkvvI0ODmvC
+        JqKPG77ZsZXD/COIH6AW25PZKi81Rl/XD2K1mBwaghByNTzGfjlMtDyTWxKf
+        54emyKGvrA3omrpfOnsUwg2Ny43KmM0qphwyoZSUTFwRz+q/TlSkQp+NtcOV
+        HQv0NK39ta/caU6ADA8Ry2/qMQ4gRgSvFvqYrIthXgqfVL+QN0lNxZnUBj/z
+        G5bUNvb3sJbvV6jHokpUB62OY32EmrtdA9gW07UKpwUA06nChx+Z3gnWjnNM
+        SrZAvph3y4TZz33hODZcJy7vGVxyB3Dow69Dw1tYNO9LDoXAcpT/Yl0XUfgF
+        HsseZPrmkoAzSuoboYorSL/LcQjCjCClAaWK7NhwFHLuw1ZO9oZpB3VzmzWR
+        JCZgCOopA+EKhipQKHbmFLtyOiA2CbJTA/HubJTiFzHmw/fvoiBuN61HuTQP
+        fa8RQNzNzAjXJLAy1372Td1bKeTgIGXT0LSMsBa5z9Kp82YZtHLu5KnMNmqT
+        hIBNz5eiYO5cPtimd79JFneK6KKAAxBoWMGCUob8zRA3+htTi1Cf7PJnx2RZ
+        3rtTdApDjVAshmVaE6CBSvh79JoHWdAI1ZdLijE6m2fJ00qH+G/GPaUt6hWG
+        Ku48+TqixYNG22uFPt0J6eEic3elB+pmfR//Ot4Pt0OjvbRrpsU5YqJ6et9o
+        1COZJ3MfW1nKLKUD15iwrOryN0QpI9DFjY2ouNf3w340GBl9KJEDH7qrnYVr
+        MAAAAFBgbxPoKbtQAAHOCoBQAAAzK+IjscRn+wIAAAAABFlaDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtYTgwNjQ3YTc3Y2E5ZGMwYjFlNTc2
+        OTI4NDlmNzZhNTItLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-a80647a77ca9dc0b1e57692849f76a52
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-2119/2120
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '2445'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - d845dea41bdf49ab9f284afb6a2f1ae6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYy0w
+        OGFjLTc0OWQtYjRkOC1iYjJmZDYxZWE1OTIvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBjLTA4YWMtNzQ5ZC1iNGQ4LWJiMmZkNjFlYTU5MiIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjcuNDA0NTIyWiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNy40MDQ1
+        NTRaIiwic2l6ZSI6MjEyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '835'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f0e35e8f664a48b4959945eff4eb0253
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3OTRjZWU5LyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOWNhZjBiLWY3ODctN2Q3OC1iM2NmLWRlMDIx
+        Nzk0Y2VlOSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMu
+        MDE1OTMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NToyMy4wMTU5NDRaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
+        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
+        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
+        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
+        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
+        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
+        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
+        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
+        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
+        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
+        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
+        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
+        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: delete
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0c-08ac-749d-b4d8-bb2fd61ea592/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 600ce41b3421485a9da6defad6bcaa3c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: ''
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=dd9762dd9828a56723ea8b762ea737faa8545b3c4823cc8ea9593e101d1c94e5
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '835'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c17ad36c8d4248c7bc5568262dd1f93a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3OTRjZWU5LyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOWNhZjBiLWY3ODctN2Q3OC1iM2NmLWRlMDIx
+        Nzk0Y2VlOSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMu
+        MDE1OTMyWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NToyMy4wMTU5NDRaIiwiZmlsZSI6ImFydGlmYWN0L2RkLzk3NjJkZDk4Mjhh
+        NTY3MjNlYThiNzYyZWE3MzdmYWE4NTQ1YjNjNDgyM2NjOGVhOTU5M2UxMDFk
+        MWM5NGU1Iiwic2l6ZSI6MjEyMCwibWQ1IjpudWxsLCJzaGExIjoiODM1OGVj
+        MDc2YzJkMmVlMzhkMWE2ZDQzNzUyMWRiOGMyYmY3ODU5MyIsInNoYTIyNCI6
+        IjBjYmYyZjhhMjkwYWUwYzIwOGNlNWFhMDk1MjhkYTM1MWU4MjBlODMzYzA2
+        ODVlNzVhMTZmM2NmIiwic2hhMjU2IjoiZGQ5NzYyZGQ5ODI4YTU2NzIzZWE4
+        Yjc2MmVhNzM3ZmFhODU0NWIzYzQ4MjNjYzhlYTk1OTNlMTAxZDFjOTRlNSIs
+        InNoYTM4NCI6IjdlZTc1NTMzNjkzNjJhZDcyZmYzZTNjYTRhNzMzMzgwM2Fi
+        YmI0MDgyMGI5NzY3ZjZhZDc2ZDUyZTRjN2Y1Y2JkODEwM2U5Mjc1YjU4YTFh
+        NDkxNTU2Zjk1MmY0N2I3NiIsInNoYTUxMiI6ImEyMTU4ZGU4Y2I3YzFkYjk3
+        MjU2MzNmYWExNzU5YTQ5NzJhZGVmNjAyNjI3OWMzMGU3YzBjOWQwMDBhNTFi
+        NDBhNDRkZjAxM2UyNGVhODQ4MWRiMjYxZTY5MmFhZGUwMDM5NjBmYjlkNTgx
+        YWViMTcxNDZmNTExY2JiZDlkOWRiIn1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU0NzE0ZjU5ODRlYmNk
+        MTIzOGZiZTM4MTg3MzJkMzc4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNTQ3
+        MTRmNTk4NGViY2QxMjM4ZmJlMzgxODczMmQzNzgNCkNvbnRlbnQtRGlzcG9z
+        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDE5Y2FmMGItZjc4Ny03ZDc4LWIzY2YtZGUwMjE3
+        OTRjZWU5Lw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU0NzE0
+        ZjU5ODRlYmNkMTIzOGZiZTM4MTg3MzJkMzc4DQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
+        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTU0NzE0ZjU5ODRl
+        YmNkMTIzOGZiZTM4MTg3MzJkMzc4DQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
+        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtNTQ3MTRmNTk4NGViY2QxMjM4ZmJl
+        MzgxODczMmQzNzgtLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-54714f5984ebcd1238fbe3818732d378
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '690'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:27 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 62e6b9132b3d444a91d8d6aea46e1935
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTA5OTctNzY3
+        Ny05ZjI2LTUyYzY5MGQwNDMxYi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:27 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-0997-7677-9f26-52c690d0431b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1005'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - dcf7f22ae15a45518ba5c0ba39c66368
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMDk5
+        Ny03Njc3LTlmMjYtNTJjNjkwZDA0MzFiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMDk5Ny03Njc3LTlmMjYtNTJjNjkwZDA0MzFiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNy42NDE5MTFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI3LjYzOTY0M1oi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiNjJlNmI5
+        MTMyYjNkNDQ0YTkxZDhkNmFlYTQ2ZTE5MzUiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NToyNy42NjA1ODBaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjcuNjkyODM2WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NToyOC4wMjE1ODhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyOGMtNzUzYy05N2ZmLTVlOTUw
+        NTFkNmM0Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
+        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
+        ZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92
+        ZXJzaW9ucy8zLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdl
+        cy8wMTljYWYwYi1mOGU5LTc0NDUtYTU4OC05YWYyMmY1M2Y0ZWIvIl0sInJl
+        c2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmRlYi5hcHRyZXBvc2l0
+        b3J5OjAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMSIsInNo
+        YXJlZDpwcm46Y29yZS5kb21haW46OTk5ODhiYTgtN2IxYS00MGI5LWE2MjYt
+        YTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/3/?fields=prn
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '73'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 213fafa4c91e4e5f8fb7b0e720a4defb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYy0w
+        YWE4LTc3YzYtOTU2YS0yZjIzMjExYTU1ZjUifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/
+    body:
+      encoding: UTF-8
+      base64_string: 'eyJzaXplIjoyMjIwfQ==
+
+        '
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/uploads/019caf0c-0cbd-7069-bd90-60a150cc1ee4/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - bf4caeca5b444b9c9cb8485423d354bb
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYy0w
+        Y2JkLTcwNjktYmQ5MC02MGExNTBjYzFlZTQvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBjLTBjYmQtNzA2OS1iZDkwLTYwYTE1MGNjMWVlNCIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjguNDQ1NTY2WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOC40NDU1
+        NzZaIiwic2l6ZSI6MjIyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: put
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0c-0cbd-7069-bd90-60a150cc1ee4/
+    body:
+      encoding: ASCII-8BIT
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTRlMDE5OTE3MjU2Nzc3
+        YThjN2NhNzExZGY0NmRkZmVmDQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9ImZpbGUiOyBmaWxlbmFtZT0iZmlsZWNodW5rMjAyNjAz
+        MDItMTE0MDAtM290dWViIg0KQ29udGVudC1MZW5ndGg6IDIyMjANCkNvbnRl
+        bnQtVHlwZTogYXBwbGljYXRpb24veC1kZWJpYW4tcGFja2FnZQ0KQ29udGVu
+        dC1UcmFuc2Zlci1FbmNvZGluZzogYmluYXJ5DQoNCiE8YXJjaD4KZGViaWFu
+        LWJpbmFyeSAgIDE3MDAxNTY2NTAgIDAgICAgIDAgICAgIDEwMDY0NCAgNCAg
+        ICAgICAgIGAKMi4wCmNvbnRyb2wudGFyLnh6ICAxNzAwMTU2NjUwICAwICAg
+        ICAwICAgICAxMDA2NDQgIDYzMiAgICAgICBgCv03elhaAAAE5ta0RgTAtwSA
+        UCEBFgAAAAAAAADREW4k4Cf/Ai9dABcLvBx9AZXAHUo+eRXCzCajXhkmHeIX
+        RmK9wffmizTewWLV1JvAVZ/cpF15lmtJ+I9Yw//r52OtRFYvgT/RKbLP2aZ9
+        DbVaAOmblUBypPhCbR9za9lkS/+GX2ctJ6okAWPUfzGKAFySOtJRdkgsinPZ
+        xI/dajRfx0j1qGLNK5EZh2HxqfL9UqA6dszB3uyeG9XSSDhJvsBCuWWK6YZR
+        PjCcNDosyHaVBeDQHQHKA/vWPl0jHOkkkL3fwyaK+EOQnxfX67vrO48CgQCf
+        KJyMbomzNPkxlcm2/wHmiXelue1q2XgeitDdqMBt3rV+ITdjCWdlmLDBD2qi
+        FvlGaFGiLupuDxbTnXQHqFUJFsWLWBhKHU3vX05U/wvQEXwTPjQmiGtMO6O+
+        uTqixbcVbyJyJ4LeLRyq+0X9FpPZWuAbVHagZWBrl2cUvvjK/8j/5BkJkwYg
+        JbrzuxQqxzCLJpcZR9Vp3j+aEEdhNSNVGA84JFlwGNjMUiZdEHxPTFJAiAOZ
+        wCVlkh93Ki0MKOXjo+s8gTYkb7LAAKcEe8ojQdGvrsO9nCEbktxpi+Gc1TbH
+        EEmim/4ioqh14mN8UxkV649epeG1TvvoUqhzcXLuegDFUVlZ60mpo6y8h8MW
+        qAQG9LhJffzvXyDI2P1utMGKmIvk84A5WZ251AsJPqK4HpINecHQIl3t/1oH
+        7murjystcDTIW8ac9K7eDfqhXyXa+ledb39MufNkPlq945MiPhWm2AAAAB3t
+        3Uilq038AAHTBIBQAAAXhJojscRn+wIAAAAABFlaZGF0YS50YXIueHogICAg
+        IDE3MDAxNTY2NTAgIDAgICAgIDAgICAgIDEwMDY0NCAgMTM5NiAgICAgIGAK
+        /Td6WFoAAATm1rRGBMCyCoBQIQEWAAAAAAAAAAxzK1rgJ/8FKl0AFwu8HH0B
+        lcAdSj55FcLMJqNeGSYd4hdGYr3B9+aLNN7BYtXUm8BVn9ykXXmWa0n4j1jD
+        /+vnY61Evp/YBtI4p4lpXbLZwVqjpqaP30K60mhWxMwVVjYK9cgzDJtHdHas
+        zYCtvcT1lzCfHMA/O2kxEW60Dxs+54GGE7fQlrjn/WX9DsSsJjmQg2fWFdqg
+        lIQEZ/tvIJZA15GPKiK/90Lqh6+6rEJml6MsV1mpySCOhK7a+SiI3iEHNH/5
+        aKQTIzjvlZgAw9xpeV5DdNhv7hhRp6KW/klHJDebUClpAGf3PNZm+Vtm+ejW
+        jEX/MNA2q7ZgxBUrcFKMTfS7NdAyAA76mZLs4G7LsG4V0HOrwT09xEH7C3eL
+        +jKJ2GsBmewxhy0hBYuzOpehV5dOvMtgBmHLzcThomdUFpPaAHlWiNbQYhx0
+        jVdod+rb/aMapAAC55XsuhUeyEGojq6Ui2QMolsiiilwUxJrr1P9hNhHWSlE
+        bn/5fWEUZCmaTM30S9BO8n7LbjElDfTBEwD60wLjotDm/jRXOOf9lRY0xrNM
+        F7vtonJRANk27j+Gah3L1Qi8iVU8IEYRs0om2qFBl3wH7THkAZc3SZ0Vr9gy
+        JAj4m6FThub5oDdD5yf1sFqMblemK4ZAd3shqADPB6itEqHzfwkbMk4f+uvR
+        2gigC+hY4uFZxClplgKhqAKzLZNpxJuZK2o8PAIm3XqrnhK04gCtQMw5pBCK
+        JLdEu+bBbAzVDWXt2u/YHNRytaCfK4VZZI9Xyr0AH6/r2Z1ijXJgNrg0mvWA
+        xlEaMYDQJGn32U2v7r/X3A4K8hdEfSoHpwyr0AJGStb/XaMmv67HTJhGYNDd
+        z5GWN6rOmyyjw0jcLOLcLvWageCVIfo+bbAJOcMRXmM0B96/A2js6AFUiE3/
+        Uddk4iUM9yg5u35vKrzDLGw/CQlHL6E6v4f7widwrf6z6QEf/7D23uCvDhQa
+        nn7fHqvvxkNKpccHz0aV4ItZdqU8mapsgSSVeba3prAvllDcecvoZprCFntV
+        fY6Gna0cyFxZlmkxuRz5O7bq9RU9xelM0bZ+swy6haOtJebECK0QS8l6tlxG
+        7bmR6nCQVNLV8huo4tzJrfwJQHMdwpFm+h7zOQZXspIte+76XbvK0n+fOveH
+        IZ7y5lzqdkBjfrqep/MK5RyCCxZ3WqAyl2ji1qPbLroI898FEuJEkhgavHQb
+        4h8rjZjpxIBWenz+ZheCtr6NApyFg8PP+k6XluwHDWHa9NnNwGuhQsdhSepI
+        y8+gdUkB2iLM5St+5HIhNAvTEJ4PGq54B57DWAv0aBdDwXNNsxnncZ8hvZOD
+        5Vho7FE3PPaV7NB1pDa5kVxwc6OsE4IL8XxRZKFUPgg8ilpn04sPhQpL3/AN
+        aO6dVjvCc2ZEYm4XHLl1PZYx59NYlvj+7vRdC74SgiirSncIqa5lqsgTFIv2
+        CkxP6/ujMWfyxJyYBNQz+sWZ9F92edjYt4vYw+qf6WKlUnln7ubXiDJi94P3
+        OlC5SD9q8y8MV/szniBPdy9RVpfzr+lui3m5IzjT2CLqFjXsOp6ihhb5M2l+
+        M84VTR+T1l29+xuzFuqigHUar0wDhDJggIpHMJ9mnKsVUFCwm8ARdlJ/16MH
+        46Eif8YFqf3yXpUagc5P8SxoB9zdHJ98+JAVZ7vbsLMatVKFIWRls4VOg9Tj
+        gXjyahWRU1o5wvHAqoGfvrbJu2uibONeFrBWMfsLX/4S7D8C1l52J3NSDL6R
+        jSVXkGeY6t9iQQAAAAAqOyk51uKyqAABzgqAUAAAMyviI7HEZ/sCAAAAAARZ
+        Wg0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTRlMDE5OTE3MjU2
+        Nzc3YThjN2NhNzExZGY0NmRkZmVmLS0NCg==
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-4e019917256777a8c7ca711df46ddfef
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Content-Range:
+      - bytes 0-2219/2220
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '2545'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, PUT, DELETE
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '242'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5451811494fd4765b40d456cb980e296
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdXBsb2Fkcy8wMTljYWYwYy0w
+        Y2JkLTcwNjktYmQ5MC02MGExNTBjYzFlZTQvIiwicHJuIjoicHJuOmNvcmUu
+        dXBsb2FkOjAxOWNhZjBjLTBjYmQtNzA2OS1iZDkwLTYwYTE1MGNjMWVlNCIs
+        InB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjguNDQ1NTY2WiIs
+        InB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOC40NDU1
+        NzZaIiwic2l6ZSI6MjIyMH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=7e64996f3bc4cc3f5ff8177ab656e915ed8f5243527c19e38dc016113ee34d22
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3b75b86b533340a8bcacc0712b01ac88
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/uploads/019caf0c-0cbd-7069-bd90-60a150cc1ee4/commit/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJzaGEyNTYiOiI3ZTY0OTk2ZjNiYzRjYzNmNWZmODE3N2FiNjU2ZTkxNWVk
+        OGY1MjQzNTI3YzE5ZTM4ZGMwMTYxMTNlZTM0ZDIyIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - fc5a40da6a1d48228b3bbccf6d216263
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTBkMzItNzFj
+        MS1iMGU2LTYwZDVjY2EzNDc5NC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-0d32-71c1-b0e6-60d5cca34794/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '897'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 31bc15ab7c33484e970917d6ae50ea0e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMGQz
+        Mi03MWMxLWIwZTYtNjBkNWNjYTM0Nzk0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMGQzMi03MWMxLWIwZTYtNjBkNWNjYTM0Nzk0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOC41NjQyNDdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI4LjU2MjQzNFoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MudXBsb2FkLmNvbW1pdCIsImxvZ2dpbmdfY2lkIjoiZmM1YTQwZGE2YTFk
+        NDgyMjhiM2JiY2NmNmQyMTYyNjMiLCJjcmVhdGVkX2J5IjoiL3B1bHAvYXBp
+        L3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0wMlQxNDo1
+        NToyOC41NzgzODJaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJUMTQ6NTU6
+        MjguNjI1NTE0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQxNDo1NToy
+        OC42NzMwODZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxwL2FwaS92
+        My93b3JrZXJzLzAxOWNhZTIyLWEyOGMtNzUzYy05N2ZmLTVlOTUwNTFkNmM0
+        Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltdLCJ0YXNr
+        X2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3JlYXRlZF9y
+        ZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8wMTljYWYwYy0w
+        ZDgyLTdmNWYtOGRlMS0wMmU0MjUzZDI0NmMvIl0sInJlc2VydmVkX3Jlc291
+        cmNlc19yZWNvcmQiOlsicHJuOmNvcmUudXBsb2FkOjAxOWNhZjBjLTBjYmQt
+        NzA2OS1iZDkwLTYwYTE1MGNjMWVlNCIsInNoYXJlZDpwcm46Y29yZS5kb21h
+        aW46OTk5ODhiYTgtN2IxYS00MGI5LWE2MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/artifacts/?sha256=7e64996f3bc4cc3f5ff8177ab656e915ed8f5243527c19e38dc016113ee34d22
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '835'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9abb1dc4653b463380f19f28e75770e0
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMvMDE5
+        Y2FmMGMtMGQ4Mi03ZjVmLThkZTEtMDJlNDI1M2QyNDZjLyIsInBybiI6InBy
+        bjpjb3JlLmFydGlmYWN0OjAxOWNhZjBjLTBkODItN2Y1Zi04ZGUxLTAyZTQy
+        NTNkMjQ2YyIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6Mjgu
+        NjQzNjI2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NToyOC42NDM2NThaIiwiZmlsZSI6ImFydGlmYWN0LzdlLzY0OTk2ZjNiYzRj
+        YzNmNWZmODE3N2FiNjU2ZTkxNWVkOGY1MjQzNTI3YzE5ZTM4ZGMwMTYxMTNl
+        ZTM0ZDIyIiwic2l6ZSI6MjIyMCwibWQ1IjpudWxsLCJzaGExIjoiNzFlNTdk
+        MzliYTZjZjhiMzdlZTdhNzgwZmY5N2U2YTZmMmY4NWM5NSIsInNoYTIyNCI6
+        IjIxNzM1YTU2MWJiOWJkODkzMzQ0MzA4Y2M4Yjk2NjAyYjI3ZWU1YmQ5YWU5
+        NGNhMGU3ODc5ZDUzIiwic2hhMjU2IjoiN2U2NDk5NmYzYmM0Y2MzZjVmZjgx
+        NzdhYjY1NmU5MTVlZDhmNTI0MzUyN2MxOWUzOGRjMDE2MTEzZWUzNGQyMiIs
+        InNoYTM4NCI6IjIyYmU1OTIzMTgyZGJlNDUxMjNlYTA3YWVjYjU4OWNhYmZj
+        MGM3ZmYxMThhNjQwYTBiNjUyOWI5YzUwZTc3ODZhNTZkYjBkNzNiYmM4ODZh
+        OTQ2YTM5NzY3MmNmYzYzZCIsInNoYTUxMiI6IjIyMjU5YWRkZGFhNGI5MzY2
+        M2U3ZTdjMWFhNTQwNjExOTE0YTlmYTVlMDAyY2Y4ZjEzYTQzNmM3N2I2OWNi
+        YWVkZjE0NDkwMTE3ODFhNWRiMWIxYzJhMTI0Mjg2ZmYxMTFmZDAzY2QxZmQx
+        OTAzZGE4OTAzZGQ4YjlmMDBkN2YxIn1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        LS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTYzMWE3YzBlN2UwMDQy
+        ZGExZWM0NGY4ZDgxMjIzY2E3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBmb3Jt
+        LWRhdGE7IG5hbWU9InJlcG9zaXRvcnkiDQoNCi9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvDQotLS0tLS0tLS0tLS0tUnVieU11bHRpcGFydFBvc3QtNjMx
+        YTdjMGU3ZTAwNDJkYTFlYzQ0ZjhkODEyMjNjYTcNCkNvbnRlbnQtRGlzcG9z
+        aXRpb246IGZvcm0tZGF0YTsgbmFtZT0iYXJ0aWZhY3QiDQoNCi9wdWxwL2Fw
+        aS92My9hcnRpZmFjdHMvMDE5Y2FmMGMtMGQ4Mi03ZjVmLThkZTEtMDJlNDI1
+        M2QyNDZjLw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTYzMWE3
+        YzBlN2UwMDQyZGExZWM0NGY4ZDgxMjIzY2E3DQpDb250ZW50LURpc3Bvc2l0
+        aW9uOiBmb3JtLWRhdGE7IG5hbWU9ImRpc3RyaWJ1dGlvbiINCg0Ka2F0ZWxs
+        bw0KLS0tLS0tLS0tLS0tLVJ1YnlNdWx0aXBhcnRQb3N0LTYzMWE3YzBlN2Uw
+        MDQyZGExZWM0NGY4ZDgxMjIzY2E3DQpDb250ZW50LURpc3Bvc2l0aW9uOiBm
+        b3JtLWRhdGE7IG5hbWU9ImNvbXBvbmVudCINCg0KdXBsb2FkDQotLS0tLS0t
+        LS0tLS0tUnVieU11bHRpcGFydFBvc3QtNjMxYTdjMGU3ZTAwNDJkYTFlYzQ0
+        ZjhkODEyMjNjYTctLQ0K
+    headers:
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-631a7c0e7e0042da1ec44f8d81223ca7
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Content-Length:
+      - '690'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:28 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 20cbd47612d3476887d5e7405069cb43
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTBlNDYtNzI1
+        My1iOTE2LTNjZjY2YzRhYmM4NC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:28 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-0e46-7253-b916-3cf66c4abc84/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1097'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2ebbe695a9934f02bfe0437e0ed8e125
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMGU0
+        Ni03MjUzLWI5MTYtM2NmNjZjNGFiYzg0LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMGU0Ni03MjUzLWI5MTYtM2NmNjZjNGFiYzg0IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOC44NDAzMjBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI4LjgzODYxMVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiMjBjYmQ0
+        NzYxMmQzNDc2ODg3ZDVlNzQwNTA2OWNiNDMiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NToyOC44NTI3MzVaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjguOTAxMTMzWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NToyOS4xNjYwODNaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyYTEtNzU4YS04YjFiLTkxOTFj
+        N2U0ZjE3MS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
+        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
+        ZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92
+        ZXJzaW9ucy80LyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdl
+        cy8wMTljYWYwYy0wZjEwLTdhOGQtOWY0MS03OWM2ZjM0YWZmNzMvIiwiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25l
+        bnRzLzAxOWNhZjBjLTBmMWEtNzQ1Ni04ZDI3LTUwZDZhMzJhMDE5YS8iXSwi
+        cmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29yZCI6WyJwcm46ZGViLmFwdHJlcG9z
+        aXRvcnk6MDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxIiwi
+        c2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5OTk4OGJhOC03YjFhLTQwYjktYTYy
+        Ni1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/?fields=prn
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '73'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 595bcfb9f28b4a25afd5982163422d4e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYy0w
+        ZjI4LTcyOWEtYjg1Mi01MWM3MTdlODNjOGMifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '2127'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3a1daf37907c43858793c81b437c4554
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzMvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGFhOC03N2M2LTk1NmEtMmYyMzIxMWE1NWY1IiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNy45MTM0OTZaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI4LjAwODI5OFoiLCJudW1i
+        ZXIiOjMsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy8z
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvMy8ifSwiZGViLnJl
+        bGVhc2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0dXJlcy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNkODMy
+        ZDEvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVhc2VfY29tcG9uZW50Ijp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVh
+        c2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3
+        NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvMy8ifX0sInJlbW92ZWQi
+        Ont9LCJwcmVzZW50Ijp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
+        LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9u
+        cy8zLyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3Vu
+        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdl
+        X3JlbGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3
+        NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVh
+        c2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0dXJlcy8/cmVwb3Np
+        dG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2Fw
+        dC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lv
+        bnMvMy8ifSwiZGViLnJlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoxLCJo
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfY29tcG9u
+        ZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNk
+        ODMyZDEvdmVyc2lvbnMvMy8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxwL2Fw
+        aS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpjb3Jl
+        LnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBhYTgtNzdjNi05NTZhLTJm
+        MjMyMTFhNTVmNSJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '423'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e3ee39e95721414183a21f920f383da6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItZjhmOC03M2M0LWJmODMtOTA1
+        ZGRiNDczMjQ0LyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjM4NTE0NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMuMzg1MTU4WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        InVwbG9hZCIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8iLCJwbGFpbl9jb21w
+        b25lbnQiOiJ1cGxvYWQifV19
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '2127'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - e44f9b0d8d104dad8db6d13f78d9586b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzMvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGFhOC03N2M2LTk1NmEtMmYyMzIxMWE1NWY1IiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyNy45MTM0OTZaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI4LjAwODI5OFoiLCJudW1i
+        ZXIiOjMsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy8z
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvMy8ifSwiZGViLnJl
+        bGVhc2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0dXJlcy8/cmVw
+        b3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3Jp
+        ZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNkODMy
+        ZDEvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVhc2VfY29tcG9uZW50Ijp7ImNv
+        dW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVh
+        c2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3
+        NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvMy8ifX0sInJlbW92ZWQi
+        Ont9LCJwcmVzZW50Ijp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVm
+        IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
+        LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9u
+        cy8zLyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3Vu
+        dCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdl
+        X3JlbGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxw
+        L2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3
+        NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVh
+        c2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0dXJlcy8/cmVwb3Np
+        dG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2Fw
+        dC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lv
+        bnMvMy8ifSwiZGViLnJlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoxLCJo
+        cmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfY29tcG9u
+        ZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0
+        b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNk
+        ODMyZDEvdmVyc2lvbnMvMy8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxwL2Fw
+        aS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpjb3Jl
+        LnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBhYTgtNzdjNi05NTZhLTJm
+        MjMyMTFhNTVmNSJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/3/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '423'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - afa3604a3c4946b0adf28ea6406fda9e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItZjhmOC03M2M0LWJmODMtOTA1
+        ZGRiNDczMjQ0LyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjM4NTE0NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMuMzg1MTU4WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        InVwbG9hZCIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8iLCJwbGFpbl9jb21w
+        b25lbnQiOiJ1cGxvYWQifV19
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/signing-services/?name=katello_deb_sign
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - b60d717c26fe463882725df30eb7b8de
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1725'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 8f5a90a79b5346258df4eb3367bb21e4
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzQvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGYyOC03MjlhLWI4NTItNTFjNzE3ZTgzYzhjIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOS4wNjc5ODJaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI5LjE1MzAxNVoiLCJudW1i
+        ZXIiOjQsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvNC8ifX0sInJlbW92
+        ZWQiOnt9LCJwcmVzZW50Ijp7ImRlYi5yZWxlYXNlX2FyY2hpdGVjdHVyZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2FyY2hpdGVjdHVyZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03
+        NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLzQvIn0sImRlYi5wYWNr
+        YWdlX3JlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25l
+        bnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4
+        MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
+        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1i
+        YjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucGFja2FnZSI6
+        eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
+        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvdmVyc2lvbnMvNC8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxw
+        L2FwaS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpj
+        b3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBmMjgtNzI5YS1iODUy
+        LTUxYzcxN2U4M2M4YyJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:29 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
+        aWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgz
+        MmQxL3ZlcnNpb25zLzQvIiwic2ltcGxlIjpmYWxzZSwic3RydWN0dXJlZCI6
+        dHJ1ZX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - cc2ea3f699b247fea88419fdda845eb9
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTEyY2YtNzIz
+        My1hMzg4LTI3MjNjNDJlZTVkOC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/019caf0c-0f10-7a8d-9f41-79c6f34aff73/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1604'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6c2a5146a90c498ab902a8219be6b525
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcGFja2Fn
+        ZXMvMDE5Y2FmMGMtMGYxMC03YThkLTlmNDEtNzljNmYzNGFmZjczLyIsInBy
+        biI6InBybjpkZWIucGFja2FnZTowMTljYWYwYy0wZjEwLTdhOGQtOWY0MS03
+        OWM2ZjM0YWZmNzMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1
+        OjI5LjA0MDkxOVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MjkuMDQwOTMzWiIsInB1bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBv
+        cnQiOm51bGwsImFydGlmYWN0IjoiL3B1bHAvYXBpL3YzL2FydGlmYWN0cy8w
+        MTljYWYwYy0wZDgyLTdmNWYtOGRlMS0wMmU0MjUzZDI0NmMvIiwicmVsYXRp
+        dmVfcGF0aCI6InBvb2wvby9vZGluL29kaW5fMS4wX3BwYzY0LmRlYiIsIm1k
+        NSI6bnVsbCwic2hhMSI6IjcxZTU3ZDM5YmE2Y2Y4YjM3ZWU3YTc4MGZmOTdl
+        NmE2ZjJmODVjOTUiLCJzaGEyMjQiOiIyMTczNWE1NjFiYjliZDg5MzM0NDMw
+        OGNjOGI5NjYwMmIyN2VlNWJkOWFlOTRjYTBlNzg3OWQ1MyIsInNoYTI1NiI6
+        IjdlNjQ5OTZmM2JjNGNjM2Y1ZmY4MTc3YWI2NTZlOTE1ZWQ4ZjUyNDM1Mjdj
+        MTllMzhkYzAxNjExM2VlMzRkMjIiLCJzaGEzODQiOiIyMmJlNTkyMzE4MmRi
+        ZTQ1MTIzZWEwN2FlY2I1ODljYWJmYzBjN2ZmMTE4YTY0MGEwYjY1MjliOWM1
+        MGU3Nzg2YTU2ZGIwZDczYmJjODg2YTk0NmEzOTc2NzJjZmM2M2QiLCJzaGE1
+        MTIiOiIyMjI1OWFkZGRhYTRiOTM2NjNlN2U3YzFhYTU0MDYxMTkxNGE5ZmE1
+        ZTAwMmNmOGYxM2E0MzZjNzdiNjljYmFlZGYxNDQ5MDExNzgxYTVkYjFiMWMy
+        YTEyNDI4NmZmMTExZmQwM2NkMWZkMTkwM2RhODkwM2RkOGI5ZjAwZDdmMSIs
+        InBhY2thZ2UiOiJvZGluIiwic291cmNlIjpudWxsLCJ2ZXJzaW9uIjoiMS4w
+        IiwiYXJjaGl0ZWN0dXJlIjoicHBjNjQiLCJzZWN0aW9uIjoibWlzYyIsInBy
+        aW9yaXR5Ijoib3B0aW9uYWwiLCJvcmlnaW4iOm51bGwsInRhZyI6bnVsbCwi
+        YnVncyI6bnVsbCwiZXNzZW50aWFsIjoieWVzIiwiYnVpbGRfZXNzZW50aWFs
+        IjpudWxsLCJpbnN0YWxsZWRfc2l6ZSI6IjkiLCJtYWludGFpbmVyIjoiRXF1
+        aXZzIER1bW15IFBhY2thZ2UgR2VuZXJhdG9yIDxyb290QD4iLCJvcmlnaW5h
+        bF9tYWludGFpbmVyIjpudWxsLCJkZXNjcmlwdGlvbiI6Ik9kaW5cbiBPZGlu
+        IGlzIGFzc29jaWF0ZWQgd2l0aCB3aXNkb20sIGhlYWxpbmcsIGRlYXRoLCBy
+        b3lhbHR5LCB0aGUgZ2FsbG93cyxcbiBrbm93bGVkZ2UsIGJhdHRsZSwgc29y
+        Y2VyeSwgcG9ldHJ5LCBmcmVuenksIGFuZCB0aGUgcnVuaWMgYWxwaGFiZXQs
+        IGFuZCBpc1xuIHRoZSBodXNiYW5kIG9mIHRoZSBnb2RkZXNzIEZyaWdnLiIs
+        ImRlc2NyaXB0aW9uX21kNSI6bnVsbCwiaG9tZXBhZ2UiOm51bGwsImJ1aWx0
+        X3VzaW5nIjpudWxsLCJhdXRvX2J1aWx0X3BhY2thZ2UiOm51bGwsIm11bHRp
+        X2FyY2giOiJmb3JlaWduIiwiYnJlYWtzIjpudWxsLCJjb25mbGljdHMiOm51
+        bGwsImRlcGVuZHMiOm51bGwsInJlY29tbWVuZHMiOm51bGwsInN1Z2dlc3Rz
+        IjpudWxsLCJlbmhhbmNlcyI6bnVsbCwicHJlX2RlcGVuZHMiOm51bGwsInBy
+        b3ZpZGVzIjpudWxsLCJyZXBsYWNlcyI6bnVsbH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-12cf-7233-a388-2723c42ee5d8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '926'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 3d868c9f67da4f36b243ef4a5e77b120
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMTJj
+        Zi03MjMzLWEzODgtMjcyM2M0MmVlNWQ4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMTJjZi03MjMzLWEzODgtMjcyM2M0MmVlNWQ4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NTozMC4wMDExMjhaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI5Ljk5OTQ2M1oi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2RlYi5hcHAudGFz
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiJjYzJlYTNm
+        Njk5YjI0N2ZlYTg4NDE5ZmRkYTg0NWViOSIsImNyZWF0ZWRfYnkiOiIvcHVs
+        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU1OjMwLjAxMzY2MFoiLCJzdGFydGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NTozMC4wNDMxMjZaIiwiZmluaXNoZWRfYXQiOiIyMDI2LTAzLTAyVDE0
+        OjU1OjMwLjQ0ODYxM1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDE5Y2FlMjItYTI4Yy03NTNjLTk3ZmYtNWU5NTA1
+        MWQ2YzRiLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
+        InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVh
+        dGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2Rl
+        Yi9hcHQvMDE5Y2FmMGMtMTMwMi03MjczLThmZWUtMWQ1N2U2NDhkNmY3LyJd
+        LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDpwcm46ZGVi
+        LmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMz
+        ZDgzMmQxIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5OTk4OGJhOC03YjFh
+        LTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0c-1302-7273-8fee-1d57e648d6f7/?fields=prn
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '69'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 7d2710d4de6a402b8f3e5208fcec1d8e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwcm4iOiJwcm46ZGViLmFwdHB1YmxpY2F0aW9uOjAxOWNhZjBjLTEzMDIt
+        NzI3My04ZmVlLTFkNTdlNjQ4ZDZmNyJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5960'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 2ecfab941f7b4fa388a9aee1b3fbeaf5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1LjE5MzI1NloiLCJu
+        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
+        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
+        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
+        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
+        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
+        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
+        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
+        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
+        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
+        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
+        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
+        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
+        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
+        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
+        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
+        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
+        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
+        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
+        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
+        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
+        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
+        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
+        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
+        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
+        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
+        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
+        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
+        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
+        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
+        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
+        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
+        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
+        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
+        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
+        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
+        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
+        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
+        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
+        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
+        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
+        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
+        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
+        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
+        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
+        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
+        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
+        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
+        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
+        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
+        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
+        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
+        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
+        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
+        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
+        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
+        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
+        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
+        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
+        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
+        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
+        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
+        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
+        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
+        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
+        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
+        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
+        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
+        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
+        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
+        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
+        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
+        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
+        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
+        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
+        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
+        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
+        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
+        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
+        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
+        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
+        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
+        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
+        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
+        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
+        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
+        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
+        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
+        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
+        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
+        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
+        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
+        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
+        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
+        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
+        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
+        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
+        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
+        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
+        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
+        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
+        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
+        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
+        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
+        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
+        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
+        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
+        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
+        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
+        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
+        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
+        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
+        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
+        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
+        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
+        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
+        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
+        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
+        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
+        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: patch
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/019caf0b-6e6d-7a7e-aac1-237e8d3bd17a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
+        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
+        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
+        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
+        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
+        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
+        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
+        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
+        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
+        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
+        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
+        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
+        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
+        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
+        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
+        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
+        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
+        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
+        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
+        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
+        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
+        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
+        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
+        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
+        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
+        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
+        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
+        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
+        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
+        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
+        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
+        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
+        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
+        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
+        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
+        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
+        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
+        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
+        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
+        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
+        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
+        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
+        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
+        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
+        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
+        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
+        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
+        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
+        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
+        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
+        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
+        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
+        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
+        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
+        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
+        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
+        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
+        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
+        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
+        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
+        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
+        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
+        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
+        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
+        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
+        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
+        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
+        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
+        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
+        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
+        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
+        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
+        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
+        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
+        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
+        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
+        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
+        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
+        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
+        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
+        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
+        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
+        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
+        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
+        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
+        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
+        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
+        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
+        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
+        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
+        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
+        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
+        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
+        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
+        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
+        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
+        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
+        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
+        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
+        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
+        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
+        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
+        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
+        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
+        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
+        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
+        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
+        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
+        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
+        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
+        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
+        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
+        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5908'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 5f76e1491cba4cd483ff16462deed6e2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
+        Z3VhcmQvcmhzbS8wMTljYWYwYi02ZTZkLTdhN2UtYWFjMS0yMzdlOGQzYmQx
+        N2EvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWNh
+        ZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3YSIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDcuOTE3NzMzWiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NTozMC42NTQ3OTZaIiwibmFtZSI6
+        IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
+        aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
+        aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
+        ICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAgIFNpZ25hdHVyZSBB
+        bGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgIElz
+        c3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1L
+        YXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlcbiAgICAgICAgICAg
+        IE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIwIEdNVFxuICAgICAg
+        ICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUwIDIwMzggR01UXG4g
+        ICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENhcm9saW5hLCBMPVJh
+        bGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQsIENOPWNlbnRvczct
+        ZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVi
+        bGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0
+        aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5
+        OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAg
+        ICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6MDE6MWE6MzM6MTk6
+        MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAgICAgIDhhOjczOmJh
+        OjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1OjgxOmE2OlxuICAgICAg
+        ICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpiZTphMjo5YzpjMjo3
+        Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAgICAgNDQ6NDY6ZWY6
+        ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6MTc6XG4gICAgICAg
+        ICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3
+        OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAgICA5ZTpmMTowZDo2
+        Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpjZjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6
+        ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAgIDU2OjJhOjEwOmIz
+        OjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFlOlxuICAgICAgICAg
+        ICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3YjpiMDo2ZDoxZDo3
+        Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAgNWE6Yjc6MDc6OWI6
+        ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6XG4gICAgICAgICAg
+        ICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2OmFiOjIyOjM0Ojcx
+        OjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2ZTo0YjpjOTo4OTo1
+        OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpcbiAgICAgICAgICAg
+        ICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6
+        OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3OjNkOjlhOjgwOmNj
+        OjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxuICAgICAgICAgICAg
+        ICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5NTpjMDo3Mzo5Njpj
+        NTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6NDg6MjA6YTY6N2Q6
+        ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4gICAgICAgICAgICAg
+        ICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkzOmE4OmI5OjBhOjcz
+        OmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTowZlxuICAgICAgICAg
+        ICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlcbiAgICAgICAgWDUw
+        OXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5djMgQmFzaWMgQ29u
+        c3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJVRVxuICAgICAgICAg
+        ICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBEaWdpdGFs
+        IFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2VydGlmaWNhdGUgU2ln
+        biwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBFeHRlbmRlZCBLZXkg
+        VXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBTZXJ2ZXIgQXV0aGVu
+        dGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRpY2F0aW9uXG4gICAg
+        ICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAgICAgICAgICAgICAg
+        U1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBOZXRzY2FwZSBDb21t
+        ZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NMIFRvb2wgR2VuZXJh
+        dGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5djMgU3ViamVjdCBL
+        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5QjpEMjpEOTo2OTo4
+        ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1
+        RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBLZXkgSWRlbnRpZmll
+        cjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpEOTo2OTo4ODo5OToy
+        QzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAg
+        ICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEv
+        TD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5pdC9DTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICAgICAgICAgIHNl
+        cmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4gICAgU2lnbmF0dXJl
+        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
+        IDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIwOjdjOmEzOjRiOjEw
+        OmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6
+        MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4gICAgICAgICAxMzo2
+        Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzoxZjowNzo4MDoyYjox
+        ZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcxOjFhOmRhOjg2OmEw
+        OjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAgICAgMTc6MmY6MGU6
+        OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6
+        XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2NTpmMzo2MDpjYzo1
+        ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5OjNjOjk5OjhhOjQ0
+        OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0OmM1OjIzOlxuICAg
+        ICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6
+        NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpkMDpmMzozZTo4ODo3
+        ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0ODpcbiAgICAgICAg
+        IDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5OmU0OjYwOjdhOjMy
+        OmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6
+        YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4gICAgICAgICBhNzo1
+        MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MTozYjpiNzplMzoxYjph
+        ODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIxOmNkOmM1OmFlOmRl
+        OjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAgICAgODg6ZWY6ZTM6
+        OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6
+        XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FU
+        RS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2SEZ1SmFONE1BMEdD
+        U3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFHRXdKVlV6RVhNQlVH
+        QTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhi
+        R1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNN
+        QzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENCalpXNTBiM00zTFdS
+        bGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQTFNRGN4
+        XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlHTE1Rc3dDUVlEVlFR
+        R0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1EyRnliMnhwYm1FeEVE
+        QU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFvTUIwdGhkR1ZzXG5i
+        Rzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEVlFRRERD
+        QmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZi
+        VENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DXG5nZ0VC
+        QUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5pWXhnNVlHbTZFMldY
+        UWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJYelpjWDF6L25aLzZw
+        S3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBhOTJtXG5qZ21aVmpu
+        ZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVGVEtMQXZudXdiUjE4
+        Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15Z0MxYXJJalJ4VDNt
+        L2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpYXG5PdUJaanJOcWx6
+        MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hPV3hmdDNvRWdncG4z
+        MHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4LzNBUThDQXdFQUFh
+        T0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5Dd1lEVlIwUEJBUURB
+        Z0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFq
+        QVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZSVpJQVliNFFnRU5C
+        Q2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1WlhKaGRHVmtJRU5s
+        Y25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBpSmtzTG5BcnQybDJl
+        bjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFrR0ExVUVCaE1DVlZN
+        eEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVoTVJBd0RnWURWUVFI
+        XG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhSbGJHeHZNUlF3RWdZ
+        RFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0ExVUVBd3dnWTJWdWRH
+        OXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1amIyMkNDUUQ5XG51
+        cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNaGxzeHErdXdy
+        NWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQd29laUtVbEUydGdO
+        TkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29DZm94SWcyXG5vLy9i
+        Rnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VKR1h6WU14ZTdrSy9u
+        and4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1NVFrVGpGWkxCRFdW
+        ZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklBZ1JyXG5uN25hd201
+        bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdzanBISHAxRk9nUW5S
+        OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
+        amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
+        RklDQVRFLS0tLS0ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5960'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6bbcd0d911134abe8ebce66f2425778c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjMwLjY1NDc5NloiLCJu
+        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
+        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
+        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
+        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
+        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
+        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
+        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
+        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
+        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
+        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
+        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
+        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
+        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
+        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
+        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
+        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
+        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
+        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
+        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
+        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
+        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
+        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
+        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
+        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
+        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
+        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
+        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
+        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
+        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
+        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
+        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
+        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
+        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
+        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
+        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
+        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
+        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
+        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
+        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
+        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
+        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
+        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
+        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
+        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
+        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
+        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
+        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
+        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
+        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
+        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
+        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
+        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
+        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
+        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
+        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
+        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
+        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
+        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
+        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
+        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
+        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
+        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
+        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
+        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
+        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
+        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
+        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
+        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
+        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
+        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
+        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
+        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
+        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
+        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
+        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
+        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
+        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
+        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
+        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
+        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
+        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
+        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
+        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
+        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
+        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
+        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
+        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
+        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
+        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
+        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
+        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
+        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
+        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
+        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
+        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
+        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
+        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
+        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
+        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
+        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
+        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
+        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
+        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
+        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
+        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
+        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
+        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
+        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
+        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
+        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
+        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
+        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
+        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
+        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
+        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
+        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
+        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
+        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
+        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: patch
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/019caf0b-6e6d-7a7e-aac1-237e8d3bd17a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
+        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
+        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
+        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
+        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
+        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
+        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
+        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
+        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
+        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
+        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
+        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
+        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
+        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
+        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
+        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
+        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
+        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
+        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
+        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
+        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
+        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
+        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
+        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
+        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
+        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
+        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
+        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
+        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
+        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
+        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
+        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
+        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
+        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
+        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
+        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
+        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
+        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
+        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
+        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
+        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
+        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
+        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
+        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
+        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
+        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
+        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
+        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
+        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
+        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
+        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
+        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
+        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
+        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
+        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
+        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
+        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
+        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
+        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
+        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
+        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
+        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
+        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
+        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
+        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
+        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
+        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
+        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
+        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
+        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
+        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
+        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
+        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
+        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
+        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
+        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
+        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
+        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
+        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
+        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
+        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
+        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
+        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
+        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
+        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
+        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
+        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
+        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
+        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
+        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
+        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
+        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
+        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
+        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
+        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
+        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
+        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
+        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
+        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
+        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
+        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
+        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
+        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
+        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
+        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
+        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
+        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
+        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
+        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
+        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
+        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
+        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
+        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5908'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 41d2d9ab571f4e168e24de9308d45226
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
+        Z3VhcmQvcmhzbS8wMTljYWYwYi02ZTZkLTdhN2UtYWFjMS0yMzdlOGQzYmQx
+        N2EvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWNh
+        ZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3YSIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDcuOTE3NzMzWiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NTozMC43NjE5NjFaIiwibmFtZSI6
+        IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
+        aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
+        aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
+        ICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAgIFNpZ25hdHVyZSBB
+        bGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgIElz
+        c3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1L
+        YXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlcbiAgICAgICAgICAg
+        IE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIwIEdNVFxuICAgICAg
+        ICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUwIDIwMzggR01UXG4g
+        ICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENhcm9saW5hLCBMPVJh
+        bGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQsIENOPWNlbnRvczct
+        ZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVi
+        bGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0
+        aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5
+        OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAg
+        ICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6MDE6MWE6MzM6MTk6
+        MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAgICAgIDhhOjczOmJh
+        OjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1OjgxOmE2OlxuICAgICAg
+        ICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpiZTphMjo5YzpjMjo3
+        Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAgICAgNDQ6NDY6ZWY6
+        ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6MTc6XG4gICAgICAg
+        ICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3
+        OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAgICA5ZTpmMTowZDo2
+        Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpjZjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6
+        ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAgIDU2OjJhOjEwOmIz
+        OjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFlOlxuICAgICAgICAg
+        ICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3YjpiMDo2ZDoxZDo3
+        Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAgNWE6Yjc6MDc6OWI6
+        ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6XG4gICAgICAgICAg
+        ICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2OmFiOjIyOjM0Ojcx
+        OjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2ZTo0YjpjOTo4OTo1
+        OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpcbiAgICAgICAgICAg
+        ICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6
+        OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3OjNkOjlhOjgwOmNj
+        OjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxuICAgICAgICAgICAg
+        ICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5NTpjMDo3Mzo5Njpj
+        NTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6NDg6MjA6YTY6N2Q6
+        ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4gICAgICAgICAgICAg
+        ICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkzOmE4OmI5OjBhOjcz
+        OmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTowZlxuICAgICAgICAg
+        ICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlcbiAgICAgICAgWDUw
+        OXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5djMgQmFzaWMgQ29u
+        c3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJVRVxuICAgICAgICAg
+        ICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBEaWdpdGFs
+        IFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2VydGlmaWNhdGUgU2ln
+        biwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBFeHRlbmRlZCBLZXkg
+        VXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBTZXJ2ZXIgQXV0aGVu
+        dGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRpY2F0aW9uXG4gICAg
+        ICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAgICAgICAgICAgICAg
+        U1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBOZXRzY2FwZSBDb21t
+        ZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NMIFRvb2wgR2VuZXJh
+        dGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5djMgU3ViamVjdCBL
+        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5QjpEMjpEOTo2OTo4
+        ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1
+        RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBLZXkgSWRlbnRpZmll
+        cjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpEOTo2OTo4ODo5OToy
+        QzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAg
+        ICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEv
+        TD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5pdC9DTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICAgICAgICAgIHNl
+        cmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4gICAgU2lnbmF0dXJl
+        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
+        IDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIwOjdjOmEzOjRiOjEw
+        OmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6
+        MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4gICAgICAgICAxMzo2
+        Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzoxZjowNzo4MDoyYjox
+        ZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcxOjFhOmRhOjg2OmEw
+        OjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAgICAgMTc6MmY6MGU6
+        OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6
+        XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2NTpmMzo2MDpjYzo1
+        ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5OjNjOjk5OjhhOjQ0
+        OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0OmM1OjIzOlxuICAg
+        ICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6
+        NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpkMDpmMzozZTo4ODo3
+        ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0ODpcbiAgICAgICAg
+        IDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5OmU0OjYwOjdhOjMy
+        OmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6
+        YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4gICAgICAgICBhNzo1
+        MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MTozYjpiNzplMzoxYjph
+        ODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIxOmNkOmM1OmFlOmRl
+        OjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAgICAgODg6ZWY6ZTM6
+        OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6
+        XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FU
+        RS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2SEZ1SmFONE1BMEdD
+        U3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFHRXdKVlV6RVhNQlVH
+        QTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhi
+        R1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNN
+        QzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENCalpXNTBiM00zTFdS
+        bGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQTFNRGN4
+        XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlHTE1Rc3dDUVlEVlFR
+        R0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1EyRnliMnhwYm1FeEVE
+        QU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFvTUIwdGhkR1ZzXG5i
+        Rzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEVlFRRERD
+        QmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZi
+        VENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DXG5nZ0VC
+        QUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5pWXhnNVlHbTZFMldY
+        UWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJYelpjWDF6L25aLzZw
+        S3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBhOTJtXG5qZ21aVmpu
+        ZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVGVEtMQXZudXdiUjE4
+        Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15Z0MxYXJJalJ4VDNt
+        L2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpYXG5PdUJaanJOcWx6
+        MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hPV3hmdDNvRWdncG4z
+        MHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4LzNBUThDQXdFQUFh
+        T0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5Dd1lEVlIwUEJBUURB
+        Z0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFq
+        QVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZSVpJQVliNFFnRU5C
+        Q2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1WlhKaGRHVmtJRU5s
+        Y25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBpSmtzTG5BcnQybDJl
+        bjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFrR0ExVUVCaE1DVlZN
+        eEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVoTVJBd0RnWURWUVFI
+        XG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhSbGJHeHZNUlF3RWdZ
+        RFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0ExVUVBd3dnWTJWdWRH
+        OXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1amIyMkNDUUQ5XG51
+        cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNaGxzeHErdXdy
+        NWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQd29laUtVbEUydGdO
+        TkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29DZm94SWcyXG5vLy9i
+        Rnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VKR1h6WU14ZTdrSy9u
+        and4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1NVFrVGpGWkxCRFdW
+        ZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklBZ1JyXG5uN25hd201
+        bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdzanBISHAxRk9nUW5S
+        OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
+        amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
+        RklDQVRFLS0tLS0ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_10_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ff73344420774ca3a8174699d0a00381
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0c-1302-7273-8fee-1d57e648d6f7/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '518'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - a3dd0fa4223c4e2ba881e9371e3ce9f5
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2RlYi9h
+        cHQvMDE5Y2FmMGMtMTMwMi03MjczLThmZWUtMWQ1N2U2NDhkNmY3LyIsInBy
+        biI6InBybjpkZWIuYXB0cHVibGljYXRpb246MDE5Y2FmMGMtMTMwMi03Mjcz
+        LThmZWUtMWQ1N2U2NDhkNmY3IiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMy0w
+        MlQxNDo1NTozMC4wNTE2NzhaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2
+        LTAzLTAyVDE0OjU1OjMwLjQ0MTc4N1oiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMt
+        MDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLzQvIiwicmVw
+        b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8w
+        MTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvIiwic2ltcGxl
+        IjpmYWxzZSwic3RydWN0dXJlZCI6dHJ1ZSwiY2hlY2twb2ludCI6ZmFsc2Us
+        InNpZ25pbmdfc2VydmljZSI6bnVsbH0=
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZGViaWFu
+        XzEwX2xhYmVsIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250
+        ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1h
+        YWMxLTIzN2U4ZDNiZDE3YS8iLCJuYW1lIjoiRGViaWFuXzEwIiwicHVibGlj
+        YXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2RlYi9hcHQvMDE5
+        Y2FmMGMtMTMwMi03MjczLThmZWUtMWQ1N2U2NDhkNmY3LyJ9
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:30 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - be64ea935aff4b61988584ef6daa5c3e
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBjLTE2NmYtNzk1
+        NC05YTAyLTgxMzA0NTEwY2M2YS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:30 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0c-166f-7954-9a02-81304510cc6a/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '918'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0637ea795fc6472ebbb6d3d98f0c3422
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGMtMTY2
+        Zi03OTU0LTlhMDItODEzMDQ1MTBjYzZhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGMtMTY2Zi03OTU0LTlhMDItODEzMDQ1MTBjYzZhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NTozMC45MzAyMDFaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjMwLjkyNzYwMVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYmU2NGVh
+        OTM1YWZmNGI2MTk4ODU4NGVmNmRhYTVjM2UiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NTozMC45NDc2OThaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTU6MzAuOTk2MDk0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NTozMS4xODIyNjFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyYTEtNzU4YS04YjFiLTkxOTFj
+        N2U0ZjE3MS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
+        YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
+        ZGViL2FwdC8wMTljYWYwYy0xNzU1LTcyYzYtYjlmNy0zZjc5ZTk1MzdjNzcv
+        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjo5OTk4OGJh
+        OC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmE6ZGlzdHJpYnV0aW9ucyIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46OTk5ODhiYTgtN2IxYS00MGI5LWE2
+        MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/019caf0c-1755-72c6-b9f7-3f79e9537c77/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '754'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 0eee2bfaf230410ba931272fbd968261
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kZWIv
+        YXB0LzAxOWNhZjBjLTE3NTUtNzJjNi1iOWY3LTNmNzllOTUzN2M3Ny8iLCJw
+        cm4iOiJwcm46ZGViLmFwdGRpc3RyaWJ1dGlvbjowMTljYWYwYy0xNzU1LTcy
+        YzYtYjlmNy0zZjc5ZTk1MzdjNzciLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAz
+        LTAyVDE0OjU1OjMxLjE2NjA2MFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjYtMDMtMDJUMTQ6NTU6MzEuMTY2MDc0WiIsImJhc2VfcGF0aCI6IkFDTUVf
+        Q29ycG9yYXRpb24vbGlicmFyeS9kZWJpYW5fMTBfbGFiZWwiLCJiYXNlX3Vy
+        bCI6Imh0dHBzOi8vY2VudG9zOS1rYXRlbGxvLWRldmVsLXN0YWJsZS5leGFt
+        cGxlLmNvbS9wdWxwL2NvbnRlbnQvQUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5
+        L2RlYmlhbl8xMF9sYWJlbC8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBp
+        L3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5Y2FmMGItNmU2
+        ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhLyIsIm5vX2NvbnRlbnRfY2hhbmdl
+        X3NpbmNlIjoiMjAyNi0wMy0wMlQxNDo1NTozMS4xNjYwNzRaIiwiaGlkZGVu
+        IjpmYWxzZSwicHVscF9sYWJlbHMiOnt9LCJuYW1lIjoiRGViaWFuXzEwIiwi
+        cmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMv
+        cHVibGljYXRpb25zL2RlYi9hcHQvMDE5Y2FmMGMtMTMwMi03MjczLThmZWUt
+        MWQ1N2U2NDhkNmY3LyIsImNoZWNrcG9pbnQiOmZhbHNlfQ==
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1725'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - ca600321296f474698f31bc948a67749
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzQvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGYyOC03MjlhLWI4NTItNTFjNzE3ZTgzYzhjIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOS4wNjc5ODJaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI5LjE1MzAxNVoiLCJudW1i
+        ZXIiOjQsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvNC8ifX0sInJlbW92
+        ZWQiOnt9LCJwcmVzZW50Ijp7ImRlYi5yZWxlYXNlX2FyY2hpdGVjdHVyZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2FyY2hpdGVjdHVyZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03
+        NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLzQvIn0sImRlYi5wYWNr
+        YWdlX3JlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25l
+        bnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4
+        MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
+        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1i
+        YjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucGFja2FnZSI6
+        eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
+        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvdmVyc2lvbnMvNC8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxw
+        L2FwaS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpj
+        b3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBmMjgtNzI5YS1iODUy
+        LTUxYzcxN2U4M2M4YyJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '423'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 6c1a3af07bdf4de18d5c05ff4b93a4ca
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItZjhmOC03M2M0LWJmODMtOTA1
+        ZGRiNDczMjQ0LyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjM4NTE0NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMuMzg1MTU4WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        InVwbG9hZCIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8iLCJwbGFpbl9jb21w
+        b25lbnQiOiJ1cGxvYWQifV19
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1725'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 807cd9d7a7d24f37b536cff9da54d403
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzQvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGYyOC03MjlhLWI4NTItNTFjNzE3ZTgzYzhjIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOS4wNjc5ODJaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI5LjE1MzAxNVoiLCJudW1i
+        ZXIiOjQsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvNC8ifX0sInJlbW92
+        ZWQiOnt9LCJwcmVzZW50Ijp7ImRlYi5yZWxlYXNlX2FyY2hpdGVjdHVyZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2FyY2hpdGVjdHVyZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03
+        NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLzQvIn0sImRlYi5wYWNr
+        YWdlX3JlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25l
+        bnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4
+        MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
+        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1i
+        YjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucGFja2FnZSI6
+        eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
+        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvdmVyc2lvbnMvNC8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxw
+        L2FwaS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpj
+        b3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBmMjgtNzI5YS1iODUy
+        LTUxYzcxN2U4M2M4YyJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '423'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 1b4bd649c92141ab986afeaf9938cd1c
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItZjhmOC03M2M0LWJmODMtOTA1
+        ZGRiNDczMjQ0LyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjM4NTE0NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMuMzg1MTU4WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        InVwbG9hZCIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8iLCJwbGFpbl9jb21w
+        b25lbnQiOiJ1cGxvYWQifV19
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1725'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - '09c4b201b362495782488a4130753b50'
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzQvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGYyOC03MjlhLWI4NTItNTFjNzE3ZTgzYzhjIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOS4wNjc5ODJaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI5LjE1MzAxNVoiLCJudW1i
+        ZXIiOjQsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvNC8ifX0sInJlbW92
+        ZWQiOnt9LCJwcmVzZW50Ijp7ImRlYi5yZWxlYXNlX2FyY2hpdGVjdHVyZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2FyY2hpdGVjdHVyZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03
+        NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLzQvIn0sImRlYi5wYWNr
+        YWdlX3JlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25l
+        bnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4
+        MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
+        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1i
+        YjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucGFja2FnZSI6
+        eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
+        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvdmVyc2lvbnMvNC8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxw
+        L2FwaS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpj
+        b3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBmMjgtNzI5YS1iODUy
+        LTUxYzcxN2U4M2M4YyJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '423'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 17d807c778aa423ba48307b4f109f26d
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItZjhmOC03M2M0LWJmODMtOTA1
+        ZGRiNDczMjQ0LyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjM4NTE0NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMuMzg1MTU4WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        InVwbG9hZCIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8iLCJwbGFpbl9jb21w
+        b25lbnQiOiJ1cGxvYWQifV19
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '1725'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 12f4d36a12444529885f0f2dbc7d3ebd
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNp
+        b25zLzQvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGMtMGYyOC03MjlhLWI4NTItNTFjNzE3ZTgzYzhjIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NToyOS4wNjc5ODJaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjI5LjE1MzAxNVoiLCJudW1i
+        ZXIiOjQsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03NzQ2LWJiNTMtZTRiOWMzZDgzMmQx
+        LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
+        ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
+        YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
+        b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9w
+        dWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0
+        LTc3NDYtYmI1My1lNGI5YzNkODMyZDEvdmVyc2lvbnMvNC8ifX0sInJlbW92
+        ZWQiOnt9LCJwcmVzZW50Ijp7ImRlYi5yZWxlYXNlX2FyY2hpdGVjdHVyZSI6
+        eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2FyY2hpdGVjdHVyZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGMtMDRkNC03
+        NzQ2LWJiNTMtZTRiOWMzZDgzMmQxL3ZlcnNpb25zLzQvIn0sImRlYi5wYWNr
+        YWdlX3JlbGVhc2VfY29tcG9uZW50Ijp7ImNvdW50IjoyLCJocmVmIjoiL3B1
+        bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VfcmVsZWFzZV9jb21wb25l
+        bnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1iYjUzLWU0YjljM2Q4
+        MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
+        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
+        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
+        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBjLTA0ZDQtNzc0Ni1i
+        YjUzLWU0YjljM2Q4MzJkMS92ZXJzaW9ucy80LyJ9LCJkZWIucGFja2FnZSI6
+        eyJjb3VudCI6MiwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
+        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYy0wNGQ0LTc3NDYtYmI1My1lNGI5
+        YzNkODMyZDEvdmVyc2lvbnMvNC8ifX19LCJ2dWxuX3JlcG9ydCI6Ii9wdWxw
+        L2FwaS92My92dWxuX3JlcG9ydC8/cmVwb3NpdG9yeV92ZXJzaW9uPXBybjpj
+        b3JlLnJlcG9zaXRvcnl2ZXJzaW9uOjAxOWNhZjBjLTBmMjgtNzI5YS1iODUy
+        LTUxYzcxN2U4M2M4YyJ9
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?repository_version=/pulp/api/v3/repositories/deb/apt/019caf0c-04d4-7746-bb53-e4b9c3d832d1/versions/4/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:55:31 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '423'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 663f4f69041b4f90b7b680e874becd26
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItZjhmOC03M2M0LWJmODMtOTA1
+        ZGRiNDczMjQ0LyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi1mOGY4LTczYzQtYmY4My05MDVkZGI0NzMyNDQiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU1OjIzLjM4NTE0NVoiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTU6MjMuMzg1MTU4WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        InVwbG9hZCIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8iLCJwbGFpbl9jb21w
+        b25lbnQiOiJ1cGxvYWQifV19
+  recorded_at: Mon, 02 Mar 2026 14:55:31 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/deb/index_model.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/deb/index_model.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -43,21 +43,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4ca17d1a819e4dca808159cfc3920fd9
+      - e6eed56051c24511bba5c1d79d9e258a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIxOjAxLjQ4NTI3OVoiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ4LjAyMjcyNloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -184,10 +184,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -208,7 +208,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -228,20 +228,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 866619cba8134a5a993f7086ed057981
+      - b8849e155415429e9fb3f1f3ece6adc6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,7 +262,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -282,20 +282,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5ec90aacef1a4f308fb4c09fd1cfc1e4
+      - 236b6f55a9114b47ac7f424bd4ea461b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -316,7 +316,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -336,20 +336,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ec6d1543188b45898c98be0074be6493
+      - e275c0ea928341009a7f6fa680a4b0df
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +370,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -390,20 +390,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d5f55e62b6a848ed9f0c7aa86b526209
+      - 7e645ef867f34afa8f9ae91725a8d983
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -411,7 +411,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -424,7 +424,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -444,21 +444,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 856828d4ba2c40d590c085364f27bcb5
+      - a2a8f936730647ec8b9a607aa9f04faf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIxOjAxLjQ4NTI3OVoiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ4LjAyMjcyNloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -585,10 +585,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -609,7 +609,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -629,20 +629,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cd43cf4b336c4634b0102483d09193a3
+      - ee7344c7f705464e9df2b8d09b2bdd79
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -663,7 +663,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -683,20 +683,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d6147d0cc6a346ddab3521a9f8185055
+      - bd758bc06eb94f90a8e42bb5ed3608e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -717,7 +717,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -737,20 +737,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fe41f5bb5c2545068745a4ee14436b46
+      - '096717f2da5540ca9b1c05096363d8ea'
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -771,7 +771,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -791,20 +791,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5de7bc5239b0422aa31c078ad7b48164
+      - 6b3cb0e1d3b84034a1f0f09d8410603d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
@@ -836,13 +836,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:41 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/deb/apt/019c4ecd-9516-775e-907f-3f34cb04b7af/"
+      - "/pulp/api/v3/remotes/deb/apt/019caf0b-7948-7ed0-8430-7d8ff11544f8/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -858,20 +858,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5b41c1bb0ce64928a8647bde7438a2bc
+      - d01c34c0841c47f8b9a48717d73a1adf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAx
-        OWM0ZWNkLTk1MTYtNzc1ZS05MDdmLTNmMzRjYjA0YjdhZi8iLCJwcm4iOiJw
-        cm46ZGViLmFwdHJlbW90ZTowMTljNGVjZC05NTE2LTc3NWUtOTA3Zi0zZjM0
-        Y2IwNGI3YWYiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQx
-        Ljg0NzAxNloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDItMTFUMjI6
-        MjM6NDEuODQ3MDI1WiIsIm5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIs
+        OWNhZjBiLTc5NDgtN2VkMC04NDMwLTdkOGZmMTE1NDRmOC8iLCJwcm4iOiJw
+        cm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi03OTQ4LTdlZDAtODQzMC03ZDhm
+        ZjExNTQ0ZjgiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjUw
+        LjY5Njk2NloiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6
+        NTQ6NTAuNjk2OTc2WiIsIm5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2RlYmlh
         bi8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3Zh
         bGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMi
@@ -889,10 +889,10 @@ http_interactions:
         ZmFsc2UsInN5bmNfdWRlYnMiOmZhbHNlLCJzeW5jX2luc3RhbGxlciI6ZmFs
         c2UsImdwZ2tleSI6bnVsbCwiaWdub3JlX21pc3NpbmdfcGFja2FnZV9pbmRp
         Y2VzIjpmYWxzZX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:41 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiZGViaWFuX3B1bHBfcmFnbmFyb2sifQ==
@@ -915,13 +915,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:42 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/"
+      - "/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -937,38 +937,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9c21d5c502d24b80b0cdddd5a419ccce
+      - cf3f85cd578e404ca0bd8781dbd65c24
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1NTZhLyIsInBy
-        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljNGVjZC05NjEyLTc2OTYt
-        YTU0ZS1jYjU3OTE5NjU1NmEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQyLjA5ODc0NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
-        MDItMTFUMjI6MjM6NDIuMTA1NDMwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2QtOTYxMi03
-        Njk2LWE1NGUtY2I1NzkxOTY1NTZhL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3LyIsInBy
+        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi03OWJkLTdlYTUt
+        ODRlZC1kNzEzYTViZDY1ODciLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjUwLjgxMzk2N1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NTAuODE4NDMzWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItNzliZC03
+        ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3L3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3
-        OTE5NjU1NmEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZGViaWFuX3B1bHBfcmFn
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi03OWJkLTdlYTUtODRlZC1kNzEz
+        YTViZDY1ODcvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZGViaWFuX3B1bHBfcmFn
         bmFyb2siLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lv
         bnMiOm51bGwsInJlbW90ZSI6bnVsbCwicHVibGlzaF91cHN0cmVhbV9yZWxl
         YXNlX2ZpZWxkcyI6dHJ1ZSwic2lnbmluZ19zZXJ2aWNlIjpudWxsLCJzaWdu
         aW5nX3NlcnZpY2VfcmVsZWFzZV9vdmVycmlkZXMiOnt9fQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:42 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/release_components/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS8iLCJj
+        YXB0LzAxOWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny8iLCJj
         b21wb25lbnQiOiJlbXB0eSIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8ifQ==
     headers:
       Content-Type:
@@ -987,7 +987,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:42 GMT
+      - Mon, 02 Mar 2026 14:54:50 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1007,20 +1007,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ed246c1ca3e4463ab54fdd9d5ed5b2a6
+      - 9e37f2af74c14058b3ef0f52be3723f9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLTk2OTYtN2M1
-        NS1iMWQ0LTMwNDA1NDMxYjhhZS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:42 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTdhMjItNzFl
+        Mi05MjRlLWYxZjMwZDE5MjQ3Ny8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:50 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-9696-7c55-b1d4-30405431b8ae/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-7a22-71e2-924e-f1f30d192477/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1028,7 +1028,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +1041,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:42 GMT
+      - Mon, 02 Mar 2026 14:54:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,41 +1061,41 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 92014eb621ec408dbca4ad0c0b480bab
+      - 10de0908f10742779ca50dd2cea8bd6c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtOTY5
-        Ni03YzU1LWIxZDQtMzA0MDU0MzFiOGFlLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtOTY5Ni03YzU1LWIxZDQtMzA0MDU0MzFiOGFlIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0Mi4yMzQwODNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQyLjIzMjE0Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItN2Ey
+        Mi03MWUyLTkyNGUtZjFmMzBkMTkyNDc3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItN2EyMi03MWUyLTkyNGUtZjFmMzBkMTkyNDc3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1MC45MTY5NDlaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjUwLjkxNTE4NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZWQyNDZj
-        MWNhM2U0NDYzYWI1NGZkZDlkNWVkNWIyYTYiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMi0x
-        MVQyMjoyMzo0Mi4yNTI2MTJaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDIuMjg5NDg5WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyMzo0Mi41MjY1NDhaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhOTktN2VjMC05NWUxLTgzYjMw
-        ZDRlZGY2Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiOWUzN2Yy
+        YWY3NGMxNDA1OGIzZWYwZjUyYmUzNzIzZjkiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NDo1MC45Mjg2NjNaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NTAuOTYyNzc2WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NDo1MS4xOTMyMzZaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyYTEtNzU4YS04YjFiLTkxOTFj
+        N2U0ZjE3MS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
-        ZWIvYXB0LzAxOWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92
+        ZWIvYXB0LzAxOWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny92
         ZXJzaW9ucy8xLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9yZWxlYXNl
-        X2NvbXBvbmVudHMvMDE5YzRlY2QtOTc1YS03ZjkzLTgzYzItN2U4ZjZiYTky
-        NTEyLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
-        YXB0cmVwb3NpdG9yeTowMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3OTE5
-        NjU1NmEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYxMWMzLTIwNmMt
-        NDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:42 GMT
+        X2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNjODZjMWNk
+        OTUzLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
+        YXB0cmVwb3NpdG9yeTowMTljYWYwYi03OWJkLTdlYTUtODRlZC1kNzEzYTVi
+        ZDY1ODciLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4YmE4LTdiMWEt
+        NDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/versions/1/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/versions/1/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1116,7 +1116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:42 GMT
+      - Mon, 02 Mar 2026 14:54:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1136,20 +1136,212 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4a9fa5a06ab14c24a3672a39dbd76054
+      - 23d07770e4374b9984f66e6ed0eae50f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZC05
-        NzY3LTdkODItYmExZC1jMDJkNzgwZjgwM2YifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:42 GMT
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi03
+        YWUzLTc3ZDgtYWQxMy1hZjk2ZGUyZmFlNTMifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?component=empty&distribution=katello&repository_version=/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '421'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 651dea097c7b41098a05ce191e99f5b2
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNj
+        ODZjMWNkOTUzLyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi01YTA1LTc2Y2ItOTc2Yi1lM2M4NmMxY2Q5NTMiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQyLjY5NTI5M1oiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDIuNjk1MzA1WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        ImVtcHR5IiwiZGlzdHJpYnV0aW9uIjoia2F0ZWxsbyIsInBsYWluX2NvbXBv
+        bmVudCI6ImVtcHR5In1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLzAxOWNhZjBiLTVhMDUtNzZjYi05
+        NzZiLWUzYzg2YzFjZDk1My8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c621785b6476419abd78820d9e70439b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTdjYjItNzYx
+        Yy1hN2M5LTRkMGRiMzZjNWVlOC8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-7cb2-761c-a7c9-4d0db36c5ee8/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:51 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '937'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 441bd5e0b8354cc98eafe961f107269f
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItN2Ni
+        Mi03NjFjLWE3YzktNGQwZGIzNmM1ZWU4LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItN2NiMi03NjFjLWE3YzktNGQwZGIzNmM1ZWU4IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1MS41NzI3MjVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjUxLjU3MDk1Nloi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        YzYyMTc4NWI2NDc2NDE5YWJkNzg4MjBkOWU3MDQzOWIiLCJjcmVhdGVkX2J5
+        IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
+        Ni0wMy0wMlQxNDo1NDo1MS41ODQ5MTRaIiwic3RhcnRlZF9hdCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NTEuNjI2MTY0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
+        My0wMlQxNDo1NDo1MS43NTU0MjdaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYmYtNzRlMC1hN2Ri
+        LWJmZTY3MDIzOGVhOS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
+        XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJk
+        NjU4Ny92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbInBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi03OWJkLTdlYTUt
+        ODRlZC1kNzEzYTViZDY1ODciLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5
+        OTg4YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
 - request:
     method: patch
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/019c4ecd-9516-775e-907f-3f34cb04b7af/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/019caf0b-7948-7ed0-8430-7d8ff11544f8/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1181,7 +1373,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:43 GMT
+      - Mon, 02 Mar 2026 14:54:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1201,25 +1393,25 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 670fa372f99e48fa9f464d2128909d88
+      - eb8f63fd3a8c47ff850ee86a72e2ccf3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLTlhZGYtN2Yx
-        Zi04OTk5LTFmNWQ2ZDIxMGRhZC8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTdkZGMtNzFk
+        ZC04M2E5LWI5NjZhNTEwYjdiYi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/sync/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAxOWM0
-        ZWNkLTk1MTYtNzc1ZS05MDdmLTNmMzRjYjA0YjdhZi8iLCJtaXJyb3IiOnRy
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAxOWNh
+        ZjBiLTc5NDgtN2VkMC04NDMwLTdkOGZmMTE1NDRmOC8iLCJtaXJyb3IiOnRy
         dWUsIm9wdGltaXplIjp0cnVlfQ==
     headers:
       Content-Type:
@@ -1238,7 +1430,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:43 GMT
+      - Mon, 02 Mar 2026 14:54:51 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1258,20 +1450,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 849053f1512f4be5b8c42d0229a2237a
+      - 7dc11f3d51c14d6a946bee385e60255f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLTliNzQtNzI0
-        Yi04ZDA5LTRhNjc3MjMyOTQ3NS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:43 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTdlNDUtN2U4
+        Yi1iM2Q4LTBmMDc4ZTE0NThhYS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:51 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-9b74-724b-8d09-4a6772329475/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-7e45-7e8b-b3d8-0f078e1458aa/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1279,7 +1471,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1292,7 +1484,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:45 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1304,7 +1496,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1622'
+      - '1621'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1312,55 +1504,55 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cfcae6df950d4335bedab795715d9b8b
+      - efea8164fa1d4939b2d2bba57a007b03
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtOWI3
-        NC03MjRiLThkMDktNGE2NzcyMzI5NDc1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtOWI3NC03MjRiLThkMDktNGE2NzcyMzI5NDc1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0My40Nzg5NjdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQzLjQ3NzA4M1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItN2U0
+        NS03ZThiLWIzZDgtMGYwNzhlMTQ1OGFhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItN2U0NS03ZThiLWIzZDgtMGYwNzhlMTQ1OGFhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1MS45NzU2MzRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjUxLjk3Mzg0MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2RlYi5hcHAudGFz
         a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsImxvZ2dpbmdfY2lkIjoi
-        ODQ5MDUzZjE1MTJmNGJlNWI4YzQyZDAyMjlhMjIzN2EiLCJjcmVhdGVkX2J5
+        N2RjMTFmM2Q1MWMxNGQ2YTk0NmJlZTM4NWU2MDI1NWYiLCJjcmVhdGVkX2J5
         IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
-        Ni0wMi0xMVQyMjoyMzo0My41MDEwNTJaIiwic3RhcnRlZF9hdCI6IjIwMjYt
-        MDItMTFUMjI6MjM6NDMuNTM4MzE2WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
-        Mi0xMVQyMjoyMzo0NS4zMjUwMjJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
-        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhOTktN2VjMC05NWUx
-        LTgzYjMwZDRlZGY2Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        Ni0wMy0wMlQxNDo1NDo1MS45ODQ3MzhaIiwic3RhcnRlZF9hdCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NTIuMDEwNDU1WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
+        My0wMlQxNDo1NDo1NC4wMjEzNjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyOGMtNzUzYy05N2Zm
+        LTVlOTUwNTFkNmM0Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
         a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
         eyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MTEsInN1ZmZpeCI6bnVsbH0seyJtZXNz
-        YWdlIjoiVXBkYXRlIFJlbGVhc2VGaWxlIHVuaXRzIiwiY29kZSI6InVwZGF0
-        ZS5yZWxlYXNlX2ZpbGUiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
-        dWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVwZGF0
-        ZSBQYWNrYWdlSW5kZXggdW5pdHMiLCJjb2RlIjoidXBkYXRlLnBhY2thZ2Vp
-        bmRleCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUi
-        OjIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29u
-        dGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
-        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MTMsInN1ZmZpeCI6bnVs
-        bH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUi
-        OiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
-        InRvdGFsIjpudWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
-        ZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92ZXJz
-        aW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpk
-        ZWIuYXB0cmVwb3NpdG9yeTowMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3
-        OTE5NjU1NmEiLCJzaGFyZWQ6cHJuOmRlYi5hcHRyZW1vdGU6MDE5YzRlY2Qt
-        OTUxNi03NzVlLTkwN2YtM2YzNGNiMDRiN2FmIiwic2hhcmVkOnBybjpjb3Jl
-        LmRvbWFpbjowZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAi
-        XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:45 GMT
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3Nh
+        Z2UiOiJVcGRhdGUgUmVsZWFzZUZpbGUgdW5pdHMiLCJjb2RlIjoidXBkYXRl
+        LnJlbGVhc2VfZmlsZSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51
+        bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVXBkYXRl
+        IFBhY2thZ2VJbmRleCB1bml0cyIsImNvZGUiOiJ1cGRhdGUucGFja2FnZWlu
+        ZGV4Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
+        Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
+        ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
+        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoxMywic3VmZml4IjpudWxs
+        fSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
+        InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
+        dG90YWwiOm51bGwsImRvbmUiOjAsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
+        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
+        cHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3L3ZlcnNp
+        b25zLzMvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmRl
+        Yi5hcHRyZXBvc2l0b3J5OjAxOWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNh
+        NWJkNjU4NyIsInNoYXJlZDpwcm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi03
+        OTQ4LTdlZDAtODQzMC03ZDhmZjExNTQ0ZjgiLCJzaGFyZWQ6cHJuOmNvcmUu
+        ZG9tYWluOjk5OTg4YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJd
+        fQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/versions/2/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/versions/3/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1381,7 +1573,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:45 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1401,20 +1593,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bf627a8502624750bcd73b77ef52b6c0
+      - 6dcc988f45e54ab4a7246d60e761031b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZC05
-        ZGU3LTdhOWUtOTgwMy0wMjFjZjZmYjNlMzcifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:45 GMT
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi04
+        Mjc0LTcyMjItYjc3Yy00ZDhlZDc4NjNlZjMifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/signing-services/?name=katello_deb_sign
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/signing-services/?name=katello_deb_sign
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1422,7 +1614,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1435,7 +1627,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:45 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1455,20 +1647,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 10e30e847b7e40588fa3c5dce735e8e1
+      - ec34a66bc67c49cea09106916292d38c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:45 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/versions/2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1489,7 +1681,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:45 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1501,7 +1693,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '3417'
+      - '3223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1509,100 +1701,96 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1738dbede6af4a509bb56bd3517d4ef2
+      - 72cf8ac0a4bf422593d7f4f8a038a644
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1NTZhL3ZlcnNp
-        b25zLzIvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
-        YzRlY2QtOWRlNy03YTllLTk4MDMtMDIxY2Y2ZmIzZTM3IiwicHVscF9jcmVh
-        dGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0NC4xMDUzODRaIiwicHVscF9sYXN0
-        X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ1LjMxMTY4MloiLCJudW1i
-        ZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L2RlYi9hcHQvMDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1NTZh
+        cHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3L3ZlcnNp
+        b25zLzMvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGItODI3NC03MjIyLWI3N2MtNGQ4ZWQ3ODYzZWYzIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1My4wNDU2OTFaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU0LjAxMjMzNFoiLCJudW1i
+        ZXIiOjMsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3
         LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
         ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAv
         YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
         b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
-        OWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92ZXJzaW9ucy8y
+        OWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny92ZXJzaW9ucy8z
         LyJ9LCJkZWIucGFja2FnZV9pbmRleCI6eyJjb3VudCI6MiwiaHJlZiI6Ii9w
         dWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX2luZGljZXMvP3JlcG9z
         aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L2RlYi9hcHQvMDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1NTZh
-        L3ZlcnNpb25zLzIvIn0sImRlYi5wYWNrYWdlX3JlbGVhc2VfY29tcG9uZW50
+        L2RlYi9hcHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3
+        L3ZlcnNpb25zLzMvIn0sImRlYi5wYWNrYWdlX3JlbGVhc2VfY29tcG9uZW50
         Ijp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGVi
         L3BhY2thZ2VfcmVsZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNp
         b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
-        OWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92ZXJzaW9ucy8y
+        OWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny92ZXJzaW9ucy8z
         LyJ9LCJkZWIucmVsZWFzZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2RlYi9yZWxlYXNlcy8/cmVwb3NpdG9yeV92ZXJzaW9u
         X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTlj
-        NGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3OTE5NjU1NmEvdmVyc2lvbnMvMi8i
+        YWYwYi03OWJkLTdlYTUtODRlZC1kNzEzYTViZDY1ODcvdmVyc2lvbnMvMy8i
         fSwiZGViLnJlbGVhc2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50IjoyLCJocmVm
         IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0
         dXJlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1j
-        YjU3OTE5NjU1NmEvdmVyc2lvbnMvMi8ifSwiZGViLnJlbGVhc2VfY29tcG9u
+        ZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi03OWJkLTdlYTUtODRlZC1k
+        NzEzYTViZDY1ODcvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVhc2VfY29tcG9u
         ZW50Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
         ZGViL3JlbGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2Fk
-        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVj
-        ZC05NjEyLTc2OTYtYTU0ZS1jYjU3OTE5NjU1NmEvdmVyc2lvbnMvMi8ifSwi
+        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYw
+        Yi03OWJkLTdlYTUtODRlZC1kNzEzYTViZDY1ODcvdmVyc2lvbnMvMy8ifSwi
         ZGViLnJlbGVhc2VfZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2RlYi9yZWxlYXNlX2ZpbGVzLz9yZXBvc2l0b3J5X3Zl
         cnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
-        LzAxOWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92ZXJzaW9u
-        cy8yLyJ9fSwicmVtb3ZlZCI6eyJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
-        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
-        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2QtOTYx
-        Mi03Njk2LWE1NGUtY2I1NzkxOTY1NTZhL3ZlcnNpb25zLzIvIn19LCJwcmVz
-        ZW50Ijp7ImRlYi5yZWxlYXNlX2ZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVsZWFzZV9maWxlcy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2Fw
-        dC8wMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3OTE5NjU1NmEvdmVyc2lv
-        bnMvMi8ifSwiZGViLnJlbGVhc2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50Ijoy
-        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJj
-        aGl0ZWN0dXJlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1j
-        YjU3OTE5NjU1NmEvdmVyc2lvbnMvMi8ifSwiZGViLnBhY2thZ2VfaW5kZXgi
-        OnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIv
-        cGFja2FnZV9pbmRpY2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWM0ZWNkLTk2MTItNzY5Ni1h
-        NTRlLWNiNTc5MTk2NTU2YS92ZXJzaW9ucy8yLyJ9LCJkZWIucGFja2FnZSI6
-        eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
-        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3
-        OTE5NjU1NmEvdmVyc2lvbnMvMi8ifSwiZGViLnBhY2thZ2VfcmVsZWFzZV9j
-        b21wb25lbnQiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9kZWIvcGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudHMvP3JlcG9zaXRv
-        cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQv
-        MDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1NTZhL3ZlcnNpb25z
-        LzIvIn0sImRlYi5yZWxlYXNlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWM0ZWNk
-        LTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92ZXJzaW9ucy8yLyJ9LCJk
-        ZWIucmVsZWFzZV9jb21wb25lbnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNkLTk2MTItNzY5Ni1hNTRlLWNiNTc5MTk2NTU2YS92ZXJz
-        aW9ucy8yLyJ9fX0sInZ1bG5fcmVwb3J0IjoiL3B1bHAvYXBpL3YzL3Z1bG5f
-        cmVwb3J0Lz9yZXBvX3ZlcnNpb25zPXBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOWM0ZWNkLTlkZTctN2E5ZS05ODAzLTAyMWNmNmZiM2UzNyJ9
-  recorded_at: Wed, 11 Feb 2026 22:23:45 GMT
+        LzAxOWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny92ZXJzaW9u
+        cy8zLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZGViLnJlbGVhc2Vf
+        ZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RlYi9yZWxlYXNlX2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBiLTc5YmQtN2Vh
+        NS04NGVkLWQ3MTNhNWJkNjU4Ny92ZXJzaW9ucy8zLyJ9LCJkZWIucmVsZWFz
+        ZV9hcmNoaXRlY3R1cmUiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kZWIvcmVsZWFzZV9hcmNoaXRlY3R1cmVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
+        LzAxOWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny92ZXJzaW9u
+        cy8zLyJ9LCJkZWIucGFja2FnZV9pbmRleCI6eyJjb3VudCI6MiwiaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX2luZGljZXMvP3Jl
+        cG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Rl
+        Yi9hcHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3L3Zl
+        cnNpb25zLzMvIn0sImRlYi5wYWNrYWdlIjp7ImNvdW50IjozLCJocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5
+        X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBiLTc5YmQtN2VhNS04NGVkLWQ3MTNhNWJkNjU4Ny92ZXJzaW9ucy8z
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi03OWJkLTdlYTUt
+        ODRlZC1kNzEzYTViZDY1ODcvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVhc2Ui
+        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIv
+        cmVsZWFzZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcx
+        M2E1YmQ2NTg3L3ZlcnNpb25zLzMvIn0sImRlYi5yZWxlYXNlX2NvbXBvbmVu
+        dCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rl
+        Yi9yZWxlYXNlX2NvbXBvbmVudHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItNzliZC03
+        ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3L3ZlcnNpb25zLzMvIn19fSwidnVsbl9y
+        ZXBvcnQiOiIvcHVscC9hcGkvdjMvdnVsbl9yZXBvcnQvP3JlcG9zaXRvcnlf
+        dmVyc2lvbj1wcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi04
+        Mjc0LTcyMjItYjc3Yy00ZDhlZDc4NjNlZjMifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2RlYi9hcHQvMDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1
-        NTZhL3ZlcnNpb25zLzIvIiwic2ltcGxlIjpmYWxzZSwic3RydWN0dXJlZCI6
+        aWVzL2RlYi9hcHQvMDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2
+        NTg3L3ZlcnNpb25zLzMvIiwic2ltcGxlIjpmYWxzZSwic3RydWN0dXJlZCI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1621,7 +1809,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:45 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1641,20 +1829,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 463d0bb2fc4a4d4e8011c9cb8a90aaac
+      - 2bf0f817d3ea43a1a071d1173cd27d66
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWE0MWYtNzI5
-        OS1hYTEyLWZjNTIxMzczOWU0YS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:45 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTg3ODktNzJk
+        Ni1iYzk5LTE5YjQ4ZjJiZmJkYy8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-a41f-7299-aa12-fc5213739e4a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-8789-72d6-bc99-19b48f2bfbdc/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,7 +1850,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1675,7 +1863,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:46 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1695,39 +1883,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5d3a6894adbc43328cf953cc62273b91
+      - 896dbbb08bf9436f9be95a96bb80afa7
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYTQx
-        Zi03Mjk5LWFhMTItZmM1MjEzNzM5ZTRhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYTQxZi03Mjk5LWFhMTItZmM1MjEzNzM5ZTRhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0NS42OTczODZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ1LjY5NTUzMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItODc4
+        OS03MmQ2LWJjOTktMTliNDhmMmJmYmRjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItODc4OS03MmQ2LWJjOTktMTliNDhmMmJmYmRjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1NC4zNDkxNDNaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU0LjM0NjMxMVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2RlYi5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI0NjNkMGJi
-        MmZjNGE0ZDRlODAxMWM5Y2I4YTkwYWFhYyIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ1LjcxOTc4NloiLCJzdGFydGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyMzo0NS43NjAzMDhaIiwiZmluaXNoZWRfYXQiOiIyMDI2LTAyLTExVDIy
-        OjIzOjQ2LjQ5OTA1MVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5YzRlYmMtY2E5OS03ZWMwLTk1ZTEtODNiMzBk
-        NGVkZjZiLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiIyYmYwZjgx
+        N2QzZWE0M2ExYTA3MWQxMTczY2QyN2Q2NiIsImNyZWF0ZWRfYnkiOiIvcHVs
+        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjU0LjM2MDM5OFoiLCJzdGFydGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NDo1NC4zOTI3NDFaIiwiZmluaXNoZWRfYXQiOiIyMDI2LTAzLTAyVDE0
+        OjU0OjU0Ljg3OTE3M1oiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDE5Y2FlMjItYTBiZi03NGUwLWE3ZGItYmZlNjcw
+        MjM4ZWE5LyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
         InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVh
         dGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2Rl
-        Yi9hcHQvMDE5YzRlY2QtYTQ2Zi03NzMwLWEwMDUtMzhhZjM2ZGJmNjc2LyJd
+        Yi9hcHQvMDE5Y2FmMGItODdkMC03YTM0LWExMWItZWVjOTIyZDNlYmEwLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDpwcm46ZGVi
-        LmFwdHJlcG9zaXRvcnk6MDE5YzRlY2QtOTYxMi03Njk2LWE1NGUtY2I1Nzkx
-        OTY1NTZhIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowZDI2MTFjMy0yMDZj
-        LTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAiXX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:46 GMT
+        LmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGItNzliZC03ZWE1LTg0ZWQtZDcxM2E1
+        YmQ2NTg3Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5OTk4OGJhOC03YjFh
+        LTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/019c4ecd-a46f-7730-a005-38af36dbf676/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0b-87d0-7a34-a11b-eec922d3eba0/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1748,7 +1936,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:46 GMT
+      - Mon, 02 Mar 2026 14:54:54 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,20 +1956,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2900d60ad54e450db551002fd541a59b
+      - 2e5acfb8dc214538a05b986e4bff39e3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46ZGViLmFwdHB1YmxpY2F0aW9uOjAxOWM0ZWNkLWE0NmYt
-        NzczMC1hMDA1LTM4YWYzNmRiZjY3NiJ9
-  recorded_at: Wed, 11 Feb 2026 22:23:46 GMT
+        eyJwcm4iOiJwcm46ZGViLmFwdHB1YmxpY2F0aW9uOjAxOWNhZjBiLTg3ZDAt
+        N2EzNC1hMTFiLWVlYzkyMmQzZWJhMCJ9
+  recorded_at: Mon, 02 Mar 2026 14:54:54 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1789,7 +1977,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1802,7 +1990,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:46 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1822,21 +2010,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 76b0f687b931475aa5313d4f2e73fc2e
+      - 3bd9acfab0be46b5ba6c3163ce8167c9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIxOjAxLjQ4NTI3OVoiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ4LjAyMjcyNloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -1963,10 +2151,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:46 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: patch
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/019c4ec2-4a0a-72a6-a0f7-8caff5c2dd3f/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/019caf0b-6e6d-7a7e-aac1-237e8d3bd17a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2099,7 +2287,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2112,7 +2300,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:46 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2132,20 +2320,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1ff1dbfc4b104e34af35779e386e0ba0
+      - b500a543a7c24992a558ae72bf7e1e98
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMTljNGVjMi00YTBhLTcyYTYtYTBmNy04Y2FmZjVjMmRk
-        M2YvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWM0
-        ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZmNWMyZGQzZiIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjYtMDItMTFUMjI6MTE6MjEuNzM4ODIyWiIsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0Ni43NzU1NzRaIiwibmFtZSI6
+        Z3VhcmQvcmhzbS8wMTljYWYwYi02ZTZkLTdhN2UtYWFjMS0yMzdlOGQzYmQx
+        N2EvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWNh
+        ZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3YSIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDcuOTE3NzMzWiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1NS4wOTY4MTBaIiwibmFtZSI6
         IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
         aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
         aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
@@ -2272,10 +2460,10 @@ http_interactions:
         OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
         amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
         RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:46 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2283,7 +2471,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2296,7 +2484,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:46 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2316,21 +2504,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 14f83f5735fd4536b1213919660b51b0
+      - 14a52946c71043b8841b6efe08397e44
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ2Ljc3NTU3NFoiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1LjA5NjgxMFoiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -2457,10 +2645,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:46 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: patch
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/019c4ec2-4a0a-72a6-a0f7-8caff5c2dd3f/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/019caf0b-6e6d-7a7e-aac1-237e8d3bd17a/
     body:
       encoding: UTF-8
       base64_string: |
@@ -2593,7 +2781,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2606,7 +2794,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:46 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2626,20 +2814,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - fca75dee665f4ef3a30a63c0a3a669d5
+      - 8243420d42df45db920cd89d6b3a4fdc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMTljNGVjMi00YTBhLTcyYTYtYTBmNy04Y2FmZjVjMmRk
-        M2YvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWM0
-        ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZmNWMyZGQzZiIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjYtMDItMTFUMjI6MTE6MjEuNzM4ODIyWiIsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0Ni45MjgxNTRaIiwibmFtZSI6
+        Z3VhcmQvcmhzbS8wMTljYWYwYi02ZTZkLTdhN2UtYWFjMS0yMzdlOGQzYmQx
+        N2EvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWNh
+        ZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3YSIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDcuOTE3NzMzWiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1NS4xOTMyNTZaIiwibmFtZSI6
         IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
         aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
         aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
@@ -2766,10 +2954,10 @@ http_interactions:
         OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
         amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
         RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:46 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2790,7 +2978,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2810,20 +2998,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 07fe20c69d664ac78c7c4faab99423a8
+      - 36ecfdf00d4a4a3ea0db4fe81a894645
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/019c4ecd-a46f-7730-a005-38af36dbf676/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0b-87d0-7a34-a11b-eec922d3eba0/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2844,7 +3032,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2864,40 +3052,40 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d1991203cf5641c8bf79e0fbf9e8ba25
+      - a822174f2fb14c56a77781975fa5ffaf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2RlYi9h
-        cHQvMDE5YzRlY2QtYTQ2Zi03NzMwLWEwMDUtMzhhZjM2ZGJmNjc2LyIsInBy
-        biI6InBybjpkZWIuYXB0cHVibGljYXRpb246MDE5YzRlY2QtYTQ2Zi03NzMw
-        LWEwMDUtMzhhZjM2ZGJmNjc2IiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMi0x
-        MVQyMjoyMzo0NS43NzY0NjJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2
-        LTAyLTExVDIyOjIzOjQ2LjQ4NTUxNloiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2Qt
-        OTYxMi03Njk2LWE1NGUtY2I1NzkxOTY1NTZhL3ZlcnNpb25zLzIvIiwicmVw
+        cHQvMDE5Y2FmMGItODdkMC03YTM0LWExMWItZWVjOTIyZDNlYmEwLyIsInBy
+        biI6InBybjpkZWIuYXB0cHVibGljYXRpb246MDE5Y2FmMGItODdkMC03YTM0
+        LWExMWItZWVjOTIyZDNlYmEwIiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMy0w
+        MlQxNDo1NDo1NC40MTg5MjdaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2
+        LTAzLTAyVDE0OjU0OjU0Ljg3NTc3NVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGIt
+        NzliZC03ZWE1LTg0ZWQtZDcxM2E1YmQ2NTg3L3ZlcnNpb25zLzMvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8w
-        MTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3OTE5NjU1NmEvIiwic2ltcGxl
+        MTljYWYwYi03OWJkLTdlYTUtODRlZC1kNzEzYTViZDY1ODcvIiwic2ltcGxl
         IjpmYWxzZSwic3RydWN0dXJlZCI6dHJ1ZSwiY2hlY2twb2ludCI6ZmFsc2Us
         InNpZ25pbmdfc2VydmljZSI6bnVsbH0=
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZGViaWFu
         X3B1bHBfcmFnbmFyb2tfbGFiZWwiLCJjb250ZW50X2d1YXJkIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5YzRlYzIt
-        NGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmLyIsIm5hbWUiOiJkZWJpYW5f
+        YXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5Y2FmMGIt
+        NmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhLyIsIm5hbWUiOiJkZWJpYW5f
         cHVscF9yYWduYXJvayIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
-        YmxpY2F0aW9ucy9kZWIvYXB0LzAxOWM0ZWNkLWE0NmYtNzczMC1hMDA1LTM4
-        YWYzNmRiZjY3Ni8ifQ==
+        YmxpY2F0aW9ucy9kZWIvYXB0LzAxOWNhZjBiLTg3ZDAtN2EzNC1hMTFiLWVl
+        YzkyMmQzZWJhMC8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -2915,7 +3103,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2935,20 +3123,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - c41c2ee5e7ac4d40938eef12e0d41fdc
+      - d23ff60e9f724666a7584b458c50b533
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWE5YjMtNzZk
-        Yy1iZmQzLTQzNjg0ZmMwOWRiMi8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLThiOTktNzM0
+        MS05M2UzLTEwZmJjZTFiNTgzZi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-a9b3-76dc-bfd3-43684fc09db2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-8b99-7341-93e3-10fbce1b583f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2956,7 +3144,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2969,7 +3157,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2989,39 +3177,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 30d94bb26b23469bbe65948ece0955b9
+      - 94cdab71618d4763869a1e817a45ea2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYTli
-        My03NmRjLWJmZDMtNDM2ODRmYzA5ZGIyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYTliMy03NmRjLWJmZDMtNDM2ODRmYzA5ZGIyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0Ny4xMjUzODFaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ3LjEyMzYyMFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItOGI5
+        OS03MzQxLTkzZTMtMTBmYmNlMWI1ODNmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItOGI5OS03MzQxLTkzZTMtMTBmYmNlMWI1ODNmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1NS4zODg2MjBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1LjM4NjI4NVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiYzQxYzJl
-        ZTVlN2FjNGQ0MDkzOGVlZjEyZTBkNDFmZGMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMi0x
-        MVQyMjoyMzo0Ny4xNDIyOThaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDcuMTgzNTE2WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyMzo0Ny40MDU1NDlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhYWItN2VkMi1hMDRiLWU2MmVi
-        MTRkMDJkZC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZDIzZmY2
+        MGU5ZjcyNDY2NmE3NTg0YjQ1OGM1MGI1MzMiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NDo1NS4zOTg1NjhaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NTUuNDMzNjY0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NDo1NS42MTY0MzJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyYTEtNzU4YS04YjFiLTkxOTFj
+        N2U0ZjE3MS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        ZGViL2FwdC8wMTljNGVjZC1hYWIxLTdiMjEtOGI2Ny1mOTQ1MTIzYjU1Mzcv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowZDI2MTFj
-        My0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDA6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MGQyNjExYzMtMjA2Yy00MDE2LWJi
-        NTctYzRiMDU5ZTFkYzQwIl19
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+        ZGViL2FwdC8wMTljYWYwYi04YzYzLTc5MDItYWQ2Mi0zNzNhMDI4ODBlZGEv
+        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjo5OTk4OGJh
+        OC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmE6ZGlzdHJpYnV0aW9ucyIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46OTk5ODhiYTgtN2IxYS00MGI5LWE2
+        MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/019c4ecd-aab1-7b21-8b67-f945123b5537/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/019caf0b-8c63-7902-ad62-373a02880eda/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3042,7 +3230,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3054,7 +3242,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '802'
+      - '787'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3062,36 +3250,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9d2879e223c344d18a860e25e33ce1e8
+      - a0f5271b2ad74a4ea27ea58bea691f5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kZWIv
-        YXB0LzAxOWM0ZWNkLWFhYjEtN2IyMS04YjY3LWY5NDUxMjNiNTUzNy8iLCJw
-        cm4iOiJwcm46ZGViLmFwdGRpc3RyaWJ1dGlvbjowMTljNGVjZC1hYWIxLTdi
-        MjEtOGI2Ny1mOTQ1MTIzYjU1MzciLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAy
-        LTExVDIyOjIzOjQ3LjM3ODM3NFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjYtMDItMTFUMjI6MjM6NDcuMzc4MzkwWiIsImJhc2VfcGF0aCI6IkFDTUVf
+        YXB0LzAxOWNhZjBiLThjNjMtNzkwMi1hZDYyLTM3M2EwMjg4MGVkYS8iLCJw
+        cm4iOiJwcm46ZGViLmFwdGRpc3RyaWJ1dGlvbjowMTljYWYwYi04YzYzLTc5
+        MDItYWQ2Mi0zNzNhMDI4ODBlZGEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAz
+        LTAyVDE0OjU0OjU1LjU4ODE2M1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjYtMDMtMDJUMTQ6NTQ6NTUuNTg4MTc0WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9kZWJpYW5fcHVscF9yYWduYXJva19sYWJl
-        bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LXB1bHAtdXBncmFkZS5x
-        amFtZXMtdGhpbmtwYWRwMWdlbjRpLmV4YW1wbGUuY29tL3B1bHAvY29udGVu
-        dC9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZGViaWFuX3B1bHBfcmFnbmFy
-        b2tfbGFiZWwvIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1h
-        MGY3LThjYWZmNWMyZGQzZi8iLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6
-        IjIwMjYtMDItMTFUMjI6MjM6NDcuMzc4MzkwWiIsImhpZGRlbiI6ZmFsc2Us
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25hcm9r
-        IiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkv
-        djMvcHVibGljYXRpb25zL2RlYi9hcHQvMDE5YzRlY2QtYTQ2Zi03NzMwLWEw
-        MDUtMzhhZjM2ZGJmNjc2LyIsImNoZWNrcG9pbnQiOmZhbHNlfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+        bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
+        aW9uL2xpYnJhcnkvZGViaWFuX3B1bHBfcmFnbmFyb2tfbGFiZWwvIiwiY29u
+        dGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NlcnRn
+        dWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3
+        YS8iLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjYtMDMtMDJUMTQ6
+        NTQ6NTUuNTg4MTc0WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7
+        fSwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25hcm9rIiwicmVwb3NpdG9yeSI6
+        bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25z
+        L2RlYi9hcHQvMDE5Y2FmMGItODdkMC03YTM0LWExMWItZWVjOTIyZDNlYmEw
+        LyIsImNoZWNrcG9pbnQiOmZhbHNlfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/versions/2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3112,7 +3300,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3132,23 +3320,23 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 737be3a9c9524615a5b11c7b1df07d14
+      - 7d95b06ffa9e41e2bd9d73ec4713f038
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
-        YWNrYWdlcy8wMTljNGVjZC1hMTFlLTdkMWQtYmM5Ni1iZjgwZmIyN2FjMWEv
-        IiwicHJuIjoicHJuOmRlYi5wYWNrYWdlOjAxOWM0ZWNkLWExMWUtN2QxZC1i
-        Yzk2LWJmODBmYjI3YWMxYSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDUuMTI3NzQ5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0w
-        Mi0xMVQyMjoyMzo0NS4xMjc3NjNaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxu
+        YWNrYWdlcy8wMTljYWYwYi02ODg5LTc2OWMtYWRmMy03OTU0MDE2ZGZiZDcv
+        IiwicHJuIjoicHJuOmRlYi5wYWNrYWdlOjAxOWNhZjBiLTY4ODktNzY5Yy1h
+        ZGYzLTc5NTQwMTZkZmJkNyIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDYuNjU0ODA5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0w
+        My0wMlQxNDo1NDo0Ni42NTQ4MTdaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxu
         X3JlcG9ydCI6bnVsbCwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzLzAxOWM0ZWNkLWExYTktNzE2ZC05MTE5LTFkMDdmNDg1MThjOC8iLCJy
+        Y3RzLzAxOWNhZjBiLTY5NWEtNzAyOS1hNWY3LTA0NjQ1ZGU3ZmMxMy8iLCJy
         ZWxhdGl2ZV9wYXRoIjoicG9vbC9hc2dhcmQvdC90aG9yL3Rob3JfMS4wX3Bw
         YzY0LmRlYiIsIm1kNSI6bnVsbCwic2hhMSI6ImI4MjY0NmY1Mjk4NDUxZGEy
         NzdhMDYyY2I1ZGNlY2VkYjZhNjc1YzAiLCJzaGEyMjQiOiI2OWVkMWM0Mzhh
@@ -3179,13 +3367,13 @@ http_interactions:
         IjpudWxsLCJzdWdnZXN0cyI6bnVsbCwiZW5oYW5jZXMiOm51bGwsInByZV9k
         ZXBlbmRzIjpudWxsLCJwcm92aWRlcyI6bnVsbCwicmVwbGFjZXMiOm51bGx9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2th
-        Z2VzLzAxOWM0ZWNkLWExMWMtN2I1MC1hMWE4LTZmZmQ3N2I4M2M4ZC8iLCJw
-        cm4iOiJwcm46ZGViLnBhY2thZ2U6MDE5YzRlY2QtYTExYy03YjUwLWExYTgt
-        NmZmZDc3YjgzYzhkIiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        Mzo0NS4wODQzNjhaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ1LjA4NDM3NVoiLCJwdWxwX2xhYmVscyI6e30sInZ1bG5fcmVw
+        Z2VzLzAxOWNhZjBiLTY4ODctN2RjNy04NTA2LTE2ZDNlZmU0ZWM1OS8iLCJw
+        cm4iOiJwcm46ZGViLnBhY2thZ2U6MDE5Y2FmMGItNjg4Ny03ZGM3LTg1MDYt
+        MTZkM2VmZTRlYzU5IiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NDo0Ni42MjkwODZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQ2LjYyOTA5NFoiLCJwdWxwX2xhYmVscyI6e30sInZ1bG5fcmVw
         b3J0IjpudWxsLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        MDE5YzRlY2QtYTFhOC03MjlkLWFhZDQtOTc4ZDM2NzJjOTVlLyIsInJlbGF0
+        MDE5Y2FmMGItNjk1Ny03ZTY1LWE4YWQtZGJhMTA2MjZkYjZkLyIsInJlbGF0
         aXZlX3BhdGgiOiJwb29sL2FzZ2FyZC9vL29kaW4vb2Rpbl8xLjBfcHBjNjQu
         ZGViIiwibWQ1IjpudWxsLCJzaGExIjoiMDY2YzU4YzZiOGI5MDQ0NDJiMjVk
         NmU0OWFhNjkxZmI3NWUxMDY0MCIsInNoYTIyNCI6IjE4MzczYzIzODdiYWQ1
@@ -3215,14 +3403,14 @@ http_interactions:
         cyI6bnVsbCwiZGVwZW5kcyI6bnVsbCwicmVjb21tZW5kcyI6bnVsbCwic3Vn
         Z2VzdHMiOm51bGwsImVuaGFuY2VzIjpudWxsLCJwcmVfZGVwZW5kcyI6bnVs
         bCwicHJvdmlkZXMiOm51bGwsInJlcGxhY2VzIjpudWxsfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlcy8wMTljNGVj
-        ZC1hMTFhLTc4ZjgtYjRkOC0wMzQ5ZDFiNzUxOTAvIiwicHJuIjoicHJuOmRl
-        Yi5wYWNrYWdlOjAxOWM0ZWNkLWExMWEtNzhmOC1iNGQ4LTAzNDlkMWI3NTE5
-        MCIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjM6NDUuMDgyNjc3
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0NS4w
-        ODI2ODVaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxuX3JlcG9ydCI6bnVsbCwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOWM0ZWNkLWEx
-        N2QtN2Q5ZS04OTQ0LTI2NTJhYzQ0ZmY3Ni8iLCJyZWxhdGl2ZV9wYXRoIjoi
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlcy8wMTljYWYw
+        Yi02ODg1LTdkMzgtYThhMi04NGNkMjhlNDc3MTUvIiwicHJuIjoicHJuOmRl
+        Yi5wYWNrYWdlOjAxOWNhZjBiLTY4ODUtN2QzOC1hOGEyLTg0Y2QyOGU0Nzcx
+        NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDYuNjI3MTM5
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ni42
+        MjcxNDhaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxuX3JlcG9ydCI6bnVsbCwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOWNhZjBiLTY5
+        NTAtN2E0Yy04ZjJiLTAxN2Y5M2JjYjAyMy8iLCJyZWxhdGl2ZV9wYXRoIjoi
         cG9vbC9hc2dhcmQvZi9mcmlnZy9mcmlnZ18xLjBfcHBjNjQuZGViIiwibWQ1
         IjpudWxsLCJzaGExIjoiYTllNzE4ZmQ1NjEyMjY0OGY0YTFlY2RjODkxN2Fj
         OTA5MzllNDJiYSIsInNoYTIyNCI6ImY4ZjBkN2Q4ZDE0M2YzNTM4OWM0ZWQ0
@@ -3248,10 +3436,10 @@ http_interactions:
         b25mbGljdHMiOm51bGwsImRlcGVuZHMiOm51bGwsInJlY29tbWVuZHMiOm51
         bGwsInN1Z2dlc3RzIjpudWxsLCJlbmhhbmNlcyI6bnVsbCwicHJlX2RlcGVu
         ZHMiOm51bGwsInByb3ZpZGVzIjpudWxsLCJyZXBsYWNlcyI6bnVsbH1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3259,7 +3447,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3272,7 +3460,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3292,21 +3480,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b1b24f4ce46b4e74aee3afb77c6c09b8
+      - 6dc0dc865cdd4443a163451f10d42b94
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ2LjkyODE1NFoiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1LjE5MzI1NloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -3433,10 +3621,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3457,7 +3645,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3477,34 +3665,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b7381bdb6a53470b9c1c5e9d20b6ad8c
+      - 899217b74900455fafecab1036b490f1
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8wMTljNGVjZC05NjEyLTc2OTYtYTU0ZS1jYjU3OTE5NjU1NmEv
-        IiwicHJuIjoicHJuOmRlYi5hcHRyZXBvc2l0b3J5OjAxOWM0ZWNkLTk2MTIt
-        NzY5Ni1hNTRlLWNiNTc5MTk2NTU2YSIsInB1bHBfY3JlYXRlZCI6IjIwMjYt
-        MDItMTFUMjI6MjM6NDIuMDk4NzQ0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoi
-        MjAyNi0wMi0xMVQyMjoyMzo0NS4zMTAxMzVaIiwidmVyc2lvbnNfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC05
-        NjEyLTc2OTYtYTU0ZS1jYjU3OTE5NjU1NmEvdmVyc2lvbnMvIiwicHVscF9s
+        ZGViL2FwdC8wMTljYWYwYi03OWJkLTdlYTUtODRlZC1kNzEzYTViZDY1ODcv
+        IiwicHJuIjoicHJuOmRlYi5hcHRyZXBvc2l0b3J5OjAxOWNhZjBiLTc5YmQt
+        N2VhNS04NGVkLWQ3MTNhNWJkNjU4NyIsInB1bHBfY3JlYXRlZCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NTAuODEzOTY3WiIsInB1bHBfbGFzdF91cGRhdGVkIjoi
+        MjAyNi0wMy0wMlQxNDo1NDo1NC4wMDkxMjdaIiwidmVyc2lvbnNfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi03
+        OWJkLTdlYTUtODRlZC1kNzEzYTViZDY1ODcvdmVyc2lvbnMvIiwicHVscF9s
         YWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWM0ZWNkLTk2MTItNzY5Ni1hNTRl
-        LWNiNTc5MTk2NTU2YS92ZXJzaW9ucy8yLyIsIm5hbWUiOiJkZWJpYW5fcHVs
+        L3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBiLTc5YmQtN2VhNS04NGVk
+        LWQ3MTNhNWJkNjU4Ny92ZXJzaW9ucy8zLyIsIm5hbWUiOiJkZWJpYW5fcHVs
         cF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192
         ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJwdWJsaXNoX3Vwc3RyZWFt
         X3JlbGVhc2VfZmllbGRzIjp0cnVlLCJzaWduaW5nX3NlcnZpY2UiOm51bGws
         InNpZ25pbmdfc2VydmljZV9yZWxlYXNlX292ZXJyaWRlcyI6e319XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-9612-7696-a54e-cb579196556a/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-79bd-7ea5-84ed-d713a5bd6587/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3525,7 +3713,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:55 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3545,20 +3733,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4d81822942fb4adabc2cae9856bda9b2
+      - b7d05d318a08425ebba83e0d8719e091
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWFjZGEtNzM3
-        Yy05NGVhLTEwMTQwYTU2ODAzMC8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLThkY2QtN2Fl
+        Ny04MDc0LWQyN2E1ZTlkZGNkOS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:55 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3579,7 +3767,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:47 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3599,21 +3787,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f8de408bcbd848eb9c906156b181dde0
+      - c1a4276d42bf45cf98a52848cc90ed39
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RlYi9h
-        cHQvMDE5YzRlY2QtOTUxNi03NzVlLTkwN2YtM2YzNGNiMDRiN2FmLyIsInBy
-        biI6InBybjpkZWIuYXB0cmVtb3RlOjAxOWM0ZWNkLTk1MTYtNzc1ZS05MDdm
-        LTNmMzRjYjA0YjdhZiIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6
-        MjM6NDEuODQ3MDE2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0x
-        MVQyMjoyMzo0My4zNjcyNjdaIiwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25h
+        cHQvMDE5Y2FmMGItNzk0OC03ZWQwLTg0MzAtN2Q4ZmYxMTU0NGY4LyIsInBy
+        biI6InBybjpkZWIuYXB0cmVtb3RlOjAxOWNhZjBiLTc5NDgtN2VkMC04NDMw
+        LTdkOGZmMTE1NDRmOCIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6
+        NTQ6NTAuNjk2OTY2WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0w
+        MlQxNDo1NDo1MS44OTQ0MDBaIiwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25h
         cm9rIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcv
         ZGViaWFuLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
@@ -3631,10 +3819,10 @@ http_interactions:
         Y2VzIjpmYWxzZSwic3luY191ZGVicyI6ZmFsc2UsInN5bmNfaW5zdGFsbGVy
         IjpmYWxzZSwiZ3Bna2V5IjpudWxsLCJpZ25vcmVfbWlzc2luZ19wYWNrYWdl
         X2luZGljZXMiOmZhbHNlfV19
-  recorded_at: Wed, 11 Feb 2026 22:23:47 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/019c4ecd-9516-775e-907f-3f34cb04b7af/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/019caf0b-7948-7ed0-8430-7d8ff11544f8/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3655,7 +3843,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3675,20 +3863,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - bd947224837547f9be317c47306dd80c
+      - d284e4b27c0b47ac930dbe4214bed022
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWFkNGEtN2Y1
-        Ni1iMDdjLWQyNjFjMzljMTdlMi8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLThlMzItNzQ1
+        NS1hMDQ1LTkxMDI1MTg1NDNjZi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-acda-737c-94ea-10140a568030/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-8dcd-7ae7-8074-d27a5e9ddcd9/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3696,7 +3884,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3709,7 +3897,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3729,37 +3917,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9aaea2bc7d9f43d39a94510df1c52928
+      - 4fbe887b444949ee9ade893598fc9b2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYWNk
-        YS03MzdjLTk0ZWEtMTAxNDBhNTY4MDMwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYWNkYS03MzdjLTk0ZWEtMTAxNDBhNTY4MDMwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0Ny45MzI0NjdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ3LjkzMDY3NFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItOGRj
+        ZC03YWU3LTgwNzQtZDI3YTVlOWRkY2Q5LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItOGRjZC03YWU3LTgwNzQtZDI3YTVlOWRkY2Q5IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1NS45NTE2NjZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU1Ljk0OTk4OFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjRkODE4
-        MjI5NDJmYjRhZGFiYzJjYWU5ODU2YmRhOWIyIiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjM6NDcuOTUxOTUyWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ3Ljk5MzY4OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDguMTcxNjM3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYWI0LTc5YmMtOTQ0Yi1jM2Ri
-        ZjMwOThiOGYvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImI3ZDA1
+        ZDMxOGEwODQyNWViYmE4M2UwZDg3MTllMDkxIiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTQ6NTUuOTYxMTg3WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjU2LjAwMDkxOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NTYuMjA2NzUxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMGI0LTc0MDktYjgyNC1iNDc2
+        ZWNiNjdmZTAvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5YzRlY2QtOTYxMi03Njk2
-        LWE1NGUtY2I1NzkxOTY1NTZhIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjow
-        ZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAiXX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
+        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGItNzliZC03ZWE1
+        LTg0ZWQtZDcxM2E1YmQ2NTg3Iiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5
+        OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-ad4a-7f56-b07c-d261c39c17e2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-8e32-7455-a045-9102518543cf/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3767,7 +3955,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3780,7 +3968,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3800,37 +3988,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - e39fcd70a290406fa0355b4a5166a5c6
+      - 6b330b1a521248bb82c847c45a0eaddc
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYWQ0
-        YS03ZjU2LWIwN2MtZDI2MWMzOWMxN2UyLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYWQ0YS03ZjU2LWIwN2MtZDI2MWMzOWMxN2UyIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0OC4wNDU4MDJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ4LjA0MzMxMloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItOGUz
+        Mi03NDU1LWEwNDUtOTEwMjUxODU0M2NmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItOGUzMi03NDU1LWEwNDUtOTEwMjUxODU0M2NmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1Ni4wNTI5NTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU2LjA1MTE2MVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImJkOTQ3
-        MjI0ODM3NTQ3ZjliZTMxN2M0NzMwNmRkODBjIiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjM6NDguMDcwMTE4WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ4LjExMDE5OVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDguMTcxNTk4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYWFiLTdlZDItYTA0Yi1lNjJl
-        YjE0ZDAyZGQvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImQyODRl
+        NGIyN2MwYjQ3YWM5MzBkYmU0MjE0YmVkMDIyIiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTQ6NTYuMDY0NDU2WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjU2LjEwMDQ5MloiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NTYuMTY2NzU3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMmExLTc1OGEtOGIxYi05MTkx
+        YzdlNGYxNzEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljNGVjZC05NTE2LTc3NWUtOTA3
-        Zi0zZjM0Y2IwNGI3YWYiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYx
-        MWMzLTIwNmMtNDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
+        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi03OTQ4LTdlZDAtODQz
+        MC03ZDhmZjExNTQ0ZjgiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4
+        YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3851,7 +4039,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3863,7 +4051,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '760'
+      - '745'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3871,35 +4059,35 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cc1123571982445fabfb92b5743fbc92
+      - 7a2e76c9c16341e2bff5a781007324ae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2RlYi9hcHQvMDE5YzRlY2QtYWFiMS03YjIxLThiNjctZjk0NTEyM2I1NTM3
-        LyIsInBybiI6InBybjpkZWIuYXB0ZGlzdHJpYnV0aW9uOjAxOWM0ZWNkLWFh
-        YjEtN2IyMS04YjY3LWY5NDUxMjNiNTUzNyIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjYtMDItMTFUMjI6MjM6NDcuMzc4Mzc0WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNi0wMi0xMVQyMjoyMzo0Ny4zNzgzOTBaIiwiYmFzZV9wYXRoIjoi
+        L2RlYi9hcHQvMDE5Y2FmMGItOGM2My03OTAyLWFkNjItMzczYTAyODgwZWRh
+        LyIsInBybiI6InBybjpkZWIuYXB0ZGlzdHJpYnV0aW9uOjAxOWNhZjBiLThj
+        NjMtNzkwMi1hZDYyLTM3M2EwMjg4MGVkYSIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjYtMDMtMDJUMTQ6NTQ6NTUuNTg4MTYzWiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNi0wMy0wMlQxNDo1NDo1NS41ODgxNzRaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2RlYmlhbl9wdWxwX3JhZ25hcm9r
-        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczktcHVscC11cGdy
-        YWRlLnFqYW1lcy10aGlua3BhZHAxZ2VuNGkuZXhhbXBsZS5jb20vcHVscC9j
-        b250ZW50L0FDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9kZWJpYW5fcHVscF9y
-        YWduYXJva19sYWJlbC8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5YzRlYzItNGEwYS03
-        MmE2LWEwZjctOGNhZmY1YzJkZDNmLyIsIm5vX2NvbnRlbnRfY2hhbmdlX3Np
-        bmNlIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
-        bWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsInJlcG9zaXRvcnkiOm51bGws
-        InB1YmxpY2F0aW9uIjpudWxsLCJjaGVja3BvaW50IjpmYWxzZX1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
+        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1k
+        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9kZWJpYW5fcHVscF9yYWduYXJva19sYWJlbC8i
+        LCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vMDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThk
+        M2JkMTdhLyIsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJkZWJpYW5fcHVs
+        cF9yYWduYXJvayIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjpu
+        dWxsLCJjaGVja3BvaW50IjpmYWxzZX1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/019c4ecd-aab1-7b21-8b67-f945123b5537/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/019caf0b-8c63-7902-ad62-373a02880eda/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3920,7 +4108,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3940,20 +4128,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 48dd864c1c9241318765ad8b4386d2c5
+      - cfff10f58b4b4cbb96b24bd5cd87028d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWFlYzctNzkw
-        NC1iODdlLTdmYTIwMDE3YTE4NC8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLThmYmEtN2E1
+        Yy1hMjJiLTQ4OGY1ZTA3ZjEyMS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3974,7 +4162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3994,20 +4182,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 21d9af0368b24f388f89a2d0b96bbd6b
+      - 9e03b6ea15f14d1dabdfefba54f65ecf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-aec7-7904-b87e-7fa20017a184/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-8fba-7a5c-a22b-488f5e07f121/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4015,7 +4203,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -4028,7 +4216,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:48 GMT
+      - Mon, 02 Mar 2026 14:54:56 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4048,31 +4236,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 79d77ba4ab2640bba16f0cbd638c1c7f
+      - 41495de3777c410da4a2e7289a711506
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYWVj
-        Ny03OTA0LWI4N2UtN2ZhMjAwMTdhMTg0LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYWVjNy03OTA0LWI4N2UtN2ZhMjAwMTdhMTg0IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0OC40MjU4MDNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ4LjQyMzk1OVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItOGZi
+        YS03YTVjLWEyMmItNDg4ZjVlMDdmMTIxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItOGZiYS03YTVjLWEyMmItNDg4ZjVlMDdmMTIxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo1Ni40NDQ4MDdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjU2LjQ0MjkzMVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjQ4ZGQ4
-        NjRjMWM5MjQxMzE4NzY1YWQ4YjQzODZkMmM1IiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjM6NDguNDQ1NzE1WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ4LjQ1Njk3MloiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDguNDc2OTkxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGws
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImNmZmYx
+        MGY1OGI0YjRjYmI5NmIyNGJkNWNkODcwMjhkIiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTQ6NTYuNDUzMDU5WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjU2LjQ1NDIyMFoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NTYuNDY5MjQ3WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGws
         InBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3Jv
         dXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291
-        cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjow
-        ZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDA6ZGlzdHJpYnV0
-        aW9ucyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MGQyNjExYzMtMjA2Yy00
-        MDE2LWJiNTctYzRiMDU5ZTFkYzQwIl19
-  recorded_at: Wed, 11 Feb 2026 22:23:48 GMT
-recorded_with: VCR 6.4.0
+        cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjo5
+        OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmE6ZGlzdHJpYnV0
+        aW9ucyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46OTk5ODhiYTgtN2IxYS00
+        MGI5LWE2MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:54:56 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/deb/index_on_sync.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/deb/index_on_sync.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -10,7 +10,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -23,7 +23,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -35,7 +35,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '5960'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -43,151 +43,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 1f23ee5f88804833a18a4dd2909cb2a9
+      - 6b8536ceb0a24b11a25d57ab9dc24963
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ2LjkyODE1NFoiLCJu
-        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
-        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
-        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
-        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
-        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
-        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
-        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
-        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
-        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
-        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
-        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
-        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
-        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
-        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
-        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
-        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
-        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
-        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
-        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
-        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
-        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
-        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
-        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
-        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
-        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
-        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
-        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
-        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
-        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
-        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
-        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
-        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
-        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
-        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
-        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
-        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
-        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
-        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
-        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
-        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
-        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
-        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
-        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
-        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
-        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
-        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
-        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
-        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
-        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
-        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
-        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
-        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
-        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
-        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
-        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
-        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
-        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
-        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
-        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
-        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
-        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
-        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
-        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
-        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
-        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
-        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
-        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
-        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
-        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
-        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
-        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
-        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
-        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
-        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
-        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
-        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
-        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
-        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
-        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
-        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
-        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
-        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
-        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
-        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
-        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
-        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
-        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
-        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
-        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
-        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
-        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
-        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
-        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
-        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
-        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
-        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
-        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
-        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
-        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
-        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
-        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
-        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
-        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
-        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
-        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
-        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
-        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
-        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
-        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
-        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
-        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
-        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
-        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
-        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
-        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
-        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -208,7 +77,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -228,20 +97,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 03c8e67b99d84693a4830b478454a273
+      - 3b6738f53e704bcdb431a839356018a6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -262,7 +131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -282,20 +151,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3f94e54356834ec2adfb634640a389ec
+      - 8ec18ec4b89344e4b7a61c3c1279ff35
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -316,7 +185,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -336,20 +205,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5dc5d92bb8c847719082f1d763af1548
+      - f843a79781444934900a9ff2e579f999
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -370,7 +239,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -390,20 +259,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a23b41e5b006427db92a8c13948b1937
+      - 520a4202cd394be7acd96a2d73a07929
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -411,7 +280,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -424,7 +293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -436,7 +305,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '5960'
+      - '52'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -444,151 +313,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 4b809e28a4a3480e9ba430d3c71b86bf
+      - c3654d4fb4874ffba35aa197705c900d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ2LjkyODE1NFoiLCJu
-        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
-        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
-        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
-        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
-        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
-        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
-        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
-        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
-        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
-        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
-        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
-        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
-        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
-        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
-        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
-        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
-        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
-        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
-        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
-        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
-        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
-        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
-        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
-        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
-        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
-        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
-        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
-        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
-        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
-        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
-        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
-        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
-        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
-        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
-        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
-        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
-        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
-        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
-        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
-        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
-        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
-        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
-        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
-        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
-        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
-        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
-        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
-        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
-        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
-        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
-        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
-        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
-        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
-        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
-        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
-        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
-        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
-        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
-        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
-        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
-        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
-        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
-        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
-        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
-        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
-        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
-        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
-        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
-        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
-        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
-        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
-        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
-        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
-        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
-        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
-        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
-        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
-        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
-        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
-        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
-        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
-        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
-        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
-        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
-        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
-        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
-        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
-        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
-        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
-        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
-        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
-        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
-        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
-        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
-        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
-        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
-        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
-        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
-        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
-        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
-        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
-        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
-        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
-        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
-        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
-        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
-        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
-        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
-        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
-        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
-        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
-        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
-        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
-        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
-        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
-        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -609,7 +347,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -629,20 +367,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - d14688475b8144b1b9ec90c23dd93962
+      - 86620dc1fdc34942a670fa393b9d5b58
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -663,7 +401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:41 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -683,20 +421,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 90ccbb589ec9466e96baa96c91b8ad3b
+      - 9a0fca73b85b4fd1b0b477a57c17b3cf
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:41 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -717,7 +455,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -737,20 +475,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - eef7f3627907490b8f507ff7cf15c686
+      - 1d9e5cf0c5de437db2e2771b969c6c2d
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:42 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -771,7 +509,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -791,20 +529,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3b7af555f15c45be9fb1aeecd9a1bceb
+      - 43b11faa0ee946c48bba57f486cb60cb
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:42 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
@@ -836,13 +574,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/remotes/deb/apt/019c4ecd-b3b8-76ab-a31f-c696ea500d37/"
+      - "/pulp/api/v3/remotes/deb/apt/019caf0b-5815-7887-8394-47970fc6f06c/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -858,20 +596,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2a8b3dfaecc34746bff461efa2b75778
+      - 4be68e943b5646cfa756ebd9a7f72c96
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAx
-        OWM0ZWNkLWIzYjgtNzZhYi1hMzFmLWM2OTZlYTUwMGQzNy8iLCJwcm4iOiJw
-        cm46ZGViLmFwdHJlbW90ZTowMTljNGVjZC1iM2I4LTc2YWItYTMxZi1jNjk2
-        ZWE1MDBkMzciLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ5
-        LjY4ODYwNFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDItMTFUMjI6
-        MjM6NDkuNjg4NjIxWiIsIm5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIs
+        OWNhZjBiLTU4MTUtNzg4Ny04Mzk0LTQ3OTcwZmM2ZjA2Yy8iLCJwcm4iOiJw
+        cm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi01ODE1LTc4ODctODM5NC00Nzk3
+        MGZjNmYwNmMiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQy
+        LjE5Nzg1M1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6
+        NTQ6NDIuMTk3ODYyWiIsIm5hbWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIs
         InVybCI6Imh0dHBzOi8vZml4dHVyZXMucHVscHByb2plY3Qub3JnL2RlYmlh
         bi8iLCJjYV9jZXJ0IjpudWxsLCJjbGllbnRfY2VydCI6bnVsbCwidGxzX3Zh
         bGlkYXRpb24iOnRydWUsInByb3h5X3VybCI6bnVsbCwicHVscF9sYWJlbHMi
@@ -889,10 +627,10 @@ http_interactions:
         ZmFsc2UsInN5bmNfdWRlYnMiOmZhbHNlLCJzeW5jX2luc3RhbGxlciI6ZmFs
         c2UsImdwZ2tleSI6bnVsbCwiaWdub3JlX21pc3NpbmdfcGFja2FnZV9pbmRp
         Y2VzIjpmYWxzZX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:42 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/
     body:
       encoding: UTF-8
       base64_string: 'eyJuYW1lIjoiZGViaWFuX3B1bHBfcmFnbmFyb2sifQ==
@@ -915,13 +653,13 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:49 GMT
+      - Mon, 02 Mar 2026 14:54:42 GMT
       Server:
       - gunicorn
       Content-Type:
       - application/json
       Location:
-      - "/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/"
+      - "/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/"
       Vary:
       - Accept,Cookie
       Allow:
@@ -937,38 +675,38 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - a6384de86b1e407b9e615eae7f2d1416
+      - 95ef7b912ecd4be78960b61a514fc8e8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNkLyIsInBy
-        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljNGVjZC1iNDk1LTczZWIt
-        OTMyYy1kNWQ1ODk0NTZmM2QiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ5LjkwOTkzN1oiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
-        MDItMTFUMjI6MjM6NDkuOTE1MTU1WiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
-        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2QtYjQ5NS03
-        M2ViLTkzMmMtZDVkNTg5NDU2ZjNkL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
+        cHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZjMTkxLyIsInBy
+        biI6InBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi01OGRkLTc1NDQt
+        YjFjMS1kYmY0ZDU5NmMxOTEiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQyLjM5ODk2OVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NDIuNDA3MTAwWiIsInZlcnNpb25zX2hyZWYiOiIvcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItNThkZC03
+        NTQ0LWIxYzEtZGJmNGQ1OTZjMTkxL3ZlcnNpb25zLyIsInB1bHBfbGFiZWxz
         Ijp7fSwibGF0ZXN0X3ZlcnNpb25faHJlZiI6Ii9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1
-        ODk0NTZmM2QvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZGViaWFuX3B1bHBfcmFn
+        c2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi01OGRkLTc1NDQtYjFjMS1kYmY0
+        ZDU5NmMxOTEvdmVyc2lvbnMvMC8iLCJuYW1lIjoiZGViaWFuX3B1bHBfcmFn
         bmFyb2siLCJkZXNjcmlwdGlvbiI6bnVsbCwicmV0YWluX3JlcG9fdmVyc2lv
         bnMiOm51bGwsInJlbW90ZSI6bnVsbCwicHVibGlzaF91cHN0cmVhbV9yZWxl
         YXNlX2ZpZWxkcyI6dHJ1ZSwic2lnbmluZ19zZXJ2aWNlIjpudWxsLCJzaWdu
         aW5nX3NlcnZpY2VfcmVsZWFzZV9vdmVycmlkZXMiOnt9fQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:49 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:42 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/release_components/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5IjoiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC8iLCJj
+        YXB0LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS8iLCJj
         b21wb25lbnQiOiJlbXB0eSIsImRpc3RyaWJ1dGlvbiI6ImthdGVsbG8ifQ==
     headers:
       Content-Type:
@@ -987,7 +725,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:50 GMT
+      - Mon, 02 Mar 2026 14:54:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1007,20 +745,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - cfa081172c67449a9f58e31292aff7a2
+      - 2fd24560f5b4492d990d7100bb99d04c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWI1MDktNzU1
-        NC04YWE0LTFlY2I0OGY0YTlmYS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:50 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTU5NDctNzgx
+        YS1iOTZhLWE3ZmM1OTFhYWYxYy8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:42 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-b509-7554-8aa4-1ecb48f4a9fa/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-5947-781a-b96a-a7fc591aaf1c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1028,7 +766,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1041,7 +779,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:50 GMT
+      - Mon, 02 Mar 2026 14:54:42 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1061,41 +799,41 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9e646cdd7f4e463ab416802aaf69613c
+      - 66cf6b9132c1472a9e0df37ec474ba5c
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYjUw
-        OS03NTU0LThhYTQtMWVjYjQ4ZjRhOWZhLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYjUwOS03NTU0LThhYTQtMWVjYjQ4ZjRhOWZhIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1MC4wMjc5ODJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjUwLjAyNTk2Mloi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNTk0
+        Ny03ODFhLWI5NmEtYTdmYzU5MWFhZjFjLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNTk0Ny03ODFhLWI5NmEtYTdmYzU5MWFhZjFjIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Mi41MTEwMzRaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQyLjUwNDIzMFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiY2ZhMDgx
-        MTcyYzY3NDQ5YTlmNThlMzEyOTJhZmY3YTIiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMi0x
-        MVQyMjoyMzo1MC4wNDgyNjBaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NTAuMDkwNjc2WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyMzo1MC4zNzAxNTBaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhYjQtNzliYy05NDRiLWMzZGJm
-        MzA5OGI4Zi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiMmZkMjQ1
+        NjBmNWI0NDkyZDk5MGQ3MTAwYmI5OWQwNGMiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NDo0Mi41MjU5OTJaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDIuNTc3Mzk0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NDo0Mi43NjgzMzFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyYTEtNzU4YS04YjFiLTkxOTFj
+        N2U0ZjE3MS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9k
-        ZWIvYXB0LzAxOWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC92
+        ZWIvYXB0LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92
         ZXJzaW9ucy8xLyIsIi9wdWxwL2FwaS92My9jb250ZW50L2RlYi9yZWxlYXNl
-        X2NvbXBvbmVudHMvMDE5YzRlY2QtOTc1YS03ZjkzLTgzYzItN2U4ZjZiYTky
-        NTEyLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
-        YXB0cmVwb3NpdG9yeTowMTljNGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1ODk0
-        NTZmM2QiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYxMWMzLTIwNmMt
-        NDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:50 GMT
+        X2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNjODZjMWNk
+        OTUzLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpkZWIu
+        YXB0cmVwb3NpdG9yeTowMTljYWYwYi01OGRkLTc1NDQtYjFjMS1kYmY0ZDU5
+        NmMxOTEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4YmE4LTdiMWEt
+        NDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:42 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/versions/1/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/versions/1/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1116,7 +854,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:50 GMT
+      - Mon, 02 Mar 2026 14:54:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1136,20 +874,212 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - acccbfcea5524688ab67fec0d7dd230f
+      - a5206d4eb3a84f93a20fbf8d72e8a543
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZC1i
-        NWU0LTcyOWYtYWM3Mi02NmI4NGMyMGFiMGYifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:50 GMT
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi01
+        YTBiLTdmMWMtOTI1YS0xYmJmZjk0ZjJiNGEifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/release_components/?component=empty&distribution=katello&repository_version=/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/versions/1/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '421'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 9a830b391175451bb1d014d3b74ffb62
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9y
+        ZWxlYXNlX2NvbXBvbmVudHMvMDE5Y2FmMGItNWEwNS03NmNiLTk3NmItZTNj
+        ODZjMWNkOTUzLyIsInBybiI6InBybjpkZWIucmVsZWFzZWNvbXBvbmVudDow
+        MTljYWYwYi01YTA1LTc2Y2ItOTc2Yi1lM2M4NmMxY2Q5NTMiLCJwdWxwX2Ny
+        ZWF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQyLjY5NTI5M1oiLCJwdWxwX2xh
+        c3RfdXBkYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDIuNjk1MzA1WiIsInB1
+        bHBfbGFiZWxzIjp7fSwidnVsbl9yZXBvcnQiOm51bGwsImNvbXBvbmVudCI6
+        ImVtcHR5IiwiZGlzdHJpYnV0aW9uIjoia2F0ZWxsbyIsInBsYWluX2NvbXBv
+        bmVudCI6ImVtcHR5In1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:43 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/modify/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJyZW1vdmVfY29udGVudF91bml0cyI6WyIvcHVscC9hcGkvdjMvY29udGVu
+        dC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLzAxOWNhZjBiLTVhMDUtNzZjYi05
+        NzZiLWUzYzg2YzFjZDk1My8iXX0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - POST, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '67'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 021f538202a041d387d7b6d0b5bd063b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTVjNGEtN2Ni
+        YS04NWI4LWVjNjU2OWIyM2E0Yi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:43 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-5c4a-7cba-85b8-ec6569b23a4b/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:43 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '937'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - c69e034bda3b420ca420b9cd99e212d1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNWM0
+        YS03Y2JhLTg1YjgtZWM2NTY5YjIzYTRiLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNWM0YS03Y2JhLTg1YjgtZWM2NTY5YjIzYTRiIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0My4yNzY5MTZaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQzLjI3NDcxMVoi
+        LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
+        a3MucmVwb3NpdG9yeS5hZGRfYW5kX3JlbW92ZSIsImxvZ2dpbmdfY2lkIjoi
+        MDIxZjUzODIwMmEwNDFkMzg3ZDdiNmQwYjViZDA2M2IiLCJjcmVhdGVkX2J5
+        IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
+        Ni0wMy0wMlQxNDo1NDo0My4yODk1ODFaIiwic3RhcnRlZF9hdCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NDMuMzM4MjE3WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
+        My0wMlQxNDo1NDo0My40MDI5MzVaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEyOGMtNzUzYy05N2Zm
+        LTVlOTUwNTFkNmM0Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
+        XSwiY3JlYXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRv
+        cmllcy9kZWIvYXB0LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2
+        YzE5MS92ZXJzaW9ucy8yLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3Jk
+        IjpbInBybjpkZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi01OGRkLTc1NDQt
+        YjFjMS1kYmY0ZDU5NmMxOTEiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5
+        OTg4YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:43 GMT
 - request:
     method: patch
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/019c4ecd-b3b8-76ab-a31f-c696ea500d37/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/019caf0b-5815-7887-8394-47970fc6f06c/
     body:
       encoding: UTF-8
       base64_string: |
@@ -1181,7 +1111,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:51 GMT
+      - Mon, 02 Mar 2026 14:54:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1201,25 +1131,25 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f7990c2a416e4204a0942fd4f051c43d
+      - c797963d8a6c40bf903f972249421e14
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWI5NWUtNzk4
-        NS1iMWI0LWI4ZWNmODNlZDU5Ni8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:51 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTVkMjYtN2Y1
+        NC1iZDkzLTQwZTJjMWM5ZDBiYi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:43 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/sync/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/sync/
     body:
       encoding: UTF-8
       base64_string: |
-        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAxOWM0
-        ZWNkLWIzYjgtNzZhYi1hMzFmLWM2OTZlYTUwMGQzNy8iLCJtaXJyb3IiOnRy
+        eyJyZW1vdGUiOiIvcHVscC9hcGkvdjMvcmVtb3Rlcy9kZWIvYXB0LzAxOWNh
+        ZjBiLTU4MTUtNzg4Ny04Mzk0LTQ3OTcwZmM2ZjA2Yy8iLCJtaXJyb3IiOnRy
         dWUsIm9wdGltaXplIjp0cnVlfQ==
     headers:
       Content-Type:
@@ -1238,7 +1168,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:51 GMT
+      - Mon, 02 Mar 2026 14:54:43 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1258,20 +1188,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 32f1a3d9d7c441de90b495cbd4e19f09
+      - 9898d4d25e884a42aaa1533019d5d868
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWI5ZjgtNzg2
-        YS04Yzg4LTI2ZmI0MmY4ODljOS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:51 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTVlNzMtNzIx
+        NC1hYTg3LTgxYTAxMWNhYmU0Zi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:43 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-b9f8-786a-8c88-26fb42f889c9/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-5e73-7214-aa87-81a011cabe4f/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1279,7 +1209,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1292,7 +1222,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:52 GMT
+      - Mon, 02 Mar 2026 14:54:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1304,7 +1234,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '1621'
+      - '1622'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1312,55 +1242,55 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 2e664a75e31c42f1818dcdfba6b274b2
+      - 7cdeeac47e304412b7a8b34345c4b518
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYjlm
-        OC03ODZhLThjODgtMjZmYjQyZjg4OWM5LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYjlmOC03ODZhLThjODgtMjZmYjQyZjg4OWM5IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1MS4yOTE0NDNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjUxLjI4OTIyNVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNWU3
+        My03MjE0LWFhODctODFhMDExY2FiZTRmLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNWU3My03MjE0LWFhODctODFhMDExY2FiZTRmIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0My44Mjk1NjJaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQzLjgyNzgwN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2RlYi5hcHAudGFz
         a3Muc3luY2hyb25pemluZy5zeW5jaHJvbml6ZSIsImxvZ2dpbmdfY2lkIjoi
-        MzJmMWEzZDlkN2M0NDFkZTkwYjQ5NWNiZDRlMTlmMDkiLCJjcmVhdGVkX2J5
+        OTg5OGQ0ZDI1ZTg4NGE0MmFhYTE1MzMwMTlkNWQ4NjgiLCJjcmVhdGVkX2J5
         IjoiL3B1bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAy
-        Ni0wMi0xMVQyMjoyMzo1MS4zMTExMzdaIiwic3RhcnRlZF9hdCI6IjIwMjYt
-        MDItMTFUMjI6MjM6NTEuMzUwMTY1WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
-        Mi0xMVQyMjoyMzo1Mi42MzU4MTFaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
-        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhOTktN2VjMC05NWUx
-        LTgzYjMwZDRlZGY2Yi8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
+        Ni0wMy0wMlQxNDo1NDo0My44NDg5NTlaIiwic3RhcnRlZF9hdCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NDMuODgwMDUxWiIsImZpbmlzaGVkX2F0IjoiMjAyNi0w
+        My0wMlQxNDo1NDo0Ni43NjQ3NDJaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6
+        Ii9wdWxwL2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYmYtNzRlMC1hN2Ri
+        LWJmZTY3MDIzOGVhOS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFz
         a3MiOltdLCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpb
         eyJtZXNzYWdlIjoiRG93bmxvYWRpbmcgQXJ0aWZhY3RzIiwiY29kZSI6InN5
         bmMuZG93bmxvYWRpbmcuYXJ0aWZhY3RzIiwic3RhdGUiOiJjb21wbGV0ZWQi
-        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6Mywic3VmZml4IjpudWxsfSx7Im1lc3Nh
-        Z2UiOiJVcGRhdGUgUmVsZWFzZUZpbGUgdW5pdHMiLCJjb2RlIjoidXBkYXRl
-        LnJlbGVhc2VfZmlsZSIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51
-        bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiVXBkYXRl
-        IFBhY2thZ2VJbmRleCB1bml0cyIsImNvZGUiOiJ1cGRhdGUucGFja2FnZWlu
-        ZGV4Iiwic3RhdGUiOiJjb21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6
-        Miwic3VmZml4IjpudWxsfSx7Im1lc3NhZ2UiOiJBc3NvY2lhdGluZyBDb250
-        ZW50IiwiY29kZSI6ImFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNv
-        bXBsZXRlZCIsInRvdGFsIjpudWxsLCJkb25lIjoxMywic3VmZml4IjpudWxs
-        fSx7Im1lc3NhZ2UiOiJVbi1Bc3NvY2lhdGluZyBDb250ZW50IiwiY29kZSI6
-        InVuYXNzb2NpYXRpbmcuY29udGVudCIsInN0YXRlIjoiY29tcGxldGVkIiwi
-        dG90YWwiOm51bGwsImRvbmUiOjEsInN1ZmZpeCI6bnVsbH1dLCJjcmVhdGVk
-        X3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNkL3ZlcnNp
-        b25zLzIvIl0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicHJuOmRl
-        Yi5hcHRyZXBvc2l0b3J5OjAxOWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4
-        OTQ1NmYzZCIsInNoYXJlZDpwcm46ZGViLmFwdHJlbW90ZTowMTljNGVjZC1i
-        M2I4LTc2YWItYTMxZi1jNjk2ZWE1MDBkMzciLCJzaGFyZWQ6cHJuOmNvcmUu
-        ZG9tYWluOjBkMjYxMWMzLTIwNmMtNDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJd
-        fQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:52 GMT
+        LCJ0b3RhbCI6bnVsbCwiZG9uZSI6MTIsInN1ZmZpeCI6bnVsbH0seyJtZXNz
+        YWdlIjoiVXBkYXRlIFJlbGVhc2VGaWxlIHVuaXRzIiwiY29kZSI6InVwZGF0
+        ZS5yZWxlYXNlX2ZpbGUiLCJzdGF0ZSI6ImNvbXBsZXRlZCIsInRvdGFsIjpu
+        dWxsLCJkb25lIjoxLCJzdWZmaXgiOm51bGx9LHsibWVzc2FnZSI6IlVwZGF0
+        ZSBQYWNrYWdlSW5kZXggdW5pdHMiLCJjb2RlIjoidXBkYXRlLnBhY2thZ2Vp
+        bmRleCIsInN0YXRlIjoiY29tcGxldGVkIiwidG90YWwiOm51bGwsImRvbmUi
+        OjIsInN1ZmZpeCI6bnVsbH0seyJtZXNzYWdlIjoiQXNzb2NpYXRpbmcgQ29u
+        dGVudCIsImNvZGUiOiJhc3NvY2lhdGluZy5jb250ZW50Iiwic3RhdGUiOiJj
+        b21wbGV0ZWQiLCJ0b3RhbCI6bnVsbCwiZG9uZSI6MTMsInN1ZmZpeCI6bnVs
+        bH0seyJtZXNzYWdlIjoiVW4tQXNzb2NpYXRpbmcgQ29udGVudCIsImNvZGUi
+        OiJ1bmFzc29jaWF0aW5nLmNvbnRlbnQiLCJzdGF0ZSI6ImNvbXBsZXRlZCIs
+        InRvdGFsIjpudWxsLCJkb25lIjowLCJzdWZmaXgiOm51bGx9XSwiY3JlYXRl
+        ZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
+        YXB0LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJz
+        aW9ucy8zLyJdLCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInBybjpk
+        ZWIuYXB0cmVwb3NpdG9yeTowMTljYWYwYi01OGRkLTc1NDQtYjFjMS1kYmY0
+        ZDU5NmMxOTEiLCJzaGFyZWQ6cHJuOmRlYi5hcHRyZW1vdGU6MDE5Y2FmMGIt
+        NTgxNS03ODg3LTgzOTQtNDc5NzBmYzZmMDZjIiwic2hhcmVkOnBybjpjb3Jl
+        LmRvbWFpbjo5OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmEi
+        XX0=
+  recorded_at: Mon, 02 Mar 2026 14:54:46 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/versions/2/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/versions/3/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1381,7 +1311,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:52 GMT
+      - Mon, 02 Mar 2026 14:54:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1401,20 +1331,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 3dd804d847a64d2a883783dba257bc18
+      - 3371fd09942248bfbeca755eb81357d8
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljNGVjZC1i
-        YzM4LTdiY2MtYTU3Mi0xNjFmZmU4NDEyYWEifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:52 GMT
+        eyJwcm4iOiJwcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi02
+        MzNjLTc0ZDQtYThiMS1kNTRmNGUxNzVlYjEifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:46 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/signing-services/?name=katello_deb_sign
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/signing-services/?name=katello_deb_sign
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1422,7 +1352,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1435,7 +1365,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:52 GMT
+      - Mon, 02 Mar 2026 14:54:46 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1455,20 +1385,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5fd13394e42c40769789166e749512c6
+      - d30ff7ab6d7545968cde734df2e2805f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:52 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:46 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/versions/2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1489,7 +1419,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:52 GMT
+      - Mon, 02 Mar 2026 14:54:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1501,7 +1431,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '3417'
+      - '3223'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1509,100 +1439,96 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - b6001f24a90a414c9d1a487bb32e26d4
+      - 52de8d9a333b4b9bb7f5f6a6eccdee53
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9h
-        cHQvMDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNkL3ZlcnNp
-        b25zLzIvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
-        YzRlY2QtYmMzOC03YmNjLWE1NzItMTYxZmZlODQxMmFhIiwicHVscF9jcmVh
-        dGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1MS44NjcxMTRaIiwicHVscF9sYXN0
-        X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjUyLjYyMzE3MFoiLCJudW1i
-        ZXIiOjIsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L2RlYi9hcHQvMDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNk
+        cHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZjMTkxL3ZlcnNp
+        b25zLzMvIiwicHJuIjoicHJuOmNvcmUucmVwb3NpdG9yeXZlcnNpb246MDE5
+        Y2FmMGItNjMzYy03NGQ0LWE4YjEtZDU0ZjRlMTc1ZWIxIiwicHVscF9jcmVh
+        dGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0NS4wNTMyOTRaIiwicHVscF9sYXN0
+        X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ2Ljc1MjY0OFoiLCJudW1i
+        ZXIiOjMsInJlcG9zaXRvcnkiOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
+        L2RlYi9hcHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZjMTkx
         LyIsImJhc2VfdmVyc2lvbiI6bnVsbCwiY29udGVudF9zdW1tYXJ5Ijp7ImFk
         ZGVkIjp7ImRlYi5wYWNrYWdlIjp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAv
         YXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5X3ZlcnNp
         b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
-        OWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC92ZXJzaW9ucy8y
+        OWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJzaW9ucy8z
         LyJ9LCJkZWIucGFja2FnZV9pbmRleCI6eyJjb3VudCI6MiwiaHJlZiI6Ii9w
         dWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX2luZGljZXMvP3JlcG9z
         aXRvcnlfdmVyc2lvbl9hZGRlZD0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVz
-        L2RlYi9hcHQvMDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNk
-        L3ZlcnNpb25zLzIvIn0sImRlYi5wYWNrYWdlX3JlbGVhc2VfY29tcG9uZW50
+        L2RlYi9hcHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZjMTkx
+        L3ZlcnNpb25zLzMvIn0sImRlYi5wYWNrYWdlX3JlbGVhc2VfY29tcG9uZW50
         Ijp7ImNvdW50IjozLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGVi
         L3BhY2thZ2VfcmVsZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNp
         b25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
-        OWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC92ZXJzaW9ucy8y
+        OWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJzaW9ucy8z
         LyJ9LCJkZWIucmVsZWFzZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2RlYi9yZWxlYXNlcy8/cmVwb3NpdG9yeV92ZXJzaW9u
         X2FkZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTlj
-        NGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1ODk0NTZmM2QvdmVyc2lvbnMvMi8i
+        YWYwYi01OGRkLTc1NDQtYjFjMS1kYmY0ZDU5NmMxOTEvdmVyc2lvbnMvMy8i
         fSwiZGViLnJlbGVhc2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50IjoyLCJocmVm
         IjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJjaGl0ZWN0
         dXJlcy8/cmVwb3NpdG9yeV92ZXJzaW9uX2FkZGVkPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC1iNDk1LTczZWItOTMyYy1k
-        NWQ1ODk0NTZmM2QvdmVyc2lvbnMvMi8ifSwiZGViLnJlbGVhc2VfY29tcG9u
+        ZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi01OGRkLTc1NDQtYjFjMS1k
+        YmY0ZDU5NmMxOTEvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVhc2VfY29tcG9u
         ZW50Ijp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQv
         ZGViL3JlbGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uX2Fk
-        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVj
-        ZC1iNDk1LTczZWItOTMyYy1kNWQ1ODk0NTZmM2QvdmVyc2lvbnMvMi8ifSwi
+        ZGVkPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYw
+        Yi01OGRkLTc1NDQtYjFjMS1kYmY0ZDU5NmMxOTEvdmVyc2lvbnMvMy8ifSwi
         ZGViLnJlbGVhc2VfZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2Fw
         aS92My9jb250ZW50L2RlYi9yZWxlYXNlX2ZpbGVzLz9yZXBvc2l0b3J5X3Zl
         cnNpb25fYWRkZWQ9L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
-        LzAxOWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC92ZXJzaW9u
-        cy8yLyJ9fSwicmVtb3ZlZCI6eyJkZWIucmVsZWFzZV9jb21wb25lbnQiOnsi
-        Y291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVs
-        ZWFzZV9jb21wb25lbnRzLz9yZXBvc2l0b3J5X3ZlcnNpb25fcmVtb3ZlZD0v
-        cHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2QtYjQ5
-        NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNkL3ZlcnNpb25zLzIvIn19LCJwcmVz
-        ZW50Ijp7ImRlYi5yZWxlYXNlX2ZpbGUiOnsiY291bnQiOjEsImhyZWYiOiIv
-        cHVscC9hcGkvdjMvY29udGVudC9kZWIvcmVsZWFzZV9maWxlcy8/cmVwb3Np
-        dG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2Fw
-        dC8wMTljNGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1ODk0NTZmM2QvdmVyc2lv
-        bnMvMi8ifSwiZGViLnJlbGVhc2VfYXJjaGl0ZWN0dXJlIjp7ImNvdW50Ijoy
-        LCJocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VfYXJj
-        aGl0ZWN0dXJlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9y
-        ZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC1iNDk1LTczZWItOTMyYy1k
-        NWQ1ODk0NTZmM2QvdmVyc2lvbnMvMi8ifSwiZGViLnBhY2thZ2VfaW5kZXgi
-        OnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIv
-        cGFja2FnZV9pbmRpY2VzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAvYXBp
-        L3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWM0ZWNkLWI0OTUtNzNlYi05
-        MzJjLWQ1ZDU4OTQ1NmYzZC92ZXJzaW9ucy8yLyJ9LCJkZWIucGFja2FnZSI6
-        eyJjb3VudCI6MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
-        YWNrYWdlcy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2FwaS92My9yZXBv
-        c2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1
-        ODk0NTZmM2QvdmVyc2lvbnMvMi8ifSwiZGViLnBhY2thZ2VfcmVsZWFzZV9j
-        b21wb25lbnQiOnsiY291bnQiOjMsImhyZWYiOiIvcHVscC9hcGkvdjMvY29u
-        dGVudC9kZWIvcGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudHMvP3JlcG9zaXRv
-        cnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQv
-        MDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNkL3ZlcnNpb25z
-        LzIvIn0sImRlYi5yZWxlYXNlIjp7ImNvdW50IjoxLCJocmVmIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnQvZGViL3JlbGVhc2VzLz9yZXBvc2l0b3J5X3ZlcnNp
-        b249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWM0ZWNk
-        LWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC92ZXJzaW9ucy8yLyJ9LCJk
-        ZWIucmVsZWFzZV9jb21wb25lbnQiOnsiY291bnQiOjEsImhyZWYiOiIvcHVs
-        cC9hcGkvdjMvY29udGVudC9kZWIvcmVsZWFzZV9jb21wb25lbnRzLz9yZXBv
-        c2l0b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIv
-        YXB0LzAxOWM0ZWNkLWI0OTUtNzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZC92ZXJz
-        aW9ucy8yLyJ9fX0sInZ1bG5fcmVwb3J0IjoiL3B1bHAvYXBpL3YzL3Z1bG5f
-        cmVwb3J0Lz9yZXBvX3ZlcnNpb25zPXBybjpjb3JlLnJlcG9zaXRvcnl2ZXJz
-        aW9uOjAxOWM0ZWNkLWJjMzgtN2JjYy1hNTcyLTE2MWZmZTg0MTJhYSJ9
-  recorded_at: Wed, 11 Feb 2026 22:23:52 GMT
+        LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJzaW9u
+        cy8zLyJ9fSwicmVtb3ZlZCI6e30sInByZXNlbnQiOnsiZGViLnJlbGVhc2Vf
+        ZmlsZSI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50
+        L2RlYi9yZWxlYXNlX2ZpbGVzLz9yZXBvc2l0b3J5X3ZlcnNpb249L3B1bHAv
+        YXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBiLTU4ZGQtNzU0
+        NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJzaW9ucy8zLyJ9LCJkZWIucmVsZWFz
+        ZV9hcmNoaXRlY3R1cmUiOnsiY291bnQiOjIsImhyZWYiOiIvcHVscC9hcGkv
+        djMvY29udGVudC9kZWIvcmVsZWFzZV9hcmNoaXRlY3R1cmVzLz9yZXBvc2l0
+        b3J5X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0
+        LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJzaW9u
+        cy8zLyJ9LCJkZWIucGFja2FnZV9pbmRleCI6eyJjb3VudCI6MiwiaHJlZiI6
+        Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX2luZGljZXMvP3Jl
+        cG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2Rl
+        Yi9hcHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZjMTkxL3Zl
+        cnNpb25zLzMvIn0sImRlYi5wYWNrYWdlIjp7ImNvdW50IjozLCJocmVmIjoi
+        L3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2thZ2VzLz9yZXBvc2l0b3J5
+        X3ZlcnNpb249L3B1bHAvYXBpL3YzL3JlcG9zaXRvcmllcy9kZWIvYXB0LzAx
+        OWNhZjBiLTU4ZGQtNzU0NC1iMWMxLWRiZjRkNTk2YzE5MS92ZXJzaW9ucy8z
+        LyJ9LCJkZWIucGFja2FnZV9yZWxlYXNlX2NvbXBvbmVudCI6eyJjb3VudCI6
+        MywiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlX3Jl
+        bGVhc2VfY29tcG9uZW50cy8/cmVwb3NpdG9yeV92ZXJzaW9uPS9wdWxwL2Fw
+        aS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi01OGRkLTc1NDQt
+        YjFjMS1kYmY0ZDU5NmMxOTEvdmVyc2lvbnMvMy8ifSwiZGViLnJlbGVhc2Ui
+        OnsiY291bnQiOjEsImhyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudC9kZWIv
+        cmVsZWFzZXMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVscC9hcGkvdjMvcmVw
+        b3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJm
+        NGQ1OTZjMTkxL3ZlcnNpb25zLzMvIn0sImRlYi5yZWxlYXNlX2NvbXBvbmVu
+        dCI6eyJjb3VudCI6MSwiaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2Rl
+        Yi9yZWxlYXNlX2NvbXBvbmVudHMvP3JlcG9zaXRvcnlfdmVyc2lvbj0vcHVs
+        cC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGItNThkZC03
+        NTQ0LWIxYzEtZGJmNGQ1OTZjMTkxL3ZlcnNpb25zLzMvIn19fSwidnVsbl9y
+        ZXBvcnQiOiIvcHVscC9hcGkvdjMvdnVsbl9yZXBvcnQvP3JlcG9zaXRvcnlf
+        dmVyc2lvbj1wcm46Y29yZS5yZXBvc2l0b3J5dmVyc2lvbjowMTljYWYwYi02
+        MzNjLTc0ZDQtYThiMS1kNTRmNGUxNzVlYjEifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
         eyJyZXBvc2l0b3J5X3ZlcnNpb24iOiIvcHVscC9hcGkvdjMvcmVwb3NpdG9y
-        aWVzL2RlYi9hcHQvMDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2
-        ZjNkL3ZlcnNpb25zLzIvIiwic2ltcGxlIjpmYWxzZSwic3RydWN0dXJlZCI6
+        aWVzL2RlYi9hcHQvMDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZj
+        MTkxL3ZlcnNpb25zLzMvIiwic2ltcGxlIjpmYWxzZSwic3RydWN0dXJlZCI6
         dHJ1ZX0=
     headers:
       Content-Type:
@@ -1621,7 +1547,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:52 GMT
+      - Mon, 02 Mar 2026 14:54:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1641,20 +1567,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6843c11fd1594925895407f211154cec
+      - 62ee1ad64c9b4aceb42b6b02aecdff33
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWMwOGEtNzQw
-        ZC05OTYxLWIyMjE4NTA1ZmM2Yy8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:52 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTZiOGEtNzkx
+        Zi05MmFkLWUwNjYwM2Q2NTZiNi8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-c08a-740d-9961-b2218505fc6c/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-6b8a-791f-92ad-e06603d656b6/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1662,7 +1588,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1675,7 +1601,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:53 GMT
+      - Mon, 02 Mar 2026 14:54:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1695,39 +1621,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 5a14dbbcd38347c69c20aaed2e32f802
+      - d6ecfa4e211543059c7d67871a110aae
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYzA4
-        YS03NDBkLTk5NjEtYjIyMTg1MDVmYzZjLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYzA4YS03NDBkLTk5NjEtYjIyMTg1MDVmYzZjIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1Mi45NzIzMzdaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjUyLjk3MDU2OFoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNmI4
+        YS03OTFmLTkyYWQtZTA2NjAzZDY1NmI2LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNmI4YS03OTFmLTkyYWQtZTA2NjAzZDY1NmI2IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny4xODExNTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ3LjE3ODkwM1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwX2RlYi5hcHAudGFz
-        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI2ODQzYzEx
-        ZmQxNTk0OTI1ODk1NDA3ZjIxMTE1NGNlYyIsImNyZWF0ZWRfYnkiOiIvcHVs
-        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjUyLjk5NDU4NFoiLCJzdGFydGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyMzo1My4wMzUwMTNaIiwiZmluaXNoZWRfYXQiOiIyMDI2LTAyLTExVDIy
-        OjIzOjUzLjc3MDY1OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
-        YXBpL3YzL3dvcmtlcnMvMDE5YzRlYmMtY2FjOC03OWQ4LTllZTUtNTRkZDEx
-        ZjRiMTYxLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
+        a3MucHVibGlzaGluZy5wdWJsaXNoIiwibG9nZ2luZ19jaWQiOiI2MmVlMWFk
+        NjRjOWI0YWNlYjQyYjZiMDJhZWNkZmYzMyIsImNyZWF0ZWRfYnkiOiIvcHVs
+        cC9hcGkvdjMvdXNlcnMvMS8iLCJ1bmJsb2NrZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQ3LjIwMzA3NFoiLCJzdGFydGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NDo0Ny4yNTE3NjBaIiwiZmluaXNoZWRfYXQiOiIyMDI2LTAzLTAyVDE0
+        OjU0OjQ3LjY3MTI5OVoiLCJlcnJvciI6bnVsbCwid29ya2VyIjoiL3B1bHAv
+        YXBpL3YzL3dvcmtlcnMvMDE5Y2FlMjItYTI4Yy03NTNjLTk3ZmYtNWU5NTA1
+        MWQ2YzRiLyIsInBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10s
         InRhc2tfZ3JvdXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVh
         dGVkX3Jlc291cmNlcyI6WyIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2Rl
-        Yi9hcHQvMDE5YzRlY2QtYzBkZC03Yjg5LTk4YmUtMjk4NDU0Zjc1NWMwLyJd
+        Yi9hcHQvMDE5Y2FmMGItNmJkYS03Y2ZjLTkyYjMtNmU5OWRmOTI0ZDdjLyJd
         LCJyZXNlcnZlZF9yZXNvdXJjZXNfcmVjb3JkIjpbInNoYXJlZDpwcm46ZGVi
-        LmFwdHJlcG9zaXRvcnk6MDE5YzRlY2QtYjQ5NS03M2ViLTkzMmMtZDVkNTg5
-        NDU2ZjNkIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjowZDI2MTFjMy0yMDZj
-        LTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAiXX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:53 GMT
+        LmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGItNThkZC03NTQ0LWIxYzEtZGJmNGQ1
+        OTZjMTkxIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5OTk4OGJhOC03YjFh
+        LTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/019c4ecd-c0dd-7b89-98be-298454f755c0/?fields=prn
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0b-6bda-7cfc-92b3-6e99df924d7c/?fields=prn
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1748,7 +1674,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:53 GMT
+      - Mon, 02 Mar 2026 14:54:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -1768,20 +1694,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 9f6769fccc384a8d87ad86bb8776411f
+      - e80e7e6be9464065b935fb585665eab3
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwcm4iOiJwcm46ZGViLmFwdHB1YmxpY2F0aW9uOjAxOWM0ZWNkLWMwZGQt
-        N2I4OS05OGJlLTI5ODQ1NGY3NTVjMCJ9
-  recorded_at: Wed, 11 Feb 2026 22:23:53 GMT
+        eyJwcm4iOiJwcm46ZGViLmFwdHB1YmxpY2F0aW9uOjAxOWNhZjBiLTZiZGEt
+        N2NmYy05MmIzLTZlOTlkZjkyNGQ3YyJ9
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -1789,7 +1715,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -1802,995 +1728,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '5960'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 2cb19dcec58245fbb30dfc1b82e9d277
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjQ2LjkyODE1NFoiLCJu
-        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
-        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
-        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
-        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
-        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
-        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
-        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
-        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
-        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
-        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
-        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
-        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
-        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
-        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
-        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
-        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
-        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
-        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
-        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
-        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
-        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
-        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
-        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
-        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
-        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
-        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
-        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
-        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
-        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
-        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
-        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
-        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
-        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
-        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
-        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
-        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
-        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
-        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
-        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
-        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
-        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
-        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
-        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
-        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
-        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
-        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
-        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
-        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
-        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
-        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
-        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
-        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
-        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
-        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
-        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
-        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
-        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
-        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
-        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
-        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
-        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
-        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
-        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
-        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
-        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
-        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
-        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
-        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
-        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
-        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
-        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
-        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
-        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
-        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
-        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
-        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
-        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
-        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
-        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
-        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
-        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
-        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
-        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
-        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
-        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
-        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
-        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
-        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
-        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
-        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
-        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
-        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
-        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
-        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
-        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
-        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
-        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
-        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
-        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
-        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
-        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
-        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
-        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
-        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
-        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
-        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
-        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
-        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
-        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
-        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
-        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
-        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
-        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
-        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
-        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
-        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
-- request:
-    method: patch
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/019c4ec2-4a0a-72a6-a0f7-8caff5c2dd3f/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
-        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
-        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
-        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
-        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
-        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
-        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
-        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
-        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
-        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
-        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
-        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
-        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
-        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
-        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
-        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
-        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
-        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
-        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
-        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
-        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
-        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
-        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
-        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
-        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
-        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
-        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
-        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
-        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
-        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
-        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
-        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
-        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
-        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
-        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
-        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
-        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
-        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
-        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
-        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
-        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
-        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
-        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
-        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
-        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
-        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
-        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
-        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
-        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
-        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
-        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
-        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
-        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
-        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
-        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
-        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
-        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
-        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
-        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
-        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
-        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
-        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
-        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
-        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
-        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
-        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
-        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
-        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
-        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
-        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
-        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
-        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
-        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
-        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
-        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
-        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
-        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
-        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
-        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
-        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
-        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
-        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
-        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
-        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
-        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
-        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
-        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
-        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
-        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
-        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
-        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
-        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
-        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
-        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
-        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
-        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
-        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
-        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
-        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
-        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
-        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
-        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
-        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
-        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
-        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
-        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
-        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
-        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
-        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
-        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
-        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
-        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
-        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
-        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
-        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
-        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
-        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
-        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
-        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '5908'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 581b752c1eea4f588b5ac663fd3b4aea
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMTljNGVjMi00YTBhLTcyYTYtYTBmNy04Y2FmZjVjMmRk
-        M2YvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWM0
-        ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZmNWMyZGQzZiIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjYtMDItMTFUMjI6MTE6MjEuNzM4ODIyWiIsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1NC4xMTU3NDlaIiwibmFtZSI6
-        IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
-        aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
-        aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
-        ICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAgIFNpZ25hdHVyZSBB
-        bGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgIElz
-        c3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1L
-        YXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlcbiAgICAgICAgICAg
-        IE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIwIEdNVFxuICAgICAg
-        ICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUwIDIwMzggR01UXG4g
-        ICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENhcm9saW5hLCBMPVJh
-        bGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQsIENOPWNlbnRvczct
-        ZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVi
-        bGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0
-        aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5
-        OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAg
-        ICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6MDE6MWE6MzM6MTk6
-        MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAgICAgIDhhOjczOmJh
-        OjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1OjgxOmE2OlxuICAgICAg
-        ICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpiZTphMjo5YzpjMjo3
-        Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAgICAgNDQ6NDY6ZWY6
-        ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6MTc6XG4gICAgICAg
-        ICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3
-        OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAgICA5ZTpmMTowZDo2
-        Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpjZjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6
-        ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAgIDU2OjJhOjEwOmIz
-        OjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFlOlxuICAgICAgICAg
-        ICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3YjpiMDo2ZDoxZDo3
-        Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAgNWE6Yjc6MDc6OWI6
-        ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6XG4gICAgICAgICAg
-        ICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2OmFiOjIyOjM0Ojcx
-        OjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2ZTo0YjpjOTo4OTo1
-        OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpcbiAgICAgICAgICAg
-        ICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6
-        OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3OjNkOjlhOjgwOmNj
-        OjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxuICAgICAgICAgICAg
-        ICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5NTpjMDo3Mzo5Njpj
-        NTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6NDg6MjA6YTY6N2Q6
-        ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4gICAgICAgICAgICAg
-        ICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkzOmE4OmI5OjBhOjcz
-        OmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTowZlxuICAgICAgICAg
-        ICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlcbiAgICAgICAgWDUw
-        OXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5djMgQmFzaWMgQ29u
-        c3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJVRVxuICAgICAgICAg
-        ICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBEaWdpdGFs
-        IFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2VydGlmaWNhdGUgU2ln
-        biwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBFeHRlbmRlZCBLZXkg
-        VXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBTZXJ2ZXIgQXV0aGVu
-        dGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRpY2F0aW9uXG4gICAg
-        ICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAgICAgICAgICAgICAg
-        U1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBOZXRzY2FwZSBDb21t
-        ZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NMIFRvb2wgR2VuZXJh
-        dGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5djMgU3ViamVjdCBL
-        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5QjpEMjpEOTo2OTo4
-        ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1
-        RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBLZXkgSWRlbnRpZmll
-        cjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpEOTo2OTo4ODo5OToy
-        QzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAg
-        ICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEv
-        TD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5pdC9DTj1jZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICAgICAgICAgIHNl
-        cmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4gICAgU2lnbmF0dXJl
-        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
-        IDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIwOjdjOmEzOjRiOjEw
-        OmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6
-        MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4gICAgICAgICAxMzo2
-        Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzoxZjowNzo4MDoyYjox
-        ZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcxOjFhOmRhOjg2OmEw
-        OjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAgICAgMTc6MmY6MGU6
-        OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6
-        XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2NTpmMzo2MDpjYzo1
-        ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5OjNjOjk5OjhhOjQ0
-        OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0OmM1OjIzOlxuICAg
-        ICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6
-        NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpkMDpmMzozZTo4ODo3
-        ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0ODpcbiAgICAgICAg
-        IDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5OmU0OjYwOjdhOjMy
-        OmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6
-        YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4gICAgICAgICBhNzo1
-        MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MTozYjpiNzplMzoxYjph
-        ODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIxOmNkOmM1OmFlOmRl
-        OjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAgICAgODg6ZWY6ZTM6
-        OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6
-        XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FU
-        RS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2SEZ1SmFONE1BMEdD
-        U3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFHRXdKVlV6RVhNQlVH
-        QTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhi
-        R1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNN
-        QzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENCalpXNTBiM00zTFdS
-        bGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQTFNRGN4
-        XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlHTE1Rc3dDUVlEVlFR
-        R0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1EyRnliMnhwYm1FeEVE
-        QU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFvTUIwdGhkR1ZzXG5i
-        Rzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEVlFRRERD
-        QmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZi
-        VENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DXG5nZ0VC
-        QUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5pWXhnNVlHbTZFMldY
-        UWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJYelpjWDF6L25aLzZw
-        S3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBhOTJtXG5qZ21aVmpu
-        ZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVGVEtMQXZudXdiUjE4
-        Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15Z0MxYXJJalJ4VDNt
-        L2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpYXG5PdUJaanJOcWx6
-        MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hPV3hmdDNvRWdncG4z
-        MHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4LzNBUThDQXdFQUFh
-        T0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5Dd1lEVlIwUEJBUURB
-        Z0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFq
-        QVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZSVpJQVliNFFnRU5C
-        Q2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1WlhKaGRHVmtJRU5s
-        Y25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBpSmtzTG5BcnQybDJl
-        bjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFrR0ExVUVCaE1DVlZN
-        eEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVoTVJBd0RnWURWUVFI
-        XG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhSbGJHeHZNUlF3RWdZ
-        RFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0ExVUVBd3dnWTJWdWRH
-        OXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1amIyMkNDUUQ5XG51
-        cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNaGxzeHErdXdy
-        NWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQd29laUtVbEUydGdO
-        TkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29DZm94SWcyXG5vLy9i
-        Rnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VKR1h6WU14ZTdrSy9u
-        and4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1NVFrVGpGWkxCRFdW
-        ZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklBZ1JyXG5uN25hd201
-        bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdzanBISHAxRk9nUW5S
-        OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
-        amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
-        RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, POST, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '5960'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - dde33c24f430436fa406333f15f05949
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
-        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjU0LjExNTc0OVoiLCJu
-        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
-        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
-        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
-        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
-        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
-        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
-        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
-        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
-        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
-        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
-        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
-        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
-        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
-        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
-        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
-        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
-        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
-        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
-        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
-        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
-        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
-        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
-        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
-        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
-        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
-        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
-        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
-        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
-        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
-        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
-        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
-        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
-        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
-        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
-        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
-        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
-        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
-        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
-        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
-        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
-        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
-        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
-        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
-        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
-        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
-        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
-        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
-        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
-        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
-        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
-        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
-        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
-        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
-        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
-        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
-        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
-        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
-        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
-        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
-        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
-        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
-        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
-        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
-        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
-        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
-        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
-        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
-        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
-        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
-        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
-        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
-        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
-        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
-        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
-        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
-        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
-        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
-        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
-        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
-        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
-        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
-        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
-        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
-        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
-        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
-        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
-        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
-        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
-        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
-        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
-        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
-        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
-        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
-        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
-        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
-        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
-        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
-        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
-        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
-        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
-        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
-        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
-        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
-        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
-        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
-        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
-        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
-        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
-        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
-        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
-        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
-        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
-        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
-        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
-        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
-        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
-        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
-        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
-        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
-        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
-        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
-        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
-- request:
-    method: patch
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/019c4ec2-4a0a-72a6-a0f7-8caff5c2dd3f/
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
-        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
-        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
-        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
-        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
-        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
-        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
-        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
-        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
-        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
-        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
-        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
-        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
-        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
-        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
-        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
-        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
-        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
-        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
-        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
-        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
-        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
-        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
-        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
-        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
-        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
-        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
-        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
-        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
-        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
-        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
-        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
-        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
-        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
-        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
-        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
-        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
-        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
-        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
-        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
-        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
-        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
-        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
-        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
-        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
-        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
-        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
-        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
-        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
-        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
-        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
-        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
-        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
-        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
-        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
-        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
-        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
-        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
-        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
-        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
-        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
-        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
-        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
-        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
-        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
-        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
-        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
-        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
-        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
-        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
-        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
-        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
-        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
-        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
-        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
-        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
-        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
-        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
-        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
-        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
-        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
-        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
-        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
-        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
-        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
-        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
-        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
-        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
-        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
-        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
-        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
-        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
-        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
-        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
-        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
-        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
-        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
-        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
-        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
-        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
-        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
-        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
-        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
-        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
-        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
-        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
-        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
-        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
-        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
-        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
-        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
-        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
-        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
-        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
-        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
-        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
-        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
-        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
-        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
-        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
-        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
-        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
-        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
-        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
-      Server:
-      - gunicorn
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept,Cookie
-      Allow:
-      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '5908'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-      Correlation-Id:
-      - 1b9dc61f3f3a454d9b595348f6bb41c6
-      Access-Control-Expose-Headers:
-      - Correlation-ID
-      Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
-    body:
-      encoding: UTF-8
-      base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
-        Z3VhcmQvcmhzbS8wMTljNGVjMi00YTBhLTcyYTYtYTBmNy04Y2FmZjVjMmRk
-        M2YvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWM0
-        ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZmNWMyZGQzZiIsInB1bHBfY3JlYXRl
-        ZCI6IjIwMjYtMDItMTFUMjI6MTE6MjEuNzM4ODIyWiIsInB1bHBfbGFzdF91
-        cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1NC4yNTQyNTNaIiwibmFtZSI6
-        IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
-        aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
-        aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
-        ICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAgIFNpZ25hdHVyZSBB
-        bGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgIElz
-        c3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1L
-        YXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2Ft
-        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlcbiAgICAgICAgICAg
-        IE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIwIEdNVFxuICAgICAg
-        ICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUwIDIwMzggR01UXG4g
-        ICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENhcm9saW5hLCBMPVJh
-        bGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQsIENOPWNlbnRvczct
-        ZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVi
-        bGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0
-        aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5
-        OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAg
-        ICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6MDE6MWE6MzM6MTk6
-        MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAgICAgIDhhOjczOmJh
-        OjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1OjgxOmE2OlxuICAgICAg
-        ICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpiZTphMjo5YzpjMjo3
-        Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAgICAgNDQ6NDY6ZWY6
-        ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6MTc6XG4gICAgICAg
-        ICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3
-        OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAgICA5ZTpmMTowZDo2
-        Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpjZjpcbiAgICAgICAg
-        ICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6
-        ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAgIDU2OjJhOjEwOmIz
-        OjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFlOlxuICAgICAgICAg
-        ICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3YjpiMDo2ZDoxZDo3
-        Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAgNWE6Yjc6MDc6OWI6
-        ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6XG4gICAgICAgICAg
-        ICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2OmFiOjIyOjM0Ojcx
-        OjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2ZTo0YjpjOTo4OTo1
-        OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpcbiAgICAgICAgICAg
-        ICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6
-        OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3OjNkOjlhOjgwOmNj
-        OjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxuICAgICAgICAgICAg
-        ICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5NTpjMDo3Mzo5Njpj
-        NTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6NDg6MjA6YTY6N2Q6
-        ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4gICAgICAgICAgICAg
-        ICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkzOmE4OmI5OjBhOjcz
-        OmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTowZlxuICAgICAgICAg
-        ICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlcbiAgICAgICAgWDUw
-        OXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5djMgQmFzaWMgQ29u
-        c3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJVRVxuICAgICAgICAg
-        ICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBEaWdpdGFs
-        IFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2VydGlmaWNhdGUgU2ln
-        biwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBFeHRlbmRlZCBLZXkg
-        VXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBTZXJ2ZXIgQXV0aGVu
-        dGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRpY2F0aW9uXG4gICAg
-        ICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAgICAgICAgICAgICAg
-        U1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBOZXRzY2FwZSBDb21t
-        ZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NMIFRvb2wgR2VuZXJh
-        dGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5djMgU3ViamVjdCBL
-        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5QjpEMjpEOTo2OTo4
-        ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1
-        RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBLZXkgSWRlbnRpZmll
-        cjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpEOTo2OTo4ODo5OToy
-        QzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAg
-        ICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEv
-        TD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5pdC9DTj1jZW50b3M3
-        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICAgICAgICAgIHNl
-        cmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4gICAgU2lnbmF0dXJl
-        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
-        IDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIwOjdjOmEzOjRiOjEw
-        OmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6
-        MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4gICAgICAgICAxMzo2
-        Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzoxZjowNzo4MDoyYjox
-        ZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcxOjFhOmRhOjg2OmEw
-        OjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAgICAgMTc6MmY6MGU6
-        OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6
-        XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2NTpmMzo2MDpjYzo1
-        ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5OjNjOjk5OjhhOjQ0
-        OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0OmM1OjIzOlxuICAg
-        ICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6
-        NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpkMDpmMzozZTo4ODo3
-        ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0ODpcbiAgICAgICAg
-        IDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5OmU0OjYwOjdhOjMy
-        OmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6
-        YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4gICAgICAgICBhNzo1
-        MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MTozYjpiNzplMzoxYjph
-        ODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIxOmNkOmM1OmFlOmRl
-        OjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAgICAgODg6ZWY6ZTM6
-        OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6
-        XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FU
-        RS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2SEZ1SmFONE1BMEdD
-        U3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFHRXdKVlV6RVhNQlVH
-        QTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhi
-        R1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNN
-        QzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENCalpXNTBiM00zTFdS
-        bGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQTFNRGN4
-        XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlHTE1Rc3dDUVlEVlFR
-        R0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1EyRnliMnhwYm1FeEVE
-        QU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFvTUIwdGhkR1ZzXG5i
-        Rzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEVlFRRERD
-        QmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZi
-        VENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DXG5nZ0VC
-        QUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5pWXhnNVlHbTZFMldY
-        UWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJYelpjWDF6L25aLzZw
-        S3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBhOTJtXG5qZ21aVmpu
-        ZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVGVEtMQXZudXdiUjE4
-        Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15Z0MxYXJJalJ4VDNt
-        L2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpYXG5PdUJaanJOcWx6
-        MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hPV3hmdDNvRWdncG4z
-        MHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4LzNBUThDQXdFQUFh
-        T0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5Dd1lEVlIwUEJBUURB
-        Z0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFq
-        QVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZSVpJQVliNFFnRU5C
-        Q2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1WlhKaGRHVmtJRU5s
-        Y25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBpSmtzTG5BcnQybDJl
-        bjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNiMHRscGlKa3NMbkFy
-        dDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFrR0ExVUVCaE1DVlZN
-        eEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVoTVJBd0RnWURWUVFI
-        XG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhSbGJHeHZNUlF3RWdZ
-        RFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0ExVUVBd3dnWTJWdWRH
-        OXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1amIyMkNDUUQ5XG51
-        cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNaGxzeHErdXdy
-        NWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQd29laUtVbEUydGdO
-        TkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29DZm94SWcyXG5vLy9i
-        Rnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VKR1h6WU14ZTdrSy9u
-        and4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1NVFrVGpGWkxCRFdW
-        ZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklBZ1JyXG5uN25hd201
-        bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdzanBISHAxRk9nUW5S
-        OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
-        amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
-        RklDQVRFLS0tLS0ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
-- request:
-    method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
-    body:
-      encoding: US-ASCII
-      base64_string: ''
-    headers:
-      Content-Type:
-      - application/json
-      User-Agent:
-      - OpenAPI-Generator/3.8.1/ruby
-      Accept:
-      - application/json
-      Authorization:
-      - Basic Og==
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
+      - Mon, 02 Mar 2026 14:54:47 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2810,20 +1748,826 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6065bc67fb164d7f9cc19c3b1cd393b3
+      - cda4474504e5414fa6828ce6d8924e48
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
+- request:
+    method: post
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJuYW1lIjoiUkhTTUNlcnRHdWFyZCIsImNhX2NlcnRpZmljYXRlIjoiQ2Vy
+        dGlmaWNhdGU6XG4gICAgRGF0YTpcbiAgICAgICAgVmVyc2lvbjogMyAoMHgy
+        KVxuICAgICAgICBTZXJpYWwgTnVtYmVyOlxuICAgICAgICAgICAgZmQ6YmE6
+        YmM6NzE6NmU6MjU6YTM6NzhcbiAgICBTaWduYXR1cmUgQWxnb3JpdGhtOiBz
+        aGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAgICAgICBJc3N1ZXI6IEM9VVMs
+        IFNUPU5vcnRoIENhcm9saW5hLCBMPVJhbGVpZ2gsIE89S2F0ZWxsbywgT1U9
+        U29tZU9yZ1VuaXQsIENOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUu
+        Y29tXG4gICAgICAgIFZhbGlkaXR5XG4gICAgICAgICAgICBOb3QgQmVmb3Jl
+        OiBNYXkgIDcgMTQ6MjE6NTAgMjAyMCBHTVRcbiAgICAgICAgICAgIE5vdCBB
+        ZnRlciA6IEphbiAxOCAxNDoyMTo1MCAyMDM4IEdNVFxuICAgICAgICBTdWJq
+        ZWN0OiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdoLCBPPUth
+        dGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVsMi5zYW1p
+        ci5leGFtcGxlLmNvbVxuICAgICAgICBTdWJqZWN0IFB1YmxpYyBLZXkgSW5m
+        bzpcbiAgICAgICAgICAgIFB1YmxpYyBLZXkgQWxnb3JpdGhtOiByc2FFbmNy
+        eXB0aW9uXG4gICAgICAgICAgICAgICAgUHVibGljLUtleTogKDIwNDggYml0
+        KVxuICAgICAgICAgICAgICAgIE1vZHVsdXM6XG4gICAgICAgICAgICAgICAg
+        ICAgIDAwOjlmOmQyOmMxOjEwOmZmOjAxOjFhOjMzOjE5OjBlOjQzOjlkOjgz
+        OmU1OlxuICAgICAgICAgICAgICAgICAgICA4YTo3MzpiYToyZDozYzo2Njpi
+        MTo3ODpjZDo4OTo4Yzo2MDplNTo4MTphNjpcbiAgICAgICAgICAgICAgICAg
+        ICAgZTg6NGQ6OTY6NWQ6MDc6YzM6YmU6YTI6OWM6YzI6N2M6OTQ6MmQ6NmU6
+        NDM6XG4gICAgICAgICAgICAgICAgICAgIDQ0OjQ2OmVmOmZkOjM2OjIwOjQ3
+        OjNiOmQ2OjM1OmZkOjk3OmNkOjk3OjE3OlxuICAgICAgICAgICAgICAgICAg
+        ICBkNzozZjplNzo2NzpmZTphOToyYTpmMTpiYzo0Nzo4Nzo2ZTplZDo2ZDpi
+        NjpcbiAgICAgICAgICAgICAgICAgICAgOWU6ZjE6MGQ6NjM6NTM6YzE6M2Y6
+        ZmQ6MTc6YWI6NWY6MzU6N2E6ODQ6Y2Y6XG4gICAgICAgICAgICAgICAgICAg
+        IDZiOmRkOmE2OjhlOjA5Ojk5OjU2OjM5OmRlOjI5OjZiOmZiOmMyOmRjOjhj
+        OlxuICAgICAgICAgICAgICAgICAgICA1NjoyYToxMDpiMzowYTpjYTpiODo2
+        YzpmYjpiODpjODplYjplNTplMjphZTpcbiAgICAgICAgICAgICAgICAgICAg
+        ZDU6NDE6MDU6NGM6YTI6YzA6YmU6N2I6YjA6NmQ6MWQ6N2M6NjY6ODA6ODg6
+        XG4gICAgICAgICAgICAgICAgICAgIDVhOmI3OjA3OjliOmQzOmI4OmZmOjkz
+        OmYzOjE5OjMzOjYzOjQ4Ojk1OjgzOlxuICAgICAgICAgICAgICAgICAgICAz
+        NDoyNzpjNjphYzpjYzphMDowYjo1NjphYjoyMjozNDo3MTo0Zjo3OTpiZjpc
+        biAgICAgICAgICAgICAgICAgICAgNmU6NGI6Yzk6ODk6NTk6ODc6OGI6N2I6
+        MzU6Nzk6Yjg6MWM6NzA6ZWU6NTg6XG4gICAgICAgICAgICAgICAgICAgIGU2
+        OjdiOjIyOjc5OmE3OjFlOmQ5OmIyOjU3OjNhOmUwOjU5OjhlOmIzOjZhOlxu
+        ICAgICAgICAgICAgICAgICAgICA5NzozZDo5YTo4MDpjYzozYjpkNTo3Nzpk
+        NDpmYTo3YTo1ODo2OTpiNjpiMzpcbiAgICAgICAgICAgICAgICAgICAgYWE6
+        OTU6NTQ6NTU6OWU6MTM6NjU6N2Y6OTU6YzA6NzM6OTY6YzU6ZmI6Nzc6XG4g
+        ICAgICAgICAgICAgICAgICAgIGEwOjQ4OjIwOmE2OjdkOmY0OmM0OmQzOmU5
+        OmFiOjk0OjkzOjRlOjFhOmUyOlxuICAgICAgICAgICAgICAgICAgICA1ZDo5
+        YjpjNTo4Nzo1MDpjNzo1NjpmMDo5MzphODpiOTowYTo3MzpjZjpmNzpcbiAg
+        ICAgICAgICAgICAgICAgICAgMDE6MGZcbiAgICAgICAgICAgICAgICBFeHBv
+        bmVudDogNjU1MzcgKDB4MTAwMDEpXG4gICAgICAgIFg1MDl2MyBleHRlbnNp
+        b25zOlxuICAgICAgICAgICAgWDUwOXYzIEJhc2ljIENvbnN0cmFpbnRzOlxu
+        ICAgICAgICAgICAgICAgIENBOlRSVUVcbiAgICAgICAgICAgIFg1MDl2MyBL
+        ZXkgVXNhZ2U6XG4gICAgICAgICAgICAgICAgRGlnaXRhbCBTaWduYXR1cmUs
+        IEtleSBFbmNpcGhlcm1lbnQsIENlcnRpZmljYXRlIFNpZ24sIENSTCBTaWdu
+        XG4gICAgICAgICAgICBYNTA5djMgRXh0ZW5kZWQgS2V5IFVzYWdlOlxuICAg
+        ICAgICAgICAgICAgIFRMUyBXZWIgU2VydmVyIEF1dGhlbnRpY2F0aW9uLCBU
+        TFMgV2ViIENsaWVudCBBdXRoZW50aWNhdGlvblxuICAgICAgICAgICAgTmV0
+        c2NhcGUgQ2VydCBUeXBlOlxuICAgICAgICAgICAgICAgIFNTTCBTZXJ2ZXIs
+        IFNTTCBDQVxuICAgICAgICAgICAgTmV0c2NhcGUgQ29tbWVudDpcbiAgICAg
+        ICAgICAgICAgICBLYXRlbGxvIFNTTCBUb29sIEdlbmVyYXRlZCBDZXJ0aWZp
+        Y2F0ZVxuICAgICAgICAgICAgWDUwOXYzIFN1YmplY3QgS2V5IElkZW50aWZp
+        ZXI6XG4gICAgICAgICAgICAgICAgOUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6
+        NzA6MkI6Qjc6Njk6NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAg
+        ICAgIFg1MDl2MyBBdXRob3JpdHkgS2V5IElkZW50aWZpZXI6XG4gICAgICAg
+        ICAgICAgICAga2V5aWQ6OUI6RDI6RDk6Njk6ODg6OTk6MkM6MkU6NzA6MkI6
+        Qjc6Njk6NzY6N0E6N0Q6RDE6ODU6NEQ6NTM6NURcbiAgICAgICAgICAgICAg
+        ICBEaXJOYW1lOi9DPVVTL1NUPU5vcnRoIENhcm9saW5hL0w9UmFsZWlnaC9P
+        PUthdGVsbG8vT1U9U29tZU9yZ1VuaXQvQ049Y2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgICAgICAgICBzZXJpYWw6RkQ6QkE6
+        QkM6NzE6NkU6MjU6QTM6NzhcblxuICAgIFNpZ25hdHVyZSBBbGdvcml0aG06
+        IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgICAzMjoxOTo2Yzpj
+        NjphZjphZTpjMjpiZTo2NDoxNjpiMDo3YzphMzo0YjoxMDplODo1YTpiNDpc
+        biAgICAgICAgIDE3Ojc0OmZkOjc1OmM2OjI2OmQyOjg4OjAxOmZlOjk1OjJl
+        OjNmOjBhOjFlOjg4OmE1OjI1OlxuICAgICAgICAgMTM6NmI6NjA6MzQ6ZDA6
+        MmM6ZGU6ZDg6NDg6MTU6ZjU6Y2M6MWY6MDc6ODA6MmI6MWQ6Mjg6XG4gICAg
+        ICAgICA5MDplOTo4Yjo0NzpjMTo3MToxYTpkYTo4NjphMDoyNzplODpjNDo4
+        ODozNjphMzpmZjpkYjpcbiAgICAgICAgIDE3OjJmOjBlOjliOmUxOjM5OmE3
+        OjFmOmRjOjI2Ojk3OjI5OjVlOjRiOjk5OjYwOmZhOjkyOlxuICAgICAgICAg
+        MTI6MjQ6ZmM6YmM6MDQ6OTQ6MjQ6NjU6ZjM6NjA6Y2M6NWU6ZWU6NDI6YmY6
+        OWU6M2M6MzE6XG4gICAgICAgICBiOTozYzo5OTo4YTo0NDozZDoyOTo1ZDph
+        Njo5OTphYTpkNTowZToxNTo5NDpjNDpjNToyMzpcbiAgICAgICAgIDhjOmI5
+        OjZlOmU1OjA5OjEzOjhjOjU2OjRiOjA0OjM1Ojk1Ojc5OjUwOjVjOjIyOjJk
+        OjFmOlxuICAgICAgICAgM2E6Njg6ZDA6ZjM6M2U6ODg6N2Q6Mzg6Mjk6MzI6
+        ZjI6NDc6YjE6MTc6OTk6ZmQ6YTY6NDg6XG4gICAgICAgICAwMjowNDo2Yjo5
+        ZjpiOTpkYTpjMjo2ZTo2NTo5Yjo5OTplNDo2MDo3YTozMjpjZDowMjpmZTpc
+        biAgICAgICAgIDcxOmRhOjE5OmUzOjkzOmJkOmM1OmE3OmEwOjQ2OjllOjI4
+        OmQyOjkxOmFjOjhlOjkxOmM3OlxuICAgICAgICAgYTc6NTE6NGU6ODE6MDk6
+        ZDE6ZjE6Mzk6NWI6MDc6ODc6NDE6M2I6Yjc6ZTM6MWI6YTg6N2U6XG4gICAg
+        ICAgICA1MTo1Mjo0ZTo2NjoyMDpiMTpjZDpjNTphZTpkZToxNzozYTpkNzpj
+        ZTowNzozNzpkODo1ZTpcbiAgICAgICAgIDg4OmVmOmUzOjk0OmMwOjk4OjNl
+        OmMzOjBkOjUxOjQ0OjNkOjUzOjUyOmZmOjVlOjBiOjFiOlxuICAgICAgICAg
+        NWI6NmM6OWI6YTZcbi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLVxuTUlJ
+        RkJ6Q0NBKytnQXdJQkFnSUpBUDI2dkhGdUphTjRNQTBHQ1NxR1NJYjNEUUVC
+        Q3dVQU1JR0xNUXN3Q1FZRFxuVlFRR0V3SlZVekVYTUJVR0ExVUVDQXdPVG05
+        eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01CMUpoYkdWcFxuWjJneEVE
+        QU9CZ05WQkFvTUIwdGhkR1ZzYkc4eEZEQVNCZ05WQkFzTUMxTnZiV1ZQY21k
+        VmJtbDBNU2t3SndZRFxuVlFRRERDQmpaVzUwYjNNM0xXUmxkbVZzTWk1ellX
+        MXBjaTVsZUdGdGNHeGxMbU52YlRBZUZ3MHlNREExTURjeFxuTkRJeE5UQmFG
+        dzB6T0RBeE1UZ3hOREl4TlRCYU1JR0xNUXN3Q1FZRFZRUUdFd0pWVXpFWE1C
+        VUdBMVVFQ0F3T1xuVG05eWRHZ2dRMkZ5YjJ4cGJtRXhFREFPQmdOVkJBY01C
+        MUpoYkdWcFoyZ3hFREFPQmdOVkJBb01CMHRoZEdWc1xuYkc4eEZEQVNCZ05W
+        QkFzTUMxTnZiV1ZQY21kVmJtbDBNU2t3SndZRFZRUUREQ0JqWlc1MGIzTTNM
+        V1JsZG1Wc1xuTWk1ellXMXBjaTVsZUdGdGNHeGxMbU52YlRDQ0FTSXdEUVlK
+        S29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ1xuZ2dFQkFKL1N3UkQvQVJv
+        ekdRNURuWVBsaW5PNkxUeG1zWGpOaVl4ZzVZR202RTJXWFFmRHZxS2N3bnlV
+        TFc1RFxuUkVidi9UWWdSenZXTmYyWHpaY1gxei9uWi82cEt2RzhSNGR1N1cy
+        Mm52RU5ZMVBCUC8wWHExODFlb1RQYTkybVxuamdtWlZqbmVLV3Y3d3R5TVZp
+        b1Fzd3JLdUd6N3VNanI1ZUt1MVVFRlRLTEF2bnV3YlIxOFpvQ0lXcmNIbTlP
+        NFxuLzVQekdUTmpTSldETkNmR3JNeWdDMWFySWpSeFQzbS9ia3ZKaVZtSGkz
+        czFlYmdjY081WTVuc2llYWNlMmJKWFxuT3VCWmpyTnFsejJhZ013NzFYZlUr
+        bnBZYWJhenFwVlVWWjRUWlgrVndIT1d4ZnQzb0VnZ3BuMzB4TlBwcTVTVFxu
+        VGhyaVhadkZoMURIVnZDVHFMa0tjOC8zQVE4Q0F3RUFBYU9DQVdvd2dnRm1N
+        QXdHQTFVZEV3UUZNQU1CQWY4d1xuQ3dZRFZSMFBCQVFEQWdHbU1CMEdBMVVk
+        SlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakFSQmdsZ1xuaGtn
+        Qmh2aENBUUVFQkFNQ0FrUXdOUVlKWUlaSUFZYjRRZ0VOQkNnV0prdGhkR1Zz
+        Ykc4Z1UxTk1JRlJ2YjJ3Z1xuUjJWdVpYSmhkR1ZrSUVObGNuUnBabWxqWVhS
+        bE1CMEdBMVVkRGdRV0JCU2IwdGxwaUprc0xuQXJ0MmwyZW4zUlxuaFUxVFhU
+        Q0J3QVlEVlIwakJJRzRNSUcxZ0JTYjB0bHBpSmtzTG5BcnQybDJlbjNSaFUx
+        VFhhR0JrYVNCampDQlxuaXpFTE1Ba0dBMVVFQmhNQ1ZWTXhGekFWQmdOVkJB
+        Z01EazV2Y25Sb0lFTmhjbTlzYVc1aE1SQXdEZ1lEVlFRSFxuREFkU1lXeGxh
+        V2RvTVJBd0RnWURWUVFLREFkTFlYUmxiR3h2TVJRd0VnWURWUVFMREF0VGIy
+        MWxUM0puVlc1cFxuZERFcE1DY0dBMVVFQXd3Z1kyVnVkRzl6Tnkxa1pYWmxi
+        REl1YzJGdGFYSXVaWGhoYlhCc1pTNWpiMjJDQ1FEOVxudXJ4eGJpV2plREFO
+        QmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBTWhsc3hxK3V3cjVrRnJCOG8wc1E2
+        RnEwRjNUOVxuZGNZbTBvZ0IvcFV1UHdvZWlLVWxFMnRnTk5BczN0aElGZlhN
+        SHdlQUt4MG9rT21MUjhGeEd0cUdvQ2ZveElnMlxuby8vYkZ5OE9tK0U1cHgv
+        Y0pwY3BYa3VaWVBxU0VpVDh2QVNVSkdYellNeGU3a0svbmp3eHVUeVppa1E5
+        S1YybVxubWFyVkRoV1V4TVVqakxsdTVRa1RqRlpMQkRXVmVWQmNJaTBmT21q
+        UTh6NklmVGdwTXZKSHNSZVovYVpJQWdSclxubjduYXdtNWxtNW5rWUhveXpR
+        TCtjZG9aNDVPOXhhZWdScDRvMHBHc2pwSEhwMUZPZ1FuUjhUbGJCNGRCTzdm
+        alxuRzZoK1VWSk9aaUN4emNXdTNoYzYxODRITjloZWlPL2psTUNZUHNNTlVV
+        UTlVMUwvWGdzYlcyeWJwZz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
+        XG4ifQ==
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Location:
+      - "/pulp/api/v3/contentguards/certguard/rhsm/019caf0b-6e6d-7a7e-aac1-237e8d3bd17a/"
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5908'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 10b13df00f514ea19d181b3c9453e4c1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
+        Z3VhcmQvcmhzbS8wMTljYWYwYi02ZTZkLTdhN2UtYWFjMS0yMzdlOGQzYmQx
+        N2EvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWNh
+        ZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3YSIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDcuOTE3NzMzWiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3NDBaIiwibmFtZSI6
+        IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
+        aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
+        aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
+        ICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAgIFNpZ25hdHVyZSBB
+        bGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgIElz
+        c3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1L
+        YXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlcbiAgICAgICAgICAg
+        IE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIwIEdNVFxuICAgICAg
+        ICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUwIDIwMzggR01UXG4g
+        ICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENhcm9saW5hLCBMPVJh
+        bGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQsIENOPWNlbnRvczct
+        ZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVi
+        bGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0
+        aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5
+        OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAg
+        ICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6MDE6MWE6MzM6MTk6
+        MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAgICAgIDhhOjczOmJh
+        OjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1OjgxOmE2OlxuICAgICAg
+        ICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpiZTphMjo5YzpjMjo3
+        Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAgICAgNDQ6NDY6ZWY6
+        ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6MTc6XG4gICAgICAg
+        ICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3
+        OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAgICA5ZTpmMTowZDo2
+        Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpjZjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6
+        ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAgIDU2OjJhOjEwOmIz
+        OjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFlOlxuICAgICAgICAg
+        ICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3YjpiMDo2ZDoxZDo3
+        Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAgNWE6Yjc6MDc6OWI6
+        ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6XG4gICAgICAgICAg
+        ICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2OmFiOjIyOjM0Ojcx
+        OjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2ZTo0YjpjOTo4OTo1
+        OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpcbiAgICAgICAgICAg
+        ICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6
+        OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3OjNkOjlhOjgwOmNj
+        OjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxuICAgICAgICAgICAg
+        ICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5NTpjMDo3Mzo5Njpj
+        NTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6NDg6MjA6YTY6N2Q6
+        ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4gICAgICAgICAgICAg
+        ICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkzOmE4OmI5OjBhOjcz
+        OmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTowZlxuICAgICAgICAg
+        ICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlcbiAgICAgICAgWDUw
+        OXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5djMgQmFzaWMgQ29u
+        c3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJVRVxuICAgICAgICAg
+        ICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBEaWdpdGFs
+        IFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2VydGlmaWNhdGUgU2ln
+        biwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBFeHRlbmRlZCBLZXkg
+        VXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBTZXJ2ZXIgQXV0aGVu
+        dGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRpY2F0aW9uXG4gICAg
+        ICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAgICAgICAgICAgICAg
+        U1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBOZXRzY2FwZSBDb21t
+        ZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NMIFRvb2wgR2VuZXJh
+        dGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5djMgU3ViamVjdCBL
+        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5QjpEMjpEOTo2OTo4
+        ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1
+        RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBLZXkgSWRlbnRpZmll
+        cjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpEOTo2OTo4ODo5OToy
+        QzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAg
+        ICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEv
+        TD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5pdC9DTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICAgICAgICAgIHNl
+        cmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4gICAgU2lnbmF0dXJl
+        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
+        IDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIwOjdjOmEzOjRiOjEw
+        OmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6
+        MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4gICAgICAgICAxMzo2
+        Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzoxZjowNzo4MDoyYjox
+        ZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcxOjFhOmRhOjg2OmEw
+        OjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAgICAgMTc6MmY6MGU6
+        OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6
+        XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2NTpmMzo2MDpjYzo1
+        ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5OjNjOjk5OjhhOjQ0
+        OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0OmM1OjIzOlxuICAg
+        ICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6
+        NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpkMDpmMzozZTo4ODo3
+        ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0ODpcbiAgICAgICAg
+        IDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5OmU0OjYwOjdhOjMy
+        OmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6
+        YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4gICAgICAgICBhNzo1
+        MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MTozYjpiNzplMzoxYjph
+        ODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIxOmNkOmM1OmFlOmRl
+        OjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAgICAgODg6ZWY6ZTM6
+        OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6
+        XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FU
+        RS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2SEZ1SmFONE1BMEdD
+        U3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFHRXdKVlV6RVhNQlVH
+        QTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhi
+        R1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNN
+        QzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENCalpXNTBiM00zTFdS
+        bGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQTFNRGN4
+        XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlHTE1Rc3dDUVlEVlFR
+        R0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1EyRnliMnhwYm1FeEVE
+        QU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFvTUIwdGhkR1ZzXG5i
+        Rzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEVlFRRERD
+        QmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZi
+        VENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DXG5nZ0VC
+        QUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5pWXhnNVlHbTZFMldY
+        UWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJYelpjWDF6L25aLzZw
+        S3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBhOTJtXG5qZ21aVmpu
+        ZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVGVEtMQXZudXdiUjE4
+        Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15Z0MxYXJJalJ4VDNt
+        L2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpYXG5PdUJaanJOcWx6
+        MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hPV3hmdDNvRWdncG4z
+        MHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4LzNBUThDQXdFQUFh
+        T0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5Dd1lEVlIwUEJBUURB
+        Z0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFq
+        QVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZSVpJQVliNFFnRU5C
+        Q2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1WlhKaGRHVmtJRU5s
+        Y25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBpSmtzTG5BcnQybDJl
+        bjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFrR0ExVUVCaE1DVlZN
+        eEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVoTVJBd0RnWURWUVFI
+        XG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhSbGJHeHZNUlF3RWdZ
+        RFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0ExVUVBd3dnWTJWdWRH
+        OXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1amIyMkNDUUQ5XG51
+        cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNaGxzeHErdXdy
+        NWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQd29laUtVbEUydGdO
+        TkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29DZm94SWcyXG5vLy9i
+        Rnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VKR1h6WU14ZTdrSy9u
+        and4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1NVFrVGpGWkxCRFdW
+        ZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklBZ1JyXG5uN25hd201
+        bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdzanBISHAxRk9nUW5S
+        OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
+        amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
+        RklDQVRFLS0tLS0ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/publications/deb/apt/019c4ecd-c0dd-7b89-98be-298454f755c0/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/?name=RHSMCertGuard
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:47 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5960'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f3b952a7825b400eaceab2874019afc6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ3LjkxNzc0MFoiLCJu
+        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
+        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
+        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
+        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
+        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
+        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
+        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
+        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
+        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
+        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
+        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
+        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
+        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
+        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
+        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
+        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
+        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
+        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
+        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
+        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
+        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
+        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
+        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
+        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
+        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
+        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
+        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
+        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
+        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
+        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
+        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
+        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
+        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
+        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
+        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
+        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
+        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
+        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
+        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
+        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
+        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
+        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
+        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
+        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
+        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
+        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
+        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
+        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
+        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
+        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
+        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
+        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
+        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
+        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
+        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
+        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
+        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
+        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
+        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
+        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
+        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
+        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
+        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
+        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
+        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
+        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
+        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
+        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
+        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
+        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
+        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
+        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
+        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
+        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
+        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
+        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
+        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
+        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
+        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
+        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
+        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
+        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
+        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
+        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
+        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
+        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
+        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
+        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
+        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
+        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
+        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
+        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
+        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
+        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
+        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
+        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
+        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
+        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
+        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
+        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
+        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
+        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
+        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
+        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
+        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
+        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
+        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
+        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
+        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
+        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
+        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
+        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
+        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
+        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
+        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
+        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
+        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
+        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
+        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
+  recorded_at: Mon, 02 Mar 2026 14:54:47 GMT
+- request:
+    method: patch
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/019caf0b-6e6d-7a7e-aac1-237e8d3bd17a/
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjYV9jZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4g
+        ICAgICAgIFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJl
+        cjpcbiAgICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAg
+        U2lnbmF0dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25c
+        biAgICAgICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1S
+        YWxlaWdoLCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxu
+        ICAgICAgICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAg
+        R01UXG4gICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAg
+        MjAzOCBHTVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fy
+        b2xpbmEsIEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwg
+        Q049Y2VudG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAg
+        U3ViamVjdCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMg
+        S2V5IEFsZ29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAg
+        IFB1YmxpYy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1
+        bHVzOlxuICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjow
+        MToxYTozMzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAg
+        ICAgOGE6NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6
+        YTY6XG4gICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJl
+        OmEyOjljOmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAg
+        ICA0NDo0NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5Nzox
+        NzpcbiAgICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6
+        ZjE6YmM6NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAg
+        IDllOmYxOjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNm
+        OlxuICAgICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1Njoz
+        OTpkZToyOTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAg
+        NTY6MmE6MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6
+        XG4gICAgICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdi
+        OmIwOjZkOjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1
+        YTpiNzowNzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4Mzpc
+        biAgICAgICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6
+        YWI6MjI6MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZl
+        OjRiOmM5Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4Olxu
+        ICAgICAgICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1
+        NzozYTplMDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6
+        M2Q6OWE6ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4g
+        ICAgICAgICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1
+        OmMwOjczOjk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0
+        ODoyMDphNjo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAg
+        ICAgICAgICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6
+        YTg6Yjk6MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBm
+        XG4gICAgICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxu
+        ICAgICAgICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2
+        MyBCYXNpYyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVF
+        XG4gICAgICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAg
+        ICAgIERpZ2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0
+        aWZpY2F0ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4
+        dGVuZGVkIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNl
+        cnZlciBBdXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGlj
+        YXRpb25cbiAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAg
+        ICAgICAgICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5l
+        dHNjYXBlIENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wg
+        VG9vbCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2
+        MyBTdWJqZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlC
+        OkQyOkQ5OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQx
+        Ojg1OjREOjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtl
+        eSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0
+        aCBDYXJvbGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0
+        L0NOPWNlbnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAg
+        ICAgICAgICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAg
+        ICBTaWduYXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlv
+        blxuICAgICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6
+        N2M6YTM6NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpj
+        NjoyNjpkMjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAg
+        ICAgICAgIDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFm
+        OjA3OjgwOjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6
+        MWE6ZGE6ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAg
+        ICAxNzoyZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5
+        OTo2MDpmYTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1
+        OmYzOjYwOmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6
+        M2M6OTk6OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6
+        YzU6MjM6XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0Yjow
+        NDozNTo5NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQw
+        OmYzOjNlOjg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4
+        OlxuICAgICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6
+        ZTQ6NjA6N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5
+        MzpiZDpjNTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAg
+        ICAgICAgIGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNi
+        OmI3OmUzOjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6
+        Y2Q6YzU6YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAg
+        ICA4ODplZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1Mjpm
+        Zjo1ZTowYjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lO
+        IENFUlRJRklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZI
+        RnVKYU40TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdF
+        d0pWVXpFWE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0Jn
+        TlZCQWNNQjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhG
+        REFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0Jq
+        Wlc1MGIzTTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVG
+        dzB5TURBMU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdM
+        TVFzd0NRWURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJG
+        eWIyeHBibUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9N
+        QjB0aGRHVnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNr
+        d0p3WURWUVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVH
+        RnRjR3hsTG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURD
+        Q0FRb0NcbmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZ
+        eGc1WUdtNkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6
+        WmNYMXovblovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5
+        Mm1cbmpnbVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZU
+        S0xBdm51d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXln
+        QzFhcklqUnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhc
+        bk91Qlpqck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9X
+        eGZ0M29FZ2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgv
+        M0FROENBd0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3
+        WURWUjBQQkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdn
+        ckJnRUZCUWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJ
+        WklBWWI0UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVa
+        WEpoZEdWa0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlK
+        a3NMbkFydDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2Iw
+        dGxwaUprc0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtH
+        QTFVRUJoTUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhN
+        UkF3RGdZRFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJs
+        Ykd4dk1SUXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFV
+        RUF3d2dZMlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVq
+        YjIyQ0NRRDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFF
+        QU1obHN4cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3
+        b2VpS1VsRTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nm
+        b3hJZzJcbm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpH
+        WHpZTXhlN2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1
+        UWtUakZaTEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFn
+        UnJcbm43bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3Nq
+        cEhIcDFGT2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2
+        MTg0SE45aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0t
+        LS1FTkQgQ0VSVElGSUNBVEUtLS0tLVxuIn0=
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.12/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5908'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 139ec7079d9844ecbeb743389a6e84ae
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvY29udGVudGd1YXJkcy9jZXJ0
+        Z3VhcmQvcmhzbS8wMTljYWYwYi02ZTZkLTdhN2UtYWFjMS0yMzdlOGQzYmQx
+        N2EvIiwicHJuIjoicHJuOmNlcnRndWFyZC5yaHNtY2VydGd1YXJkOjAxOWNh
+        ZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3YSIsInB1bHBfY3JlYXRl
+        ZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDcuOTE3NzMzWiIsInB1bHBfbGFzdF91
+        cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0OC4wMjI3MjZaIiwibmFtZSI6
+        IlJIU01DZXJ0R3VhcmQiLCJkZXNjcmlwdGlvbiI6bnVsbCwiY2FfY2VydGlm
+        aWNhdGUiOiJDZXJ0aWZpY2F0ZTpcbiAgICBEYXRhOlxuICAgICAgICBWZXJz
+        aW9uOiAzICgweDIpXG4gICAgICAgIFNlcmlhbCBOdW1iZXI6XG4gICAgICAg
+        ICAgICBmZDpiYTpiYzo3MTo2ZToyNTphMzo3OFxuICAgIFNpZ25hdHVyZSBB
+        bGdvcml0aG06IHNoYTI1NldpdGhSU0FFbmNyeXB0aW9uXG4gICAgICAgIElz
+        c3VlcjogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEsIEw9UmFsZWlnaCwgTz1L
+        YXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2VudG9zNy1kZXZlbDIuc2Ft
+        aXIuZXhhbXBsZS5jb21cbiAgICAgICAgVmFsaWRpdHlcbiAgICAgICAgICAg
+        IE5vdCBCZWZvcmU6IE1heSAgNyAxNDoyMTo1MCAyMDIwIEdNVFxuICAgICAg
+        ICAgICAgTm90IEFmdGVyIDogSmFuIDE4IDE0OjIxOjUwIDIwMzggR01UXG4g
+        ICAgICAgIFN1YmplY3Q6IEM9VVMsIFNUPU5vcnRoIENhcm9saW5hLCBMPVJh
+        bGVpZ2gsIE89S2F0ZWxsbywgT1U9U29tZU9yZ1VuaXQsIENOPWNlbnRvczct
+        ZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgIFN1YmplY3QgUHVi
+        bGljIEtleSBJbmZvOlxuICAgICAgICAgICAgUHVibGljIEtleSBBbGdvcml0
+        aG06IHJzYUVuY3J5cHRpb25cbiAgICAgICAgICAgICAgICBQdWJsaWMtS2V5
+        OiAoMjA0OCBiaXQpXG4gICAgICAgICAgICAgICAgTW9kdWx1czpcbiAgICAg
+        ICAgICAgICAgICAgICAgMDA6OWY6ZDI6YzE6MTA6ZmY6MDE6MWE6MzM6MTk6
+        MGU6NDM6OWQ6ODM6ZTU6XG4gICAgICAgICAgICAgICAgICAgIDhhOjczOmJh
+        OjJkOjNjOjY2OmIxOjc4OmNkOjg5OjhjOjYwOmU1OjgxOmE2OlxuICAgICAg
+        ICAgICAgICAgICAgICBlODo0ZDo5Njo1ZDowNzpjMzpiZTphMjo5YzpjMjo3
+        Yzo5NDoyZDo2ZTo0MzpcbiAgICAgICAgICAgICAgICAgICAgNDQ6NDY6ZWY6
+        ZmQ6MzY6MjA6NDc6M2I6ZDY6MzU6ZmQ6OTc6Y2Q6OTc6MTc6XG4gICAgICAg
+        ICAgICAgICAgICAgIGQ3OjNmOmU3OjY3OmZlOmE5OjJhOmYxOmJjOjQ3Ojg3
+        OjZlOmVkOjZkOmI2OlxuICAgICAgICAgICAgICAgICAgICA5ZTpmMTowZDo2
+        Mzo1MzpjMTozZjpmZDoxNzphYjo1ZjozNTo3YTo4NDpjZjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNmI6ZGQ6YTY6OGU6MDk6OTk6NTY6Mzk6ZGU6Mjk6NmI6
+        ZmI6YzI6ZGM6OGM6XG4gICAgICAgICAgICAgICAgICAgIDU2OjJhOjEwOmIz
+        OjBhOmNhOmI4OjZjOmZiOmI4OmM4OmViOmU1OmUyOmFlOlxuICAgICAgICAg
+        ICAgICAgICAgICBkNTo0MTowNTo0YzphMjpjMDpiZTo3YjpiMDo2ZDoxZDo3
+        Yzo2Njo4MDo4ODpcbiAgICAgICAgICAgICAgICAgICAgNWE6Yjc6MDc6OWI6
+        ZDM6Yjg6ZmY6OTM6ZjM6MTk6MzM6NjM6NDg6OTU6ODM6XG4gICAgICAgICAg
+        ICAgICAgICAgIDM0OjI3OmM2OmFjOmNjOmEwOjBiOjU2OmFiOjIyOjM0Ojcx
+        OjRmOjc5OmJmOlxuICAgICAgICAgICAgICAgICAgICA2ZTo0YjpjOTo4OTo1
+        OTo4Nzo4Yjo3YjozNTo3OTpiODoxYzo3MDplZTo1ODpcbiAgICAgICAgICAg
+        ICAgICAgICAgZTY6N2I6MjI6Nzk6YTc6MWU6ZDk6YjI6NTc6M2E6ZTA6NTk6
+        OGU6YjM6NmE6XG4gICAgICAgICAgICAgICAgICAgIDk3OjNkOjlhOjgwOmNj
+        OjNiOmQ1Ojc3OmQ0OmZhOjdhOjU4OjY5OmI2OmIzOlxuICAgICAgICAgICAg
+        ICAgICAgICBhYTo5NTo1NDo1NTo5ZToxMzo2NTo3Zjo5NTpjMDo3Mzo5Njpj
+        NTpmYjo3NzpcbiAgICAgICAgICAgICAgICAgICAgYTA6NDg6MjA6YTY6N2Q6
+        ZjQ6YzQ6ZDM6ZTk6YWI6OTQ6OTM6NGU6MWE6ZTI6XG4gICAgICAgICAgICAg
+        ICAgICAgIDVkOjliOmM1Ojg3OjUwOmM3OjU2OmYwOjkzOmE4OmI5OjBhOjcz
+        OmNmOmY3OlxuICAgICAgICAgICAgICAgICAgICAwMTowZlxuICAgICAgICAg
+        ICAgICAgIEV4cG9uZW50OiA2NTUzNyAoMHgxMDAwMSlcbiAgICAgICAgWDUw
+        OXYzIGV4dGVuc2lvbnM6XG4gICAgICAgICAgICBYNTA5djMgQmFzaWMgQ29u
+        c3RyYWludHM6XG4gICAgICAgICAgICAgICAgQ0E6VFJVRVxuICAgICAgICAg
+        ICAgWDUwOXYzIEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBEaWdpdGFs
+        IFNpZ25hdHVyZSwgS2V5IEVuY2lwaGVybWVudCwgQ2VydGlmaWNhdGUgU2ln
+        biwgQ1JMIFNpZ25cbiAgICAgICAgICAgIFg1MDl2MyBFeHRlbmRlZCBLZXkg
+        VXNhZ2U6XG4gICAgICAgICAgICAgICAgVExTIFdlYiBTZXJ2ZXIgQXV0aGVu
+        dGljYXRpb24sIFRMUyBXZWIgQ2xpZW50IEF1dGhlbnRpY2F0aW9uXG4gICAg
+        ICAgICAgICBOZXRzY2FwZSBDZXJ0IFR5cGU6XG4gICAgICAgICAgICAgICAg
+        U1NMIFNlcnZlciwgU1NMIENBXG4gICAgICAgICAgICBOZXRzY2FwZSBDb21t
+        ZW50OlxuICAgICAgICAgICAgICAgIEthdGVsbG8gU1NMIFRvb2wgR2VuZXJh
+        dGVkIENlcnRpZmljYXRlXG4gICAgICAgICAgICBYNTA5djMgU3ViamVjdCBL
+        ZXkgSWRlbnRpZmllcjpcbiAgICAgICAgICAgICAgICA5QjpEMjpEOTo2OTo4
+        ODo5OToyQzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1
+        RFxuICAgICAgICAgICAgWDUwOXYzIEF1dGhvcml0eSBLZXkgSWRlbnRpZmll
+        cjpcbiAgICAgICAgICAgICAgICBrZXlpZDo5QjpEMjpEOTo2OTo4ODo5OToy
+        QzoyRTo3MDoyQjpCNzo2OTo3Njo3QTo3RDpEMTo4NTo0RDo1Mzo1RFxuICAg
+        ICAgICAgICAgICAgIERpck5hbWU6L0M9VVMvU1Q9Tm9ydGggQ2Fyb2xpbmEv
+        TD1SYWxlaWdoL089S2F0ZWxsby9PVT1Tb21lT3JnVW5pdC9DTj1jZW50b3M3
+        LWRldmVsMi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICAgICAgICAgIHNl
+        cmlhbDpGRDpCQTpCQzo3MTo2RToyNTpBMzo3OFxuXG4gICAgU2lnbmF0dXJl
+        IEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAgICAg
+        IDMyOjE5OjZjOmM2OmFmOmFlOmMyOmJlOjY0OjE2OmIwOjdjOmEzOjRiOjEw
+        OmU4OjVhOmI0OlxuICAgICAgICAgMTc6NzQ6ZmQ6NzU6YzY6MjY6ZDI6ODg6
+        MDE6ZmU6OTU6MmU6M2Y6MGE6MWU6ODg6YTU6MjU6XG4gICAgICAgICAxMzo2
+        Yjo2MDozNDpkMDoyYzpkZTpkODo0ODoxNTpmNTpjYzoxZjowNzo4MDoyYjox
+        ZDoyODpcbiAgICAgICAgIDkwOmU5OjhiOjQ3OmMxOjcxOjFhOmRhOjg2OmEw
+        OjI3OmU4OmM0Ojg4OjM2OmEzOmZmOmRiOlxuICAgICAgICAgMTc6MmY6MGU6
+        OWI6ZTE6Mzk6YTc6MWY6ZGM6MjY6OTc6Mjk6NWU6NGI6OTk6NjA6ZmE6OTI6
+        XG4gICAgICAgICAxMjoyNDpmYzpiYzowNDo5NDoyNDo2NTpmMzo2MDpjYzo1
+        ZTplZTo0MjpiZjo5ZTozYzozMTpcbiAgICAgICAgIGI5OjNjOjk5OjhhOjQ0
+        OjNkOjI5OjVkOmE2Ojk5OmFhOmQ1OjBlOjE1Ojk0OmM0OmM1OjIzOlxuICAg
+        ICAgICAgOGM6Yjk6NmU6ZTU6MDk6MTM6OGM6NTY6NGI6MDQ6MzU6OTU6Nzk6
+        NTA6NWM6MjI6MmQ6MWY6XG4gICAgICAgICAzYTo2ODpkMDpmMzozZTo4ODo3
+        ZDozODoyOTozMjpmMjo0NzpiMToxNzo5OTpmZDphNjo0ODpcbiAgICAgICAg
+        IDAyOjA0OjZiOjlmOmI5OmRhOmMyOjZlOjY1OjliOjk5OmU0OjYwOjdhOjMy
+        OmNkOjAyOmZlOlxuICAgICAgICAgNzE6ZGE6MTk6ZTM6OTM6YmQ6YzU6YTc6
+        YTA6NDY6OWU6Mjg6ZDI6OTE6YWM6OGU6OTE6Yzc6XG4gICAgICAgICBhNzo1
+        MTo0ZTo4MTowOTpkMTpmMTozOTo1YjowNzo4Nzo0MTozYjpiNzplMzoxYjph
+        ODo3ZTpcbiAgICAgICAgIDUxOjUyOjRlOjY2OjIwOmIxOmNkOmM1OmFlOmRl
+        OjE3OjNhOmQ3OmNlOjA3OjM3OmQ4OjVlOlxuICAgICAgICAgODg6ZWY6ZTM6
+        OTQ6YzA6OTg6M2U6YzM6MGQ6NTE6NDQ6M2Q6NTM6NTI6ZmY6NWU6MGI6MWI6
+        XG4gICAgICAgICA1Yjo2Yzo5YjphNlxuLS0tLS1CRUdJTiBDRVJUSUZJQ0FU
+        RS0tLS0tXG5NSUlGQnpDQ0ErK2dBd0lCQWdJSkFQMjZ2SEZ1SmFONE1BMEdD
+        U3FHU0liM0RRRUJDd1VBTUlHTE1Rc3dDUVlEXG5WUVFHRXdKVlV6RVhNQlVH
+        QTFVRUNBd09UbTl5ZEdnZ1EyRnliMnhwYm1FeEVEQU9CZ05WQkFjTUIxSmhi
+        R1ZwXG5aMmd4RURBT0JnTlZCQW9NQjB0aGRHVnNiRzh4RkRBU0JnTlZCQXNN
+        QzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEXG5WUVFERENCalpXNTBiM00zTFdS
+        bGRtVnNNaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZiVEFlRncweU1EQTFNRGN4
+        XG5OREl4TlRCYUZ3MHpPREF4TVRneE5ESXhOVEJhTUlHTE1Rc3dDUVlEVlFR
+        R0V3SlZVekVYTUJVR0ExVUVDQXdPXG5UbTl5ZEdnZ1EyRnliMnhwYm1FeEVE
+        QU9CZ05WQkFjTUIxSmhiR1ZwWjJneEVEQU9CZ05WQkFvTUIwdGhkR1ZzXG5i
+        Rzh4RkRBU0JnTlZCQXNNQzFOdmJXVlBjbWRWYm1sME1Ta3dKd1lEVlFRRERD
+        QmpaVzUwYjNNM0xXUmxkbVZzXG5NaTV6WVcxcGNpNWxlR0Z0Y0d4bExtTnZi
+        VENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DXG5nZ0VC
+        QUovU3dSRC9BUm96R1E1RG5ZUGxpbk82TFR4bXNYak5pWXhnNVlHbTZFMldY
+        UWZEdnFLY3dueVVMVzVEXG5SRWJ2L1RZZ1J6dldOZjJYelpjWDF6L25aLzZw
+        S3ZHOFI0ZHU3VzIybnZFTlkxUEJQLzBYcTE4MWVvVFBhOTJtXG5qZ21aVmpu
+        ZUtXdjd3dHlNVmlvUXN3ckt1R3o3dU1qcjVlS3UxVUVGVEtMQXZudXdiUjE4
+        Wm9DSVdyY0htOU80XG4vNVB6R1ROalNKV0ROQ2ZHck15Z0MxYXJJalJ4VDNt
+        L2JrdkppVm1IaTNzMWViZ2NjTzVZNW5zaWVhY2UyYkpYXG5PdUJaanJOcWx6
+        MmFnTXc3MVhmVStucFlhYmF6cXBWVVZaNFRaWCtWd0hPV3hmdDNvRWdncG4z
+        MHhOUHBxNVNUXG5UaHJpWFp2RmgxREhWdkNUcUxrS2M4LzNBUThDQXdFQUFh
+        T0NBV293Z2dGbU1Bd0dBMVVkRXdRRk1BTUJBZjh3XG5Dd1lEVlIwUEJBUURB
+        Z0dtTUIwR0ExVWRKUVFXTUJRR0NDc0dBUVVGQndNQkJnZ3JCZ0VGQlFjREFq
+        QVJCZ2xnXG5oa2dCaHZoQ0FRRUVCQU1DQWtRd05RWUpZSVpJQVliNFFnRU5C
+        Q2dXSmt0aGRHVnNiRzhnVTFOTUlGUnZiMndnXG5SMlZ1WlhKaGRHVmtJRU5s
+        Y25ScFptbGpZWFJsTUIwR0ExVWREZ1FXQkJTYjB0bHBpSmtzTG5BcnQybDJl
+        bjNSXG5oVTFUWFRDQndBWURWUjBqQklHNE1JRzFnQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JoVTFUWGFHQmthU0JqakNCXG5pekVMTUFrR0ExVUVCaE1DVlZN
+        eEZ6QVZCZ05WQkFnTURrNXZjblJvSUVOaGNtOXNhVzVoTVJBd0RnWURWUVFI
+        XG5EQWRTWVd4bGFXZG9NUkF3RGdZRFZRUUtEQWRMWVhSbGJHeHZNUlF3RWdZ
+        RFZRUUxEQXRUYjIxbFQzSm5WVzVwXG5kREVwTUNjR0ExVUVBd3dnWTJWdWRH
+        OXpOeTFrWlhabGJESXVjMkZ0YVhJdVpYaGhiWEJzWlM1amIyMkNDUUQ5XG51
+        cnh4YmlXamVEQU5CZ2txaGtpRzl3MEJBUXNGQUFPQ0FRRUFNaGxzeHErdXdy
+        NWtGckI4bzBzUTZGcTBGM1Q5XG5kY1ltMG9nQi9wVXVQd29laUtVbEUydGdO
+        TkFzM3RoSUZmWE1Id2VBS3gwb2tPbUxSOEZ4R3RxR29DZm94SWcyXG5vLy9i
+        Rnk4T20rRTVweC9jSnBjcFhrdVpZUHFTRWlUOHZBU1VKR1h6WU14ZTdrSy9u
+        and4dVR5WmlrUTlLVjJtXG5tYXJWRGhXVXhNVWpqTGx1NVFrVGpGWkxCRFdW
+        ZVZCY0lpMGZPbWpROHo2SWZUZ3BNdkpIc1JlWi9hWklBZ1JyXG5uN25hd201
+        bG01bmtZSG95elFMK2Nkb1o0NU85eGFlZ1JwNG8wcEdzanBISHAxRk9nUW5S
+        OFRsYkI0ZEJPN2ZqXG5HNmgrVVZKT1ppQ3h6Y1d1M2hjNjE4NEhOOWhlaU8v
+        amxNQ1lQc01OVVVROVUxTC9YZ3NiVzJ5YnBnPT1cbi0tLS0tRU5EIENFUlRJ
+        RklDQVRFLS0tLS0ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2844,7 +2588,61 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 00d4717a1fbb4cb68a8bfb1b096d83e3
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/publications/deb/apt/019caf0b-6bda-7cfc-92b3-6e99df924d7c/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.8.1/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2864,40 +2662,40 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 86aa078d594b4855a57eb19c55f2827c
+      - 578a20d91a804a00b70a66bc6579261f
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25zL2RlYi9h
-        cHQvMDE5YzRlY2QtYzBkZC03Yjg5LTk4YmUtMjk4NDU0Zjc1NWMwLyIsInBy
-        biI6InBybjpkZWIuYXB0cHVibGljYXRpb246MDE5YzRlY2QtYzBkZC03Yjg5
-        LTk4YmUtMjk4NDU0Zjc1NWMwIiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMi0x
-        MVQyMjoyMzo1My4wNTQ2MzhaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2
-        LTAyLTExVDIyOjIzOjUzLjc1NzgwOFoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
-        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5YzRlY2Qt
-        YjQ5NS03M2ViLTkzMmMtZDVkNTg5NDU2ZjNkL3ZlcnNpb25zLzIvIiwicmVw
+        cHQvMDE5Y2FmMGItNmJkYS03Y2ZjLTkyYjMtNmU5OWRmOTI0ZDdjLyIsInBy
+        biI6InBybjpkZWIuYXB0cHVibGljYXRpb246MDE5Y2FmMGItNmJkYS03Y2Zj
+        LTkyYjMtNmU5OWRmOTI0ZDdjIiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMy0w
+        MlQxNDo1NDo0Ny4yNTk1NzJaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2
+        LTAzLTAyVDE0OjU0OjQ3LjY2NjQzMVoiLCJyZXBvc2l0b3J5X3ZlcnNpb24i
+        OiIvcHVscC9hcGkvdjMvcmVwb3NpdG9yaWVzL2RlYi9hcHQvMDE5Y2FmMGIt
+        NThkZC03NTQ0LWIxYzEtZGJmNGQ1OTZjMTkxL3ZlcnNpb25zLzMvIiwicmVw
         b3NpdG9yeSI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8w
-        MTljNGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1ODk0NTZmM2QvIiwic2ltcGxl
+        MTljYWYwYi01OGRkLTc1NDQtYjFjMS1kYmY0ZDU5NmMxOTEvIiwic2ltcGxl
         IjpmYWxzZSwic3RydWN0dXJlZCI6dHJ1ZSwiY2hlY2twb2ludCI6ZmFsc2Us
         InNpZ25pbmdfc2VydmljZSI6bnVsbH0=
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: post
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/
     body:
       encoding: UTF-8
       base64_string: |
         eyJiYXNlX3BhdGgiOiJBQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZGViaWFu
         X3B1bHBfcmFnbmFyb2tfbGFiZWwiLCJjb250ZW50X2d1YXJkIjoiL3B1bHAv
-        YXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5YzRlYzIt
-        NGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmLyIsIm5hbWUiOiJkZWJpYW5f
+        YXBpL3YzL2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5Y2FmMGIt
+        NmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhLyIsIm5hbWUiOiJkZWJpYW5f
         cHVscF9yYWduYXJvayIsInB1YmxpY2F0aW9uIjoiL3B1bHAvYXBpL3YzL3B1
-        YmxpY2F0aW9ucy9kZWIvYXB0LzAxOWM0ZWNkLWMwZGQtN2I4OS05OGJlLTI5
-        ODQ1NGY3NTVjMC8ifQ==
+        YmxpY2F0aW9ucy9kZWIvYXB0LzAxOWNhZjBiLTZiZGEtN2NmYy05MmIzLTZl
+        OTlkZjkyNGQ3Yy8ifQ==
     headers:
       Content-Type:
       - application/json
@@ -2915,7 +2713,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2935,20 +2733,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - f73214257d8f47dc8e845e9587fbdc53
+      - 89bc07d4e2df4dc3a25668935efb1773
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWM2NGUtN2Mw
-        MS1iNDU5LTZkNjZiMWVhNGJjZC8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTZmOGMtNzk0
+        ZC05ZTJmLTc2MGQ3OTY0YjY3YS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-c64e-7c01-b459-6d66b1ea4bcd/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-6f8c-794d-9e2f-760d7964b67a/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -2956,7 +2754,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -2969,7 +2767,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -2989,39 +2787,39 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - dccda9b6bc5c4c5d94e4bdc17f3122f2
+      - 4ee009982fc14a5c958bea980d83100b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtYzY0
-        ZS03YzAxLWI0NTktNmQ2NmIxZWE0YmNkLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtYzY0ZS03YzAxLWI0NTktNmQ2NmIxZWE0YmNkIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1NC40NDk4MjJaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjU0LjQ0NzQ0MVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNmY4
+        Yy03OTRkLTllMmYtNzYwZDc5NjRiNjdhLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNmY4Yy03OTRkLTllMmYtNzYwZDc5NjRiNjdhIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0OC4yMDY5OTdaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ4LjIwNTE5NFoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiZjczMjE0
-        MjU3ZDhmNDdkYzhlODQ1ZTk1ODdmYmRjNTMiLCJjcmVhdGVkX2J5IjoiL3B1
-        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMi0x
-        MVQyMjoyMzo1NC40Njg3MTJaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NTQuNTA3MDU0WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMi0xMVQy
-        MjoyMzo1NC43MjU0NjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
-        L2FwaS92My93b3JrZXJzLzAxOWM0ZWJjLWNhYzgtNzlkOC05ZWU1LTU0ZGQx
-        MWY0YjE2MS8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
+        a3MuYmFzZS5nZW5lcmFsX2NyZWF0ZSIsImxvZ2dpbmdfY2lkIjoiODliYzA3
+        ZDRlMmRmNGRjM2EyNTY2ODkzNWVmYjE3NzMiLCJjcmVhdGVkX2J5IjoiL3B1
+        bHAvYXBpL3YzL3VzZXJzLzEvIiwidW5ibG9ja2VkX2F0IjoiMjAyNi0wMy0w
+        MlQxNDo1NDo0OC4yMTU5MzlaIiwic3RhcnRlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDguMjUxNjI3WiIsImZpbmlzaGVkX2F0IjoiMjAyNi0wMy0wMlQx
+        NDo1NDo0OC40MTk2NjlaIiwiZXJyb3IiOm51bGwsIndvcmtlciI6Ii9wdWxw
+        L2FwaS92My93b3JrZXJzLzAxOWNhZTIyLWEwYjQtNzQwOS1iODI0LWI0NzZl
+        Y2I2N2ZlMC8iLCJwYXJlbnRfdGFzayI6bnVsbCwiY2hpbGRfdGFza3MiOltd
         LCJ0YXNrX2dyb3VwIjpudWxsLCJwcm9ncmVzc19yZXBvcnRzIjpbXSwiY3Jl
         YXRlZF9yZXNvdXJjZXMiOlsiL3B1bHAvYXBpL3YzL2Rpc3RyaWJ1dGlvbnMv
-        ZGViL2FwdC8wMTljNGVjZC1jNzQ4LTc2ZGEtYjRiNC1mMmY2MmZiNDEwY2Yv
-        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjowZDI2MTFj
-        My0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDA6ZGlzdHJpYnV0aW9ucyIs
-        InNoYXJlZDpwcm46Y29yZS5kb21haW46MGQyNjExYzMtMjA2Yy00MDE2LWJi
-        NTctYzRiMDU5ZTFkYzQwIl19
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
+        ZGViL2FwdC8wMTljYWYwYi03MDViLTc2YTQtYjAxZi0wYjY3NWQxYjFmYmQv
+        Il0sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjo5OTk4OGJh
+        OC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmE6ZGlzdHJpYnV0aW9ucyIs
+        InNoYXJlZDpwcm46Y29yZS5kb21haW46OTk5ODhiYTgtN2IxYS00MGI5LWE2
+        MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/019c4ecd-c748-76da-b4b4-f2f62fb410cf/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/019caf0b-705b-76a4-b01f-0b675d1b1fbd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3042,7 +2840,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:54 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3054,7 +2852,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '802'
+      - '787'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3062,36 +2860,36 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 94c4f3f2463f4d13b3efc3a257e32845
+      - 49db1593ed894b6fb0a57783e9474741
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvZGlzdHJpYnV0aW9ucy9kZWIv
-        YXB0LzAxOWM0ZWNkLWM3NDgtNzZkYS1iNGI0LWYyZjYyZmI0MTBjZi8iLCJw
-        cm4iOiJwcm46ZGViLmFwdGRpc3RyaWJ1dGlvbjowMTljNGVjZC1jNzQ4LTc2
-        ZGEtYjRiNC1mMmY2MmZiNDEwY2YiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAy
-        LTExVDIyOjIzOjU0LjY5NzAzOFoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
-        MjYtMDItMTFUMjI6MjM6NTQuNjk3MDUwWiIsImJhc2VfcGF0aCI6IkFDTUVf
+        YXB0LzAxOWNhZjBiLTcwNWItNzZhNC1iMDFmLTBiNjc1ZDFiMWZiZC8iLCJw
+        cm4iOiJwcm46ZGViLmFwdGRpc3RyaWJ1dGlvbjowMTljYWYwYi03MDViLTc2
+        YTQtYjAxZi0wYjY3NWQxYjFmYmQiLCJwdWxwX2NyZWF0ZWQiOiIyMDI2LTAz
+        LTAyVDE0OjU0OjQ4LjQxMjMyNVoiLCJwdWxwX2xhc3RfdXBkYXRlZCI6IjIw
+        MjYtMDMtMDJUMTQ6NTQ6NDguNDEyMzM3WiIsImJhc2VfcGF0aCI6IkFDTUVf
         Q29ycG9yYXRpb24vbGlicmFyeS9kZWJpYW5fcHVscF9yYWduYXJva19sYWJl
-        bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LXB1bHAtdXBncmFkZS5x
-        amFtZXMtdGhpbmtwYWRwMWdlbjRpLmV4YW1wbGUuY29tL3B1bHAvY29udGVu
-        dC9BQ01FX0NvcnBvcmF0aW9uL2xpYnJhcnkvZGViaWFuX3B1bHBfcmFnbmFy
-        b2tfbGFiZWwvIiwiY29udGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250
-        ZW50Z3VhcmRzL2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1h
-        MGY3LThjYWZmNWMyZGQzZi8iLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6
-        IjIwMjYtMDItMTFUMjI6MjM6NTQuNjk3MDUwWiIsImhpZGRlbiI6ZmFsc2Us
-        InB1bHBfbGFiZWxzIjp7fSwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25hcm9r
-        IiwicmVwb3NpdG9yeSI6bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkv
-        djMvcHVibGljYXRpb25zL2RlYi9hcHQvMDE5YzRlY2QtYzBkZC03Yjg5LTk4
-        YmUtMjk4NDU0Zjc1NWMwLyIsImNoZWNrcG9pbnQiOmZhbHNlfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:54 GMT
+        bCIsImJhc2VfdXJsIjoiaHR0cHM6Ly9jZW50b3M5LWthdGVsbG8tZGV2ZWwt
+        c3RhYmxlLmV4YW1wbGUuY29tL3B1bHAvY29udGVudC9BQ01FX0NvcnBvcmF0
+        aW9uL2xpYnJhcnkvZGViaWFuX3B1bHBfcmFnbmFyb2tfbGFiZWwvIiwiY29u
+        dGVudF9ndWFyZCI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRzL2NlcnRn
+        dWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4ZDNiZDE3
+        YS8iLCJub19jb250ZW50X2NoYW5nZV9zaW5jZSI6IjIwMjYtMDMtMDJUMTQ6
+        NTQ6NDguNDEyMzM3WiIsImhpZGRlbiI6ZmFsc2UsInB1bHBfbGFiZWxzIjp7
+        fSwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25hcm9rIiwicmVwb3NpdG9yeSI6
+        bnVsbCwicHVibGljYXRpb24iOiIvcHVscC9hcGkvdjMvcHVibGljYXRpb25z
+        L2RlYi9hcHQvMDE5Y2FmMGItNmJkYS03Y2ZjLTkyYjMtNmU5OWRmOTI0ZDdj
+        LyIsImNoZWNrcG9pbnQiOmZhbHNlfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/content/deb/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/versions/2/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/content/deb/packages/?limit=2000&offset=0&repository_version=/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/versions/3/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3112,7 +2910,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3132,23 +2930,23 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 6e4344a6bf8e4d39a1ded01a4fad8d11
+      - dd101b95b3414bd4ad242a87b54e5497
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MywibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9w
-        YWNrYWdlcy8wMTljNGVjZC1hMTFlLTdkMWQtYmM5Ni1iZjgwZmIyN2FjMWEv
-        IiwicHJuIjoicHJuOmRlYi5wYWNrYWdlOjAxOWM0ZWNkLWExMWUtN2QxZC1i
-        Yzk2LWJmODBmYjI3YWMxYSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NDUuMTI3NzQ5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0w
-        Mi0xMVQyMjoyMzo0NS4xMjc3NjNaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxu
+        YWNrYWdlcy8wMTljYWYwYi02ODg5LTc2OWMtYWRmMy03OTU0MDE2ZGZiZDcv
+        IiwicHJuIjoicHJuOmRlYi5wYWNrYWdlOjAxOWNhZjBiLTY4ODktNzY5Yy1h
+        ZGYzLTc5NTQwMTZkZmJkNyIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDYuNjU0ODA5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0w
+        My0wMlQxNDo1NDo0Ni42NTQ4MTdaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxu
         X3JlcG9ydCI6bnVsbCwiYXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZh
-        Y3RzLzAxOWM0ZWNkLWExYTktNzE2ZC05MTE5LTFkMDdmNDg1MThjOC8iLCJy
+        Y3RzLzAxOWNhZjBiLTY5NWEtNzAyOS1hNWY3LTA0NjQ1ZGU3ZmMxMy8iLCJy
         ZWxhdGl2ZV9wYXRoIjoicG9vbC9hc2dhcmQvdC90aG9yL3Rob3JfMS4wX3Bw
         YzY0LmRlYiIsIm1kNSI6bnVsbCwic2hhMSI6ImI4MjY0NmY1Mjk4NDUxZGEy
         NzdhMDYyY2I1ZGNlY2VkYjZhNjc1YzAiLCJzaGEyMjQiOiI2OWVkMWM0Mzhh
@@ -3179,13 +2977,13 @@ http_interactions:
         IjpudWxsLCJzdWdnZXN0cyI6bnVsbCwiZW5oYW5jZXMiOm51bGwsInByZV9k
         ZXBlbmRzIjpudWxsLCJwcm92aWRlcyI6bnVsbCwicmVwbGFjZXMiOm51bGx9
         LHsicHVscF9ocmVmIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnQvZGViL3BhY2th
-        Z2VzLzAxOWM0ZWNkLWExMWMtN2I1MC1hMWE4LTZmZmQ3N2I4M2M4ZC8iLCJw
-        cm4iOiJwcm46ZGViLnBhY2thZ2U6MDE5YzRlY2QtYTExYy03YjUwLWExYTgt
-        NmZmZDc3YjgzYzhkIiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoy
-        Mzo0NS4wODQzNjhaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjQ1LjA4NDM3NVoiLCJwdWxwX2xhYmVscyI6e30sInZ1bG5fcmVw
+        Z2VzLzAxOWNhZjBiLTY4ODctN2RjNy04NTA2LTE2ZDNlZmU0ZWM1OS8iLCJw
+        cm4iOiJwcm46ZGViLnBhY2thZ2U6MDE5Y2FmMGItNjg4Ny03ZGM3LTg1MDYt
+        MTZkM2VmZTRlYzU5IiwicHVscF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1
+        NDo0Ni42MjkwODZaIiwicHVscF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQ2LjYyOTA5NFoiLCJwdWxwX2xhYmVscyI6e30sInZ1bG5fcmVw
         b3J0IjpudWxsLCJhcnRpZmFjdCI6Ii9wdWxwL2FwaS92My9hcnRpZmFjdHMv
-        MDE5YzRlY2QtYTFhOC03MjlkLWFhZDQtOTc4ZDM2NzJjOTVlLyIsInJlbGF0
+        MDE5Y2FmMGItNjk1Ny03ZTY1LWE4YWQtZGJhMTA2MjZkYjZkLyIsInJlbGF0
         aXZlX3BhdGgiOiJwb29sL2FzZ2FyZC9vL29kaW4vb2Rpbl8xLjBfcHBjNjQu
         ZGViIiwibWQ1IjpudWxsLCJzaGExIjoiMDY2YzU4YzZiOGI5MDQ0NDJiMjVk
         NmU0OWFhNjkxZmI3NWUxMDY0MCIsInNoYTIyNCI6IjE4MzczYzIzODdiYWQ1
@@ -3215,14 +3013,14 @@ http_interactions:
         cyI6bnVsbCwiZGVwZW5kcyI6bnVsbCwicmVjb21tZW5kcyI6bnVsbCwic3Vn
         Z2VzdHMiOm51bGwsImVuaGFuY2VzIjpudWxsLCJwcmVfZGVwZW5kcyI6bnVs
         bCwicHJvdmlkZXMiOm51bGwsInJlcGxhY2VzIjpudWxsfSx7InB1bHBfaHJl
-        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlcy8wMTljNGVj
-        ZC1hMTFhLTc4ZjgtYjRkOC0wMzQ5ZDFiNzUxOTAvIiwicHJuIjoicHJuOmRl
-        Yi5wYWNrYWdlOjAxOWM0ZWNkLWExMWEtNzhmOC1iNGQ4LTAzNDlkMWI3NTE5
-        MCIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6MjM6NDUuMDgyNjc3
-        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo0NS4w
-        ODI2ODVaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxuX3JlcG9ydCI6bnVsbCwi
-        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOWM0ZWNkLWEx
-        N2QtN2Q5ZS04OTQ0LTI2NTJhYzQ0ZmY3Ni8iLCJyZWxhdGl2ZV9wYXRoIjoi
+        ZiI6Ii9wdWxwL2FwaS92My9jb250ZW50L2RlYi9wYWNrYWdlcy8wMTljYWYw
+        Yi02ODg1LTdkMzgtYThhMi04NGNkMjhlNDc3MTUvIiwicHJuIjoicHJuOmRl
+        Yi5wYWNrYWdlOjAxOWNhZjBiLTY4ODUtN2QzOC1hOGEyLTg0Y2QyOGU0Nzcx
+        NSIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6NTQ6NDYuNjI3MTM5
+        WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ni42
+        MjcxNDhaIiwicHVscF9sYWJlbHMiOnt9LCJ2dWxuX3JlcG9ydCI6bnVsbCwi
+        YXJ0aWZhY3QiOiIvcHVscC9hcGkvdjMvYXJ0aWZhY3RzLzAxOWNhZjBiLTY5
+        NTAtN2E0Yy04ZjJiLTAxN2Y5M2JjYjAyMy8iLCJyZWxhdGl2ZV9wYXRoIjoi
         cG9vbC9hc2dhcmQvZi9mcmlnZy9mcmlnZ18xLjBfcHBjNjQuZGViIiwibWQ1
         IjpudWxsLCJzaGExIjoiYTllNzE4ZmQ1NjEyMjY0OGY0YTFlY2RjODkxN2Fj
         OTA5MzllNDJiYSIsInNoYTIyNCI6ImY4ZjBkN2Q4ZDE0M2YzNTM4OWM0ZWQ0
@@ -3248,10 +3046,10 @@ http_interactions:
         b25mbGljdHMiOm51bGwsImRlcGVuZHMiOm51bGwsInJlY29tbWVuZHMiOm51
         bGwsInN1Z2dlc3RzIjpudWxsLCJlbmhhbmNlcyI6bnVsbCwicHJlX2RlcGVu
         ZHMiOm51bGwsInByb3ZpZGVzIjpudWxsLCJyZXBsYWNlcyI6bnVsbH1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3259,7 +3057,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3272,7 +3070,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3292,21 +3090,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 66e5ec59a738440b80cb2584a4036caf
+      - 5988802eccce41b9838b39b344ee091a
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
-        L2NlcnRndWFyZC9yaHNtLzAxOWM0ZWMyLTRhMGEtNzJhNi1hMGY3LThjYWZm
-        NWMyZGQzZi8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
-        MDE5YzRlYzItNGEwYS03MmE2LWEwZjctOGNhZmY1YzJkZDNmIiwicHVscF9j
-        cmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoxMToyMS43Mzg4MjJaIiwicHVscF9s
-        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjU0LjI1NDI1M1oiLCJu
+        L2NlcnRndWFyZC9yaHNtLzAxOWNhZjBiLTZlNmQtN2E3ZS1hYWMxLTIzN2U4
+        ZDNiZDE3YS8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThkM2JkMTdhIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0Ny45MTc3MzNaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ4LjAyMjcyNloiLCJu
         YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
         ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
         IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
@@ -3433,10 +3231,10 @@ http_interactions:
         T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
         aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
         Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3457,7 +3255,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:48 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3477,34 +3275,34 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 55fca47cd1a944dda95d6f17cee4af70
+      - e60659f81f47400abd9b347663ad4c47
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMv
-        ZGViL2FwdC8wMTljNGVjZC1iNDk1LTczZWItOTMyYy1kNWQ1ODk0NTZmM2Qv
-        IiwicHJuIjoicHJuOmRlYi5hcHRyZXBvc2l0b3J5OjAxOWM0ZWNkLWI0OTUt
-        NzNlYi05MzJjLWQ1ZDU4OTQ1NmYzZCIsInB1bHBfY3JlYXRlZCI6IjIwMjYt
-        MDItMTFUMjI6MjM6NDkuOTA5OTM3WiIsInB1bHBfbGFzdF91cGRhdGVkIjoi
-        MjAyNi0wMi0xMVQyMjoyMzo1Mi42MjE0NDVaIiwidmVyc2lvbnNfaHJlZiI6
-        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljNGVjZC1i
-        NDk1LTczZWItOTMyYy1kNWQ1ODk0NTZmM2QvdmVyc2lvbnMvIiwicHVscF9s
+        ZGViL2FwdC8wMTljYWYwYi01OGRkLTc1NDQtYjFjMS1kYmY0ZDU5NmMxOTEv
+        IiwicHJuIjoicHJuOmRlYi5hcHRyZXBvc2l0b3J5OjAxOWNhZjBiLTU4ZGQt
+        NzU0NC1iMWMxLWRiZjRkNTk2YzE5MSIsInB1bHBfY3JlYXRlZCI6IjIwMjYt
+        MDMtMDJUMTQ6NTQ6NDIuMzk4OTY5WiIsInB1bHBfbGFzdF91cGRhdGVkIjoi
+        MjAyNi0wMy0wMlQxNDo1NDo0Ni43NDg5ODlaIiwidmVyc2lvbnNfaHJlZiI6
+        Ii9wdWxwL2FwaS92My9yZXBvc2l0b3JpZXMvZGViL2FwdC8wMTljYWYwYi01
+        OGRkLTc1NDQtYjFjMS1kYmY0ZDU5NmMxOTEvdmVyc2lvbnMvIiwicHVscF9s
         YWJlbHMiOnt9LCJsYXRlc3RfdmVyc2lvbl9ocmVmIjoiL3B1bHAvYXBpL3Yz
-        L3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWM0ZWNkLWI0OTUtNzNlYi05MzJj
-        LWQ1ZDU4OTQ1NmYzZC92ZXJzaW9ucy8yLyIsIm5hbWUiOiJkZWJpYW5fcHVs
+        L3JlcG9zaXRvcmllcy9kZWIvYXB0LzAxOWNhZjBiLTU4ZGQtNzU0NC1iMWMx
+        LWRiZjRkNTk2YzE5MS92ZXJzaW9ucy8zLyIsIm5hbWUiOiJkZWJpYW5fcHVs
         cF9yYWduYXJvayIsImRlc2NyaXB0aW9uIjpudWxsLCJyZXRhaW5fcmVwb192
         ZXJzaW9ucyI6bnVsbCwicmVtb3RlIjpudWxsLCJwdWJsaXNoX3Vwc3RyZWFt
         X3JlbGVhc2VfZmllbGRzIjp0cnVlLCJzaWduaW5nX3NlcnZpY2UiOm51bGws
         InNpZ25pbmdfc2VydmljZV9yZWxlYXNlX292ZXJyaWRlcyI6e319XX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:48 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/repositories/deb/apt/019c4ecd-b495-73eb-932c-d5d589456f3d/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/019caf0b-58dd-7544-b1c1-dbf4d596c191/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3525,7 +3323,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3545,20 +3343,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - eefa9c9b183243aebfee2c82e5a04b98
+      - b481116f95ec43c1bc336466fe93f3f6
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWNhMjQtNzBh
-        Yi1hMjk2LTI2YTQxZGRmZmE1NS8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTcyYmMtN2Ni
+        MS05OWY2LWZhNDVlOGY0YTk1Ny8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3579,7 +3377,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3599,21 +3397,21 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - '0947c68ab8ad4575848a2ff9465b4b0e'
+      - b67730b113084a62b00c719f72da1916
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9yZW1vdGVzL2RlYi9h
-        cHQvMDE5YzRlY2QtYjNiOC03NmFiLWEzMWYtYzY5NmVhNTAwZDM3LyIsInBy
-        biI6InBybjpkZWIuYXB0cmVtb3RlOjAxOWM0ZWNkLWIzYjgtNzZhYi1hMzFm
-        LWM2OTZlYTUwMGQzNyIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDItMTFUMjI6
-        MjM6NDkuNjg4NjA0WiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMi0x
-        MVQyMjoyMzo1MS4xNzQ1MjZaIiwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25h
+        cHQvMDE5Y2FmMGItNTgxNS03ODg3LTgzOTQtNDc5NzBmYzZmMDZjLyIsInBy
+        biI6InBybjpkZWIuYXB0cmVtb3RlOjAxOWNhZjBiLTU4MTUtNzg4Ny04Mzk0
+        LTQ3OTcwZmM2ZjA2YyIsInB1bHBfY3JlYXRlZCI6IjIwMjYtMDMtMDJUMTQ6
+        NTQ6NDIuMTk3ODUzWiIsInB1bHBfbGFzdF91cGRhdGVkIjoiMjAyNi0wMy0w
+        MlQxNDo1NDo0My41Mjg2MTZaIiwibmFtZSI6ImRlYmlhbl9wdWxwX3JhZ25h
         cm9rIiwidXJsIjoiaHR0cHM6Ly9maXh0dXJlcy5wdWxwcHJvamVjdC5vcmcv
         ZGViaWFuLyIsImNhX2NlcnQiOm51bGwsImNsaWVudF9jZXJ0IjpudWxsLCJ0
         bHNfdmFsaWRhdGlvbiI6dHJ1ZSwicHJveHlfdXJsIjpudWxsLCJwdWxwX2xh
@@ -3631,10 +3429,10 @@ http_interactions:
         Y2VzIjpmYWxzZSwic3luY191ZGVicyI6ZmFsc2UsInN5bmNfaW5zdGFsbGVy
         IjpmYWxzZSwiZ3Bna2V5IjpudWxsLCJpZ25vcmVfbWlzc2luZ19wYWNrYWdl
         X2luZGljZXMiOmZhbHNlfV19
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/remotes/deb/apt/019c4ecd-b3b8-76ab-a31f-c696ea500d37/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/019caf0b-5815-7887-8394-47970fc6f06c/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3655,7 +3453,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3675,20 +3473,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - aeee7a4a041e4bb09ac8ef707abae80a
+      - d0b10919b8b5451fa8d3da8e0bf5eec9
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWNhOGMtNzY4
-        MS1iNGU0LWMyN2I2ZTE2NWNlNi8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTczNDItN2Jl
+        My04ZDc0LTllYWQyMDU2ZmI5Ny8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-ca24-70ab-a296-26a41ddffa55/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-72bc-7cb1-99f6-fa45e8f4a957/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3696,7 +3494,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3709,7 +3507,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3729,37 +3527,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - de5ed50384c24d5d8faa07a07ab91e11
+      - ec6d5babdd884f549d4c7d56cb5d1656
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtY2Ey
-        NC03MGFiLWEyOTYtMjZhNDFkZGZmYTU1LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtY2EyNC03MGFiLWEyOTYtMjZhNDFkZGZmYTU1IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1NS40MzA0ODlaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjU1LjQyODUyN1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNzJi
+        Yy03Y2IxLTk5ZjYtZmE0NWU4ZjRhOTU3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNzJiYy03Y2IxLTk5ZjYtZmE0NWU4ZjRhOTU3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0OS4wMjI2NDBaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ5LjAyMDgwMVoi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImVlZmE5
-        YzliMTgzMjQzYWViZmVlMmM4MmU1YTA0Yjk4IiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjM6NTUuNDQ3MjYxWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjU1LjQ4NzkxNFoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NTUuNjI0NTMwWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYTk5LTdlYzAtOTVlMS04M2Iz
-        MGQ0ZWRmNmIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImI0ODEx
+        MTZmOTVlYzQzYzFiYzMzNjQ2NmZlOTNmM2Y2IiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTQ6NDkuMDMyMDkwWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQ5LjA2NjQzM1oiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDkuMjU2NzQ1WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMmExLTc1OGEtOGIxYi05MTkx
+        YzdlNGYxNzEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5YzRlY2QtYjQ5NS03M2Vi
-        LTkzMmMtZDVkNTg5NDU2ZjNkIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjow
-        ZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDAiXX0=
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+        ZCI6WyJwcm46ZGViLmFwdHJlcG9zaXRvcnk6MDE5Y2FmMGItNThkZC03NTQ0
+        LWIxYzEtZGJmNGQ1OTZjMTkxIiwic2hhcmVkOnBybjpjb3JlLmRvbWFpbjo5
+        OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmEiXX0=
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-ca8c-7681-b4e4-c27b6e165ce6/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-7342-7be3-8d74-9ead2056fb97/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3767,7 +3565,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -3780,7 +3578,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3800,37 +3598,37 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 24d59d7179904f159ca80c5888239b93
+      - ccaacfcbecbe41e1b1d3dfacb11fef47
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtY2E4
-        Yy03NjgxLWI0ZTQtYzI3YjZlMTY1Y2U2LyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtY2E4Yy03NjgxLWI0ZTQtYzI3YjZlMTY1Y2U2IiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1NS41MzQ5MTZaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjU1LjUzMzE2NVoi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNzM0
+        Mi03YmUzLThkNzQtOWVhZDIwNTZmYjk3LyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNzM0Mi03YmUzLThkNzQtOWVhZDIwNTZmYjk3IiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0OS4xNTY0OTVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ5LjE1NDcyN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImFlZWU3
-        YTRhMDQxZTRiYjA5YWM4ZWY3MDdhYmFlODBhIiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjM6NTUuNTUyODY0WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjU1LjU5NTczOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NTUuNjQ2Mzg4WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
-        cC9hcGkvdjMvd29ya2Vycy8wMTljNGViYy1jYWM4LTc5ZDgtOWVlNS01NGRk
-        MTFmNGIxNjEvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6ImQwYjEw
+        OTE5YjhiNTQ1MWZhOGQzZGE4ZTBiZjVlZWM5IiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTQ6NDkuMTczMDY5WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQ5LjIwNjkwOVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDkuMjUzOTA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOiIvcHVs
+        cC9hcGkvdjMvd29ya2Vycy8wMTljYWUyMi1hMjhjLTc1M2MtOTdmZi01ZTk1
+        MDUxZDZjNGIvIiwicGFyZW50X3Rhc2siOm51bGwsImNoaWxkX3Rhc2tzIjpb
         XSwidGFza19ncm91cCI6bnVsbCwicHJvZ3Jlc3NfcmVwb3J0cyI6W10sImNy
         ZWF0ZWRfcmVzb3VyY2VzIjpbXSwicmVzZXJ2ZWRfcmVzb3VyY2VzX3JlY29y
-        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljNGVjZC1iM2I4LTc2YWItYTMx
-        Zi1jNjk2ZWE1MDBkMzciLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjBkMjYx
-        MWMzLTIwNmMtNDAxNi1iYjU3LWM0YjA1OWUxZGM0MCJdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+        ZCI6WyJwcm46ZGViLmFwdHJlbW90ZTowMTljYWYwYi01ODE1LTc4ODctODM5
+        NC00Nzk3MGZjNmYwNmMiLCJzaGFyZWQ6cHJuOmNvcmUuZG9tYWluOjk5OTg4
+        YmE4LTdiMWEtNDBiOS1hNjI2LWExZDMwMmYxMjliYSJdfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_pulp_ragnarok
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3851,7 +3649,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3863,7 +3661,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '760'
+      - '745'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3871,35 +3669,35 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 7d894fa544004805b9d383f3c7984d29
+      - 536a5f2da6464986a579840eac8d528b
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9kaXN0cmlidXRpb25z
-        L2RlYi9hcHQvMDE5YzRlY2QtYzc0OC03NmRhLWI0YjQtZjJmNjJmYjQxMGNm
-        LyIsInBybiI6InBybjpkZWIuYXB0ZGlzdHJpYnV0aW9uOjAxOWM0ZWNkLWM3
-        NDgtNzZkYS1iNGI0LWYyZjYyZmI0MTBjZiIsInB1bHBfY3JlYXRlZCI6IjIw
-        MjYtMDItMTFUMjI6MjM6NTQuNjk3MDM4WiIsInB1bHBfbGFzdF91cGRhdGVk
-        IjoiMjAyNi0wMi0xMVQyMjoyMzo1NC42OTcwNTBaIiwiYmFzZV9wYXRoIjoi
+        L2RlYi9hcHQvMDE5Y2FmMGItNzA1Yi03NmE0LWIwMWYtMGI2NzVkMWIxZmJk
+        LyIsInBybiI6InBybjpkZWIuYXB0ZGlzdHJpYnV0aW9uOjAxOWNhZjBiLTcw
+        NWItNzZhNC1iMDFmLTBiNjc1ZDFiMWZiZCIsInB1bHBfY3JlYXRlZCI6IjIw
+        MjYtMDMtMDJUMTQ6NTQ6NDguNDEyMzI1WiIsInB1bHBfbGFzdF91cGRhdGVk
+        IjoiMjAyNi0wMy0wMlQxNDo1NDo0OC40MTIzMzdaIiwiYmFzZV9wYXRoIjoi
         QUNNRV9Db3Jwb3JhdGlvbi9saWJyYXJ5L2RlYmlhbl9wdWxwX3JhZ25hcm9r
-        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczktcHVscC11cGdy
-        YWRlLnFqYW1lcy10aGlua3BhZHAxZ2VuNGkuZXhhbXBsZS5jb20vcHVscC9j
-        b250ZW50L0FDTUVfQ29ycG9yYXRpb24vbGlicmFyeS9kZWJpYW5fcHVscF9y
-        YWduYXJva19sYWJlbC8iLCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3Yz
-        L2NvbnRlbnRndWFyZHMvY2VydGd1YXJkL3Joc20vMDE5YzRlYzItNGEwYS03
-        MmE2LWEwZjctOGNhZmY1YzJkZDNmLyIsIm5vX2NvbnRlbnRfY2hhbmdlX3Np
-        bmNlIjpudWxsLCJoaWRkZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5h
-        bWUiOiJkZWJpYW5fcHVscF9yYWduYXJvayIsInJlcG9zaXRvcnkiOm51bGws
-        InB1YmxpY2F0aW9uIjpudWxsLCJjaGVja3BvaW50IjpmYWxzZX1dfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+        X2xhYmVsIiwiYmFzZV91cmwiOiJodHRwczovL2NlbnRvczkta2F0ZWxsby1k
+        ZXZlbC1zdGFibGUuZXhhbXBsZS5jb20vcHVscC9jb250ZW50L0FDTUVfQ29y
+        cG9yYXRpb24vbGlicmFyeS9kZWJpYW5fcHVscF9yYWduYXJva19sYWJlbC8i
+        LCJjb250ZW50X2d1YXJkIjoiL3B1bHAvYXBpL3YzL2NvbnRlbnRndWFyZHMv
+        Y2VydGd1YXJkL3Joc20vMDE5Y2FmMGItNmU2ZC03YTdlLWFhYzEtMjM3ZThk
+        M2JkMTdhLyIsIm5vX2NvbnRlbnRfY2hhbmdlX3NpbmNlIjpudWxsLCJoaWRk
+        ZW4iOmZhbHNlLCJwdWxwX2xhYmVscyI6e30sIm5hbWUiOiJkZWJpYW5fcHVs
+        cF9yYWduYXJvayIsInJlcG9zaXRvcnkiOm51bGwsInB1YmxpY2F0aW9uIjpu
+        dWxsLCJjaGVja3BvaW50IjpmYWxzZX1dfQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: delete
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/019c4ecd-c748-76da-b4b4-f2f62fb410cf/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/019caf0b-705b-76a4-b01f-0b675d1b1fbd/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3920,7 +3718,7 @@ http_interactions:
       message: Accepted
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3940,20 +3738,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - 0c84360dc4a64875881a1f68889c04f5
+      - 4a689894681b4545b7c6f0d979688b25
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWM0ZWNkLWNiZmEtNzc0
-        NC1iNDEwLWI3MzA0Mzg3MTc0MC8ifQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+        eyJ0YXNrIjoiL3B1bHAvYXBpL3YzL3Rhc2tzLzAxOWNhZjBiLTc0OTMtNzI3
+        Mi1hODBhLTFkMTdkM2JlYTIzMS8ifQ==
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_pulp_ragnarok_label
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -3974,7 +3772,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:55 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -3994,20 +3792,20 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - ab1f2f27536e4627984811c0c422c71c
+      - 77fef52702c948d0a3b4abc509a24bd2
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
         eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
         dHMiOltdfQ==
-  recorded_at: Wed, 11 Feb 2026 22:23:55 GMT
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
 - request:
     method: get
-    uri: https://centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com/pulp/api/v3/tasks/019c4ecd-cbfa-7744-b410-b73043871740/
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/tasks/019caf0b-7493-7272-a80a-1d17d3bea231/
     body:
       encoding: US-ASCII
       base64_string: ''
@@ -4015,7 +3813,7 @@ http_interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - OpenAPI-Generator/3.85.10/ruby
+      - OpenAPI-Generator/3.85.12/ruby
       Accept:
       - application/json
       Authorization:
@@ -4028,7 +3826,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 11 Feb 2026 22:23:56 GMT
+      - Mon, 02 Mar 2026 14:54:49 GMT
       Server:
       - gunicorn
       Content-Type:
@@ -4048,31 +3846,31 @@ http_interactions:
       Cross-Origin-Opener-Policy:
       - same-origin
       Correlation-Id:
-      - eb339c9c5478491ebb69af12981f7e44
+      - 39ab6791119b4186baa22af4559ec45e
       Access-Control-Expose-Headers:
       - Correlation-ID
       Via:
-      - 1.1 centos9-pulp-upgrade.qjames-thinkpadp1gen4i.example.com
+      - 1.1 centos9-katello-devel-stable.example.com
     body:
       encoding: UTF-8
       base64_string: |
-        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5YzRlY2QtY2Jm
-        YS03NzQ0LWI0MTAtYjczMDQzODcxNzQwLyIsInBybiI6InBybjpjb3JlLnRh
-        c2s6MDE5YzRlY2QtY2JmYS03NzQ0LWI0MTAtYjczMDQzODcxNzQwIiwicHVs
-        cF9jcmVhdGVkIjoiMjAyNi0wMi0xMVQyMjoyMzo1NS45MDEzODNaIiwicHVs
-        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTExVDIyOjIzOjU1Ljg5OTU5N1oi
+        eyJwdWxwX2hyZWYiOiIvcHVscC9hcGkvdjMvdGFza3MvMDE5Y2FmMGItNzQ5
+        My03MjcyLWE4MGEtMWQxN2QzYmVhMjMxLyIsInBybiI6InBybjpjb3JlLnRh
+        c2s6MDE5Y2FmMGItNzQ5My03MjcyLWE4MGEtMWQxN2QzYmVhMjMxIiwicHVs
+        cF9jcmVhdGVkIjoiMjAyNi0wMy0wMlQxNDo1NDo0OS40OTM4MzVaIiwicHVs
+        cF9sYXN0X3VwZGF0ZWQiOiIyMDI2LTAzLTAyVDE0OjU0OjQ5LjQ5MjIyN1oi
         LCJzdGF0ZSI6ImNvbXBsZXRlZCIsIm5hbWUiOiJwdWxwY29yZS5hcHAudGFz
-        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjBjODQz
-        NjBkYzRhNjQ4NzU4ODFhMWY2ODg4OWMwNGY1IiwiY3JlYXRlZF9ieSI6Ii9w
-        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDIt
-        MTFUMjI6MjM6NTUuOTE3NTE5WiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAyLTEx
-        VDIyOjIzOjU1LjkyOTA0NVoiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDItMTFU
-        MjI6MjM6NTUuOTQ4NTYxWiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGws
+        a3MuYmFzZS5hZ2VuZXJhbF9kZWxldGUiLCJsb2dnaW5nX2NpZCI6IjRhNjg5
+        ODk0NjgxYjQ1NDViN2M2ZjBkOTc5Njg4YjI1IiwiY3JlYXRlZF9ieSI6Ii9w
+        dWxwL2FwaS92My91c2Vycy8xLyIsInVuYmxvY2tlZF9hdCI6IjIwMjYtMDMt
+        MDJUMTQ6NTQ6NDkuNTAxNDgwWiIsInN0YXJ0ZWRfYXQiOiIyMDI2LTAzLTAy
+        VDE0OjU0OjQ5LjUwMjk4M1oiLCJmaW5pc2hlZF9hdCI6IjIwMjYtMDMtMDJU
+        MTQ6NTQ6NDkuNTE3MjA0WiIsImVycm9yIjpudWxsLCJ3b3JrZXIiOm51bGws
         InBhcmVudF90YXNrIjpudWxsLCJjaGlsZF90YXNrcyI6W10sInRhc2tfZ3Jv
         dXAiOm51bGwsInByb2dyZXNzX3JlcG9ydHMiOltdLCJjcmVhdGVkX3Jlc291
-        cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjow
-        ZDI2MTFjMy0yMDZjLTQwMTYtYmI1Ny1jNGIwNTllMWRjNDA6ZGlzdHJpYnV0
-        aW9ucyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46MGQyNjExYzMtMjA2Yy00
-        MDE2LWJiNTctYzRiMDU5ZTFkYzQwIl19
-  recorded_at: Wed, 11 Feb 2026 22:23:56 GMT
-recorded_with: VCR 6.4.0
+        cmNlcyI6W10sInJlc2VydmVkX3Jlc291cmNlc19yZWNvcmQiOlsicGRybjo5
+        OTk4OGJhOC03YjFhLTQwYjktYTYyNi1hMWQzMDJmMTI5YmE6ZGlzdHJpYnV0
+        aW9ucyIsInNoYXJlZDpwcm46Y29yZS5kb21haW46OTk5ODhiYTgtN2IxYS00
+        MGI5LWE2MjYtYTFkMzAyZjEyOWJhIl19
+  recorded_at: Mon, 02 Mar 2026 14:54:49 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/apt/pulp_distributions.yml
+++ b/test/fixtures/vcr_cassettes/katello/service/pulp3/repository/apt/pulp_distributions.yml
@@ -1,0 +1,404 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/contentguards/certguard/rhsm/
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.85.9/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 04 Feb 2026 15:38:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '5960'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 622e365595dc4546aa92e4b7250dc5f1
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MSwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOlt7InB1bHBfaHJlZiI6Ii9wdWxwL2FwaS92My9jb250ZW50Z3VhcmRz
+        L2NlcnRndWFyZC9yaHNtLzAxOWMyNDBhLTM4ZGEtN2Y2Yi1iNGNiLTU0ODY5
+        YjI3MjhhMC8iLCJwcm4iOiJwcm46Y2VydGd1YXJkLnJoc21jZXJ0Z3VhcmQ6
+        MDE5YzI0MGEtMzhkYS03ZjZiLWI0Y2ItNTQ4NjliMjcyOGEwIiwicHVscF9j
+        cmVhdGVkIjoiMjAyNi0wMi0wM1QxNTowNjoxNS42NDMyNThaIiwicHVscF9s
+        YXN0X3VwZGF0ZWQiOiIyMDI2LTAyLTA0VDEyOjU3OjAwLjU2NDY5NFoiLCJu
+        YW1lIjoiUkhTTUNlcnRHdWFyZCIsImRlc2NyaXB0aW9uIjpudWxsLCJjYV9j
+        ZXJ0aWZpY2F0ZSI6IkNlcnRpZmljYXRlOlxuICAgIERhdGE6XG4gICAgICAg
+        IFZlcnNpb246IDMgKDB4MilcbiAgICAgICAgU2VyaWFsIE51bWJlcjpcbiAg
+        ICAgICAgICAgIGZkOmJhOmJjOjcxOjZlOjI1OmEzOjc4XG4gICAgU2lnbmF0
+        dXJlIEFsZ29yaXRobTogc2hhMjU2V2l0aFJTQUVuY3J5cHRpb25cbiAgICAg
+        ICAgSXNzdWVyOiBDPVVTLCBTVD1Ob3J0aCBDYXJvbGluYSwgTD1SYWxlaWdo
+        LCBPPUthdGVsbG8sIE9VPVNvbWVPcmdVbml0LCBDTj1jZW50b3M3LWRldmVs
+        Mi5zYW1pci5leGFtcGxlLmNvbVxuICAgICAgICBWYWxpZGl0eVxuICAgICAg
+        ICAgICAgTm90IEJlZm9yZTogTWF5ICA3IDE0OjIxOjUwIDIwMjAgR01UXG4g
+        ICAgICAgICAgICBOb3QgQWZ0ZXIgOiBKYW4gMTggMTQ6MjE6NTAgMjAzOCBH
+        TVRcbiAgICAgICAgU3ViamVjdDogQz1VUywgU1Q9Tm9ydGggQ2Fyb2xpbmEs
+        IEw9UmFsZWlnaCwgTz1LYXRlbGxvLCBPVT1Tb21lT3JnVW5pdCwgQ049Y2Vu
+        dG9zNy1kZXZlbDIuc2FtaXIuZXhhbXBsZS5jb21cbiAgICAgICAgU3ViamVj
+        dCBQdWJsaWMgS2V5IEluZm86XG4gICAgICAgICAgICBQdWJsaWMgS2V5IEFs
+        Z29yaXRobTogcnNhRW5jcnlwdGlvblxuICAgICAgICAgICAgICAgIFB1Ymxp
+        Yy1LZXk6ICgyMDQ4IGJpdClcbiAgICAgICAgICAgICAgICBNb2R1bHVzOlxu
+        ICAgICAgICAgICAgICAgICAgICAwMDo5ZjpkMjpjMToxMDpmZjowMToxYToz
+        MzoxOTowZTo0Mzo5ZDo4MzplNTpcbiAgICAgICAgICAgICAgICAgICAgOGE6
+        NzM6YmE6MmQ6M2M6NjY6YjE6Nzg6Y2Q6ODk6OGM6NjA6ZTU6ODE6YTY6XG4g
+        ICAgICAgICAgICAgICAgICAgIGU4OjRkOjk2OjVkOjA3OmMzOmJlOmEyOjlj
+        OmMyOjdjOjk0OjJkOjZlOjQzOlxuICAgICAgICAgICAgICAgICAgICA0NDo0
+        NjplZjpmZDozNjoyMDo0NzozYjpkNjozNTpmZDo5NzpjZDo5NzoxNzpcbiAg
+        ICAgICAgICAgICAgICAgICAgZDc6M2Y6ZTc6Njc6ZmU6YTk6MmE6ZjE6YmM6
+        NDc6ODc6NmU6ZWQ6NmQ6YjY6XG4gICAgICAgICAgICAgICAgICAgIDllOmYx
+        OjBkOjYzOjUzOmMxOjNmOmZkOjE3OmFiOjVmOjM1OjdhOjg0OmNmOlxuICAg
+        ICAgICAgICAgICAgICAgICA2YjpkZDphNjo4ZTowOTo5OTo1NjozOTpkZToy
+        OTo2YjpmYjpjMjpkYzo4YzpcbiAgICAgICAgICAgICAgICAgICAgNTY6MmE6
+        MTA6YjM6MGE6Y2E6Yjg6NmM6ZmI6Yjg6Yzg6ZWI6ZTU6ZTI6YWU6XG4gICAg
+        ICAgICAgICAgICAgICAgIGQ1OjQxOjA1OjRjOmEyOmMwOmJlOjdiOmIwOjZk
+        OjFkOjdjOjY2OjgwOjg4OlxuICAgICAgICAgICAgICAgICAgICA1YTpiNzow
+        Nzo5YjpkMzpiODpmZjo5MzpmMzoxOTozMzo2Mzo0ODo5NTo4MzpcbiAgICAg
+        ICAgICAgICAgICAgICAgMzQ6Mjc6YzY6YWM6Y2M6YTA6MGI6NTY6YWI6MjI6
+        MzQ6NzE6NGY6Nzk6YmY6XG4gICAgICAgICAgICAgICAgICAgIDZlOjRiOmM5
+        Ojg5OjU5Ojg3OjhiOjdiOjM1Ojc5OmI4OjFjOjcwOmVlOjU4OlxuICAgICAg
+        ICAgICAgICAgICAgICBlNjo3YjoyMjo3OTphNzoxZTpkOTpiMjo1NzozYTpl
+        MDo1OTo4ZTpiMzo2YTpcbiAgICAgICAgICAgICAgICAgICAgOTc6M2Q6OWE6
+        ODA6Y2M6M2I6ZDU6Nzc6ZDQ6ZmE6N2E6NTg6Njk6YjY6YjM6XG4gICAgICAg
+        ICAgICAgICAgICAgIGFhOjk1OjU0OjU1OjllOjEzOjY1OjdmOjk1OmMwOjcz
+        Ojk2OmM1OmZiOjc3OlxuICAgICAgICAgICAgICAgICAgICBhMDo0ODoyMDph
+        Njo3ZDpmNDpjNDpkMzplOTphYjo5NDo5Mzo0ZToxYTplMjpcbiAgICAgICAg
+        ICAgICAgICAgICAgNWQ6OWI6YzU6ODc6NTA6Yzc6NTY6ZjA6OTM6YTg6Yjk6
+        MGE6NzM6Y2Y6Zjc6XG4gICAgICAgICAgICAgICAgICAgIDAxOjBmXG4gICAg
+        ICAgICAgICAgICAgRXhwb25lbnQ6IDY1NTM3ICgweDEwMDAxKVxuICAgICAg
+        ICBYNTA5djMgZXh0ZW5zaW9uczpcbiAgICAgICAgICAgIFg1MDl2MyBCYXNp
+        YyBDb25zdHJhaW50czpcbiAgICAgICAgICAgICAgICBDQTpUUlVFXG4gICAg
+        ICAgICAgICBYNTA5djMgS2V5IFVzYWdlOlxuICAgICAgICAgICAgICAgIERp
+        Z2l0YWwgU2lnbmF0dXJlLCBLZXkgRW5jaXBoZXJtZW50LCBDZXJ0aWZpY2F0
+        ZSBTaWduLCBDUkwgU2lnblxuICAgICAgICAgICAgWDUwOXYzIEV4dGVuZGVk
+        IEtleSBVc2FnZTpcbiAgICAgICAgICAgICAgICBUTFMgV2ViIFNlcnZlciBB
+        dXRoZW50aWNhdGlvbiwgVExTIFdlYiBDbGllbnQgQXV0aGVudGljYXRpb25c
+        biAgICAgICAgICAgIE5ldHNjYXBlIENlcnQgVHlwZTpcbiAgICAgICAgICAg
+        ICAgICBTU0wgU2VydmVyLCBTU0wgQ0FcbiAgICAgICAgICAgIE5ldHNjYXBl
+        IENvbW1lbnQ6XG4gICAgICAgICAgICAgICAgS2F0ZWxsbyBTU0wgVG9vbCBH
+        ZW5lcmF0ZWQgQ2VydGlmaWNhdGVcbiAgICAgICAgICAgIFg1MDl2MyBTdWJq
+        ZWN0IEtleSBJZGVudGlmaWVyOlxuICAgICAgICAgICAgICAgIDlCOkQyOkQ5
+        OjY5Ojg4Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjRE
+        OjUzOjVEXG4gICAgICAgICAgICBYNTA5djMgQXV0aG9yaXR5IEtleSBJZGVu
+        dGlmaWVyOlxuICAgICAgICAgICAgICAgIGtleWlkOjlCOkQyOkQ5OjY5Ojg4
+        Ojk5OjJDOjJFOjcwOjJCOkI3OjY5Ojc2OjdBOjdEOkQxOjg1OjREOjUzOjVE
+        XG4gICAgICAgICAgICAgICAgRGlyTmFtZTovQz1VUy9TVD1Ob3J0aCBDYXJv
+        bGluYS9MPVJhbGVpZ2gvTz1LYXRlbGxvL09VPVNvbWVPcmdVbml0L0NOPWNl
+        bnRvczctZGV2ZWwyLnNhbWlyLmV4YW1wbGUuY29tXG4gICAgICAgICAgICAg
+        ICAgc2VyaWFsOkZEOkJBOkJDOjcxOjZFOjI1OkEzOjc4XG5cbiAgICBTaWdu
+        YXR1cmUgQWxnb3JpdGhtOiBzaGEyNTZXaXRoUlNBRW5jcnlwdGlvblxuICAg
+        ICAgICAgMzI6MTk6NmM6YzY6YWY6YWU6YzI6YmU6NjQ6MTY6YjA6N2M6YTM6
+        NGI6MTA6ZTg6NWE6YjQ6XG4gICAgICAgICAxNzo3NDpmZDo3NTpjNjoyNjpk
+        Mjo4ODowMTpmZTo5NToyZTozZjowYToxZTo4ODphNToyNTpcbiAgICAgICAg
+        IDEzOjZiOjYwOjM0OmQwOjJjOmRlOmQ4OjQ4OjE1OmY1OmNjOjFmOjA3Ojgw
+        OjJiOjFkOjI4OlxuICAgICAgICAgOTA6ZTk6OGI6NDc6YzE6NzE6MWE6ZGE6
+        ODY6YTA6Mjc6ZTg6YzQ6ODg6MzY6YTM6ZmY6ZGI6XG4gICAgICAgICAxNzoy
+        ZjowZTo5YjplMTozOTphNzoxZjpkYzoyNjo5NzoyOTo1ZTo0Yjo5OTo2MDpm
+        YTo5MjpcbiAgICAgICAgIDEyOjI0OmZjOmJjOjA0Ojk0OjI0OjY1OmYzOjYw
+        OmNjOjVlOmVlOjQyOmJmOjllOjNjOjMxOlxuICAgICAgICAgYjk6M2M6OTk6
+        OGE6NDQ6M2Q6Mjk6NWQ6YTY6OTk6YWE6ZDU6MGU6MTU6OTQ6YzQ6YzU6MjM6
+        XG4gICAgICAgICA4YzpiOTo2ZTplNTowOToxMzo4Yzo1Njo0YjowNDozNTo5
+        NTo3OTo1MDo1YzoyMjoyZDoxZjpcbiAgICAgICAgIDNhOjY4OmQwOmYzOjNl
+        Ojg4OjdkOjM4OjI5OjMyOmYyOjQ3OmIxOjE3Ojk5OmZkOmE2OjQ4OlxuICAg
+        ICAgICAgMDI6MDQ6NmI6OWY6Yjk6ZGE6YzI6NmU6NjU6OWI6OTk6ZTQ6NjA6
+        N2E6MzI6Y2Q6MDI6ZmU6XG4gICAgICAgICA3MTpkYToxOTplMzo5MzpiZDpj
+        NTphNzphMDo0Njo5ZToyODpkMjo5MTphYzo4ZTo5MTpjNzpcbiAgICAgICAg
+        IGE3OjUxOjRlOjgxOjA5OmQxOmYxOjM5OjViOjA3Ojg3OjQxOjNiOmI3OmUz
+        OjFiOmE4OjdlOlxuICAgICAgICAgNTE6NTI6NGU6NjY6MjA6YjE6Y2Q6YzU6
+        YWU6ZGU6MTc6M2E6ZDc6Y2U6MDc6Mzc6ZDg6NWU6XG4gICAgICAgICA4ODpl
+        ZjplMzo5NDpjMDo5ODozZTpjMzowZDo1MTo0NDozZDo1Mzo1MjpmZjo1ZTow
+        YjoxYjpcbiAgICAgICAgIDViOjZjOjliOmE2XG4tLS0tLUJFR0lOIENFUlRJ
+        RklDQVRFLS0tLS1cbk1JSUZCekNDQSsrZ0F3SUJBZ0lKQVAyNnZIRnVKYU40
+        TUEwR0NTcUdTSWIzRFFFQkN3VUFNSUdMTVFzd0NRWURcblZRUUdFd0pWVXpF
+        WE1CVUdBMVVFQ0F3T1RtOXlkR2dnUTJGeWIyeHBibUV4RURBT0JnTlZCQWNN
+        QjFKaGJHVnBcbloyZ3hFREFPQmdOVkJBb01CMHRoZEdWc2JHOHhGREFTQmdO
+        VkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURcblZRUUREQ0JqWlc1MGIz
+        TTNMV1JsZG1Wc01pNXpZVzFwY2k1bGVHRnRjR3hsTG1OdmJUQWVGdzB5TURB
+        MU1EY3hcbk5ESXhOVEJhRncwek9EQXhNVGd4TkRJeE5UQmFNSUdMTVFzd0NR
+        WURWUVFHRXdKVlV6RVhNQlVHQTFVRUNBd09cblRtOXlkR2dnUTJGeWIyeHBi
+        bUV4RURBT0JnTlZCQWNNQjFKaGJHVnBaMmd4RURBT0JnTlZCQW9NQjB0aGRH
+        VnNcbmJHOHhGREFTQmdOVkJBc01DMU52YldWUGNtZFZibWwwTVNrd0p3WURW
+        UVFERENCalpXNTBiM00zTFdSbGRtVnNcbk1pNXpZVzFwY2k1bGVHRnRjR3hs
+        TG1OdmJUQ0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0Nc
+        bmdnRUJBSi9Td1JEL0FSb3pHUTVEbllQbGluTzZMVHhtc1hqTmlZeGc1WUdt
+        NkUyV1hRZkR2cUtjd255VUxXNURcblJFYnYvVFlnUnp2V05mMlh6WmNYMXov
+        blovNnBLdkc4UjRkdTdXMjJudkVOWTFQQlAvMFhxMTgxZW9UUGE5Mm1cbmpn
+        bVpWam5lS1d2N3d0eU1WaW9Rc3dyS3VHejd1TWpyNWVLdTFVRUZUS0xBdm51
+        d2JSMThab0NJV3JjSG05TzRcbi81UHpHVE5qU0pXRE5DZkdyTXlnQzFhcklq
+        UnhUM20vYmt2SmlWbUhpM3MxZWJnY2NPNVk1bnNpZWFjZTJiSlhcbk91Qlpq
+        ck5xbHoyYWdNdzcxWGZVK25wWWFiYXpxcFZVVlo0VFpYK1Z3SE9XeGZ0M29F
+        Z2dwbjMweE5QcHE1U1RcblRocmlYWnZGaDFESFZ2Q1RxTGtLYzgvM0FROENB
+        d0VBQWFPQ0FXb3dnZ0ZtTUF3R0ExVWRFd1FGTUFNQkFmOHdcbkN3WURWUjBQ
+        QkFRREFnR21NQjBHQTFVZEpRUVdNQlFHQ0NzR0FRVUZCd01CQmdnckJnRUZC
+        UWNEQWpBUkJnbGdcbmhrZ0JodmhDQVFFRUJBTUNBa1F3TlFZSllJWklBWWI0
+        UWdFTkJDZ1dKa3RoZEdWc2JHOGdVMU5NSUZSdmIyd2dcblIyVnVaWEpoZEdW
+        a0lFTmxjblJwWm1sallYUmxNQjBHQTFVZERnUVdCQlNiMHRscGlKa3NMbkFy
+        dDJsMmVuM1JcbmhVMVRYVENCd0FZRFZSMGpCSUc0TUlHMWdCU2IwdGxwaUpr
+        c0xuQXJ0MmwyZW4zUmhVMVRYYUdCa2FTQmpqQ0Jcbml6RUxNQWtHQTFVRUJo
+        TUNWVk14RnpBVkJnTlZCQWdNRGs1dmNuUm9JRU5oY205c2FXNWhNUkF3RGdZ
+        RFZRUUhcbkRBZFNZV3hsYVdkb01SQXdEZ1lEVlFRS0RBZExZWFJsYkd4dk1S
+        UXdFZ1lEVlFRTERBdFRiMjFsVDNKblZXNXBcbmRERXBNQ2NHQTFVRUF3d2dZ
+        MlZ1ZEc5ek55MWtaWFpsYkRJdWMyRnRhWEl1WlhoaGJYQnNaUzVqYjIyQ0NR
+        RDlcbnVyeHhiaVdqZURBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQU1obHN4
+        cSt1d3I1a0ZyQjhvMHNRNkZxMEYzVDlcbmRjWW0wb2dCL3BVdVB3b2VpS1Vs
+        RTJ0Z05OQXMzdGhJRmZYTUh3ZUFLeDBva09tTFI4RnhHdHFHb0Nmb3hJZzJc
+        bm8vL2JGeThPbStFNXB4L2NKcGNwWGt1WllQcVNFaVQ4dkFTVUpHWHpZTXhl
+        N2tLL25qd3h1VHlaaWtROUtWMm1cbm1hclZEaFdVeE1VampMbHU1UWtUakZa
+        TEJEV1ZlVkJjSWkwZk9talE4ejZJZlRncE12SkhzUmVaL2FaSUFnUnJcbm43
+        bmF3bTVsbTVua1lIb3l6UUwrY2RvWjQ1Tzl4YWVnUnA0bzBwR3NqcEhIcDFG
+        T2dRblI4VGxiQjRkQk83Zmpcbkc2aCtVVkpPWmlDeHpjV3UzaGM2MTg0SE45
+        aGVpTy9qbE1DWVBzTU5VVVE5VTFML1hnc2JXMnlicGc9PVxuLS0tLS1FTkQg
+        Q0VSVElGSUNBVEUtLS0tLSJ9XX0=
+  recorded_at: Wed, 04 Feb 2026 15:38:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/repositories/deb/apt/?name=debian_9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 04 Feb 2026 15:38:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - f141986b07a54af1bfddbab3f8f48de6
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 04 Feb 2026 15:38:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/remotes/deb/apt/?name=debian_9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 04 Feb 2026 15:38:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 4002155cca1845eba932cc23b51e686b
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 04 Feb 2026 15:38:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?name=debian_9
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 04 Feb 2026 15:38:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 89b40ad102844ee6bdca511bf5cb0c22
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 04 Feb 2026 15:38:29 GMT
+- request:
+    method: get
+    uri: https://centos9-katello-devel-stable.example.com/pulp/api/v3/distributions/deb/apt/?base_path=ACME_Corporation/library/debian_9_label
+    body:
+      encoding: US-ASCII
+      base64_string: ''
+    headers:
+      Content-Type:
+      - application/json
+      User-Agent:
+      - OpenAPI-Generator/3.7.0/ruby
+      Accept:
+      - application/json
+      Authorization:
+      - Basic Og==
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 04 Feb 2026 15:38:29 GMT
+      Server:
+      - gunicorn
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept,Cookie
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '52'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Correlation-Id:
+      - 79ff1125670a43049cfa229f21566a7a
+      Access-Control-Expose-Headers:
+      - Correlation-ID
+      Via:
+      - 1.1 centos9-katello-devel-stable.example.com
+    body:
+      encoding: UTF-8
+      base64_string: |
+        eyJjb3VudCI6MCwibmV4dCI6bnVsbCwicHJldmlvdXMiOm51bGwsInJlc3Vs
+        dHMiOltdfQ==
+  recorded_at: Wed, 04 Feb 2026 15:38:29 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
Remaining work: Everything relating to tests.

## Summary by Sourcery

Improve handling of empty metadata for Debian repositories in Pulp and add validation for missing deb entities.

Bug Fixes:
- Ensure initial empty deb metadata is removed from Pulp repositories before syncing or uploading real content, preventing stale empty components from persisting.
- Raise a dedicated error when a deb repository version lacks required components or distributions, surfacing inconsistent or invalid repository states earlier.

Enhancements:
- Add support to destroy the initially created empty deb component metadata on demand via the repository backend service.
- Always initialize deb repositories on creation, regardless of whether they are library instances.

Tests:
- Update deb upload orchestration tests to account for additional repository versions created by initializing and later removing empty deb metadata.