### PR TITLE
Fixes #39145 - Add Pulp 3.105 gems to gemspec

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -51,15 +51,15 @@ Gem::Specification.new do |gem|
   # Pulp dependencies
   # faraday pin for compatibility with foreman_azure_rm
   gem.add_dependency "faraday", ">= 1.10.2", "< 1.11.0"
-  gem.add_dependency "pulpcore_client", ">= 3.85.0", "< 3.86.0"
-  gem.add_dependency "pulp_file_client", ">= 3.85.0", "< 3.86.0"
-  gem.add_dependency "pulp_ansible_client", ">= 0.28.0", "< 0.29.0"
-  gem.add_dependency "pulp_container_client", ">= 2.26.0", "< 2.27.0"
+  gem.add_dependency "pulpcore_client", ">= 3.105.0", "< 3.106.0"
+  gem.add_dependency "pulp_file_client", ">= 3.105.0", "< 3.106.0"
+  gem.add_dependency "pulp_ansible_client", ">= 0.29.0", "< 0.30.0"
+  gem.add_dependency "pulp_container_client", ">= 2.27.0", "< 2.28.0"
   gem.add_dependency "pulp_deb_client", ">= 3.8.0", "< 3.9.0"
-  gem.add_dependency "pulp_rpm_client", ">= 3.32.0", "< 3.33.0"
-  gem.add_dependency "pulp_certguard_client", ">= 3.85.0", "< 3.86.0"
-  gem.add_dependency "pulp_python_client", ">= 3.19.0", "< 3.20.0"
-  gem.add_dependency "pulp_ostree_client", ">= 2.5.0", "< 2.6.0"
+  gem.add_dependency "pulp_rpm_client", ">= 3.35.0", "< 3.36.0"
+  gem.add_dependency "pulp_certguard_client", ">= 3.105.0", "< 3.106.0"
+  gem.add_dependency "pulp_python_client", ">= 3.27.0", "< 3.28.0"
+  gem.add_dependency "pulp_ostree_client", ">= 2.6.0", "< 2.7.0"
 
   # UI
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add the Pulp 3.105 gems to gemspec. These were tested on a Katello devel environment and all work without issue.

#### Considerations taken when implementing this change?
See [this post](https://community.theforeman.org/t/request-for-pulpcore-3-105-builds/45973) to check status of RPM build.

#### What are the testing steps for this pull request?
1. Pull changes on a Pulp 3.105 box.
2. Run `bundle update` and `bundle pristine` to install gems.
3. Make sure Katello can push / pull different types of content to and from Pulp.

## Summary by Sourcery

Update Katello gemspec to align Pulp client dependencies with the Pulp 3.105 release series.

Bug Fixes:
- Ensure compatibility with Pulp 3.105 by bumping required versions of core and plugin client gems.

Enhancements:
- Raise version constraints for multiple Pulp client gems (core, file, ansible, container, rpm, certguard, python, ostree) to the corresponding 3.105-compatible ranges in the gemspec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated multiple Pulp client dependency version ranges to newer releases, improving compatibility with recent Pulp versions, reducing potential dependency conflicts, and enhancing overall stability of backend integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->