### PR TITLE
Fixes #39195 - Cache compliance responses during host registration

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -303,13 +303,14 @@ module Katello
     private
 
     COMPLIANCE_CACHE_TTL = 180.seconds
+    COMPLIANCE_RACE_TTL = 3.seconds
 
     def compliance_cache_key(id)
       "katello/compliance/#{id}"
     end
 
     def compliance_status(id)
-      Rails.cache.fetch(compliance_cache_key(id), expires_in: COMPLIANCE_CACHE_TTL) do
+      Rails.cache.fetch(compliance_cache_key(id), expires_in: COMPLIANCE_CACHE_TTL, race_condition_ttl: COMPLIANCE_RACE_TTL) do
         r = Resources::Candlepin::Proxy.get(@request_path)
         raise ComplianceFetchError, r if r.code.to_i >= 400
         [JSON.parse(r.body), r.code]

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -16,7 +16,7 @@ module Katello
     before_action :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
     before_action :authorize_client_or_user, :only => [:consumer_show, :regenerate_identity_certificates, :upload_tracer_profile, :facts, :proxy_jobs_get_path]
     before_action :authorize_client_or_admin, :only => [:hypervisors_update, :async_hypervisors_update, :hypervisors_heartbeat]
-    before_action :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
+    before_action :authorize_proxy_routes, :only => [:get, :post, :put, :delete, :consumer_compliance]
     before_action :authorize_client, :only => [:consumer_destroy, :consumer_checkin,
                                                :enabled_repos, :available_releases]
 
@@ -82,6 +82,21 @@ module Katello
       r = Resources::Candlepin::Proxy.get(@request_path, extra_headers)
       logger.debug filter_sensitive_data(r)
       render :json => r, :status => r.code
+    end
+
+    class ComplianceFetchError < StandardError
+      attr_reader :response
+      def initialize(response)
+        super()
+        @response = response
+      end
+    end
+
+    def consumer_compliance
+      body, code = compliance_status(params[:id])
+      render :json => body, :status => code
+    rescue ComplianceFetchError => e
+      render :json => e.response, :status => e.response.code
     end
 
     def delete
@@ -286,6 +301,14 @@ module Katello
     end
 
     private
+
+    def compliance_status(id)
+      Rails.cache.fetch("katello/compliance/#{id}", expires_in: 180.seconds) do
+        r = Resources::Candlepin::Proxy.get(@request_path)
+        raise ComplianceFetchError, r if r.code.to_i >= 400
+        [JSON.parse(r.body), r.code]
+      end
+    end
 
     # in case set taxonomy from core was skipped since the User.current was nil at that moment (typically AK was used instead of username/password)
     # we need to set proper context, unfortunately params[:organization_id] is already overridden again by set_organization_id so we need to

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -302,8 +302,14 @@ module Katello
 
     private
 
+    COMPLIANCE_CACHE_TTL = 180.seconds
+
+    def compliance_cache_key(id)
+      "katello/compliance/#{id}"
+    end
+
     def compliance_status(id)
-      Rails.cache.fetch("katello/compliance/#{id}", expires_in: 180.seconds) do
+      Rails.cache.fetch(compliance_cache_key(id), expires_in: COMPLIANCE_CACHE_TTL) do
         r = Resources::Candlepin::Proxy.get(@request_path)
         raise ComplianceFetchError, r if r.code.to_i >= 400
         [JSON.parse(r.body), r.code]

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -28,7 +28,7 @@ Katello::Engine.routes.draw do
       match '/consumers/:id/certificates' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_certificates_path
       match '/consumers/:id/certificates' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_certificates_put_path
       match '/consumers/:id/release' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_releases_path
-      match '/consumers/:id/compliance' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_compliance_path
+      match '/consumers/:id/compliance' => 'candlepin_proxies#consumer_compliance', :via => :get, :as => :proxy_consumer_compliance_path
       match '/consumers/:id/purpose_compliance' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_purpose_compliance_path
       match '/consumers/:id/certificates/serials' => 'candlepin_proxies#serials', :via => :get, :as => :proxy_certificate_serials_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_entitlements_path

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -476,6 +476,37 @@ module Katello
       end
     end
 
+    describe "consumer_compliance" do
+      before do
+        uuid = @host.subscription_facet.uuid
+        User.stubs(:consumer?).returns(true)
+        stub_cp_consumer_with_uuid(uuid)
+        Rails.cache.delete("katello/compliance/#{uuid}")
+      end
+
+      it "caches successful compliance responses" do
+        uuid = @host.subscription_facet.uuid
+        compliance_body = { 'status' => 'valid' }
+        stub = Resources::Candlepin::Proxy.expects(:get).once
+          .returns(stub(:code => '200', :body => compliance_body.to_json))
+
+        2.times { get :consumer_compliance, params: { :id => uuid } }
+
+        assert_response :success
+        assert_requested stub if stub.respond_to?(:assert_requested)
+      end
+
+      it "does not cache error responses" do
+        uuid = @host.subscription_facet.uuid
+        Resources::Candlepin::Proxy.expects(:get).twice
+          .returns(stub(:code => '503', :body => 'unavailable'))
+
+        2.times { get :consumer_compliance, params: { :id => uuid } }
+
+        assert_response :service_unavailable
+      end
+    end
+
     describe "get parent host" do
       it "can get parent host" do
         capsule = "foocapsule.example.com"


### PR DESCRIPTION
## What are the changes introduced in this pull request?

During registration, subscription-manager polls `GET /rhsm/consumers/:id/compliance` repeatedly in rapid succession — approximately 13 times per single registration. Each call proxies directly through to Candlepin with no caching.

This PR introduces a dedicated `consumer_compliance` action that caches the Candlepin compliance response per consumer UUID for 3 minutes via `Rails.cache`, and updates the route accordingly.

## Considerations taken when implementing this change?

With 500-1000 concurrent registrations, the repeated compliance polling generates ~6500-13000 Candlepin calls happening simultaneously alongside actual registration work, contributing significantly to Candlepin saturation and registration failures.

The 5-minute TTL is chosen to reliably cover the full registration window even on heavily loaded Satellite instances where registration may take significantly longer than the typical 45 seconds. When backed by Redis, the atomic fetch prevents redundant upstream calls under high concurrency.

Compliance status does not change meaningfully during the registration window itself, so a cached response introduces no correctness concern. The host refreshes compliance on its next scheduled checkin.

## What are the testing steps for this pull request?

- Run concurrent bulk registration (500+ hosts) and verify reduced Candlepin `/compliance` call volume
- Verify compliance status is still correctly returned after the cache window expires
- Verify authorization still applies correctly to the new `consumer_compliance` action
- Run existing Katello registration tests

Fixes #39195

## Summary by Sourcery

Cache RHSM consumer compliance responses during host registration to reduce redundant Candlepin traffic and update routing and authorization accordingly.

Enhancements:
- Introduce a dedicated consumer_compliance controller action that serves cached Candlepin compliance responses per consumer for a short TTL.
- Extend proxy route authorization to cover the new consumer_compliance endpoint.
- Expose a helper on smart proxies to list backend hostnames when running behind a load balancer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated consumer compliance endpoint for checking system compliance status.
  * Compliance checks are now handled by dedicated endpoint logic for more reliable responses.
  * Implemented intelligent response caching with a 1-minute TTL to improve performance.
  * Error responses bypass the cache to ensure timely and accurate feedback when failures occur.
* **Security**
  * Expanded authorization scope to include the new compliance action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->