### PR TITLE
Fixes #39202 - Eliminate redundant Candlepin GETs during host registration

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -211,13 +211,13 @@ module Katello
 
     #api :POST, "/environments/:environment_id/consumers", N_("Register a consumer in environment")
     def consumer_create
-      host = Katello::RegistrationManager.process_registration(rhsm_params, find_content_view_environments)
+      host, consumer_data = Katello::RegistrationManager.process_registration(rhsm_params, find_content_view_environments)
 
       host.reload
 
       update_host_registered_through(host, request.headers)
 
-      render :json => Resources::Candlepin::Consumer.get(host.subscription_facet.uuid)
+      render :json => consumer_data
     end
 
     #api :DELETE, "/consumers/:id", N_("Unregister a consumer")
@@ -239,12 +239,11 @@ module Katello
       additional_set_taxonomy
       activation_keys = find_activation_keys
 
-      host = Katello::RegistrationManager.process_registration(rhsm_params, nil, activation_keys)
+      host, consumer_data = Katello::RegistrationManager.process_registration(rhsm_params, nil, activation_keys)
 
       update_host_registered_through(host, request.headers)
-      host.reload
 
-      render :json => Resources::Candlepin::Consumer.get(host.subscription_facet.uuid)
+      render :json => consumer_data
     end
 
     #api :GET, "/status", N_("Shows version information")

--- a/app/controllers/katello/api/v2/host_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/host_subscriptions_controller.rb
@@ -53,7 +53,7 @@ module Katello
     def create
       rhsm_params = params_to_rhsm_params
 
-      host = Katello::RegistrationManager.process_registration(rhsm_params, [@content_view_environment])
+      host, _consumer_data = Katello::RegistrationManager.process_registration(rhsm_params, [@content_view_environment])
       host.reload
       ::Katello::Host::SubscriptionFacet.update_facts(host, rhsm_params[:facts]) unless rhsm_params[:facts].blank?
 

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -33,13 +33,13 @@ module Katello
         )
         host.organization = organization unless host.organization
 
-        register_host(host, rhsm_params, content_view_environments, activation_keys)
+        consumer_data = register_host(host, rhsm_params, content_view_environments, activation_keys)
 
         if host_uuid_overridden
           host.subscription_facet.update_dmi_uuid_override(host_uuid)
         end
 
-        host
+        [host, consumer_data]
       end
 
       def dmi_uuid_allowed_dups
@@ -181,8 +181,9 @@ module Katello
         host.subscription_facet = populate_subscription_facet(host, activation_keys, consumer_params, host_uuid)
         host.save! # the host has content and subscription facets at this point
 
+        consumer_data = nil
         User.as_anonymous_admin do
-          begin
+          consumer_data = begin
             create_in_candlepin(host, content_view_environments, consumer_params, activation_keys)
           rescue StandardError => e
             # Invalidate the cached Candlepin status immediately so subsequent
@@ -195,8 +196,10 @@ module Katello
             raise e
           end
 
-          finalize_registration(host)
+          finalize_registration(host, consumer_data)
         end
+
+        consumer_data
       end
       # rubocop:enable Metrics/MethodLength
 
@@ -231,19 +234,17 @@ module Katello
         # if CP fails, nothing to clean up yet w.r.t. backend services
         cp_create = ::Katello::Resources::Candlepin::Consumer.create(content_view_environments.map(&:cp_id), consumer_params, activation_keys.map(&:cp_name), host.organization)
         ::Katello::Host::SubscriptionFacet.update_facts(host, consumer_params[:facts]) unless consumer_params[:facts].blank?
-        uuid = cp_create[:uuid]
-        if uuid.present? && uuid != host.subscription_facet.uuid
-          Rails.logger.info(_("Candlepin returned different consumer uuid than requested (%s), updating uuid in subscription_facet.") % uuid)
-          host.subscription_facet.uuid = uuid
+        fail ::Katello::Errors::CandlepinError, _("Candlepin consumer registration response is missing a uuid") if cp_create&.[]('uuid').blank?
+        if cp_create['uuid'] != host.subscription_facet.uuid
+          Rails.logger.info(_("Candlepin returned different consumer uuid than requested (%s), updating uuid in subscription_facet.") % cp_create['uuid'])
+          host.subscription_facet.uuid = cp_create['uuid']
           host.subscription_facet.save!
         end
-        uuid
+        cp_create
       end
 
-      def finalize_registration(host)
-        host = ::Host.find(host.id)
-        host.subscription_facet.update_from_consumer_attributes(host.subscription_facet.candlepin_consumer.
-            consumer_attributes.except(:guestIds, :facts))
+      def finalize_registration(host, consumer_attributes)
+        host.subscription_facet.update_from_consumer_attributes(consumer_attributes.except(:guestIds, :facts))
         host.subscription_facet.save!
         host.refresh_statuses([
                                 ::Katello::ErrataStatus,

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -54,19 +54,18 @@ module Katello
       end
 
       it "should register" do
-        Resources::Candlepin::Consumer.stubs(:get)
-
-        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts}, nil, [@activation_key]).returns(@host)
+        Resources::Candlepin::Consumer.expects(:get).never
+        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts}, nil, [@activation_key]).returns([@host, { 'uuid' => 'fake-uuid' }])
 
         post(:consumer_activate, params: { :organization_id => @activation_key.organization.label, :activation_keys => @activation_key.name, :facts => @facts })
 
         assert_response :success
+        assert_equal 'fake-uuid', JSON.parse(response.body)['uuid']
       end
 
       it "de-duplicates provided activation key names" do
-        Resources::Candlepin::Consumer.stubs(:get)
-
-        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts}, nil, [@activation_key]).returns(@host)
+        Resources::Candlepin::Consumer.expects(:get).never
+        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts}, nil, [@activation_key]).returns([@host, { 'uuid' => 'fake-uuid' }])
 
         key_names = "#{@activation_key.name},#{@activation_key.name}"
 
@@ -95,19 +94,20 @@ module Katello
       end
 
       it "should register" do
+        Resources::Candlepin::Consumer.expects(:get).never
         ::Katello::RegistrationManager.expects(:check_registration_services).returns(true)
-        Resources::Candlepin::Consumer.stubs(:get)
-        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts }, [@content_view_environment]).returns(@host)
+        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts }, [@content_view_environment]).returns([@host, { 'uuid' => 'fake-uuid' }])
 
         post(:consumer_create, params: { :organization_id => @content_view_environment.content_view.organization.label, :environment_id => @content_view_environment.cp_id, :facts => @facts })
 
         assert_response :success
+        assert_equal 'fake-uuid', JSON.parse(response.body)['uuid']
       end
 
       it "should register with new environments param" do
+        Resources::Candlepin::Consumer.expects(:get).never
         ::Katello::RegistrationManager.expects(:check_registration_services).returns(true)
-        Resources::Candlepin::Consumer.stubs(:get)
-        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts }, [@content_view_environment]).returns(@host)
+        ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts }, [@content_view_environment]).returns([@host, { 'uuid' => 'fake-uuid' }])
 
         post(:consumer_create, params: { :organization_id => @content_view_environment.content_view.organization.label, :environments => [{id: @content_view_environment.cp_id}], :facts => @facts })
 

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -60,9 +60,10 @@ module Katello
         }],
       }
       content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment).id)
-      Resources::Candlepin::Consumer.stubs(:get)
+      consumer_data = { 'uuid' => 'consumer-uuid-ignored-by-this-endpoint' }
+      Resources::Candlepin::Consumer.expects(:get).never
       ::Katello::RegistrationManager.expects(:check_registration_services).returns(true)
-      ::Katello::RegistrationManager.expects(:process_registration).with(expected_consumer_params, [content_view_environment]).returns(@host)
+      ::Katello::RegistrationManager.expects(:process_registration).with(expected_consumer_params, [content_view_environment]).returns([@host, consumer_data])
       post(:create,
         params: {
           :lifecycle_environment_id => content_view_environment.environment_id,
@@ -75,6 +76,12 @@ module Katello
       )
 
       assert_response :success
+      body = JSON.parse(response.body)
+      # The controller renders the host, not the consumer data returned by
+      # RegistrationManager. Verify the host name is present and the
+      # consumer UUID is not surfaced in the response.
+      assert_equal @host.name, body['name']
+      refute_equal consumer_data['uuid'], body['uuid']
     end
 
     def test_create_dead_backend

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -213,8 +213,7 @@ module Katello
 
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
 
-        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([@content_view_environment.cp_id], rhsm_params, [], @library.organization).returns(:uuid => 'fake-uuid-from-candlepin')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-candlepin').returns({})
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([@content_view_environment.cp_id], rhsm_params, [], @library.organization).returns('uuid' => 'fake-uuid-from-candlepin')
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_hypervisor).twice
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_guests).twice
 
@@ -230,9 +229,8 @@ module Katello
 
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
 
-        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([cvpe.cp_id], rhsm_params, ["cp_name_baz"], @host_collection.organization).returns(:uuid => 'fake-uuid-from-katello')
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([cvpe.cp_id], rhsm_params, ["cp_name_baz"], @host_collection.organization).returns('uuid' => 'fake-uuid-from-katello')
         Katello::ActivationKey.any_instance.stubs(:cp_name).returns('cp_name_baz')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-katello').returns({})
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_hypervisor).twice
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_guests).twice
         ::Host::Managed.any_instance.stubs(:refresh_statuses)
@@ -272,8 +270,7 @@ module Katello
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
         ::Host::Managed.any_instance.stubs(:refresh_statuses)
 
-        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([@content_view_environment.cp_id], rhsm_params, [], @content_view.organization).returns(:uuid => 'fake-uuid-from-katello')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-katello').returns({})
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([@content_view_environment.cp_id], rhsm_params, [], @content_view.organization).returns('uuid' => 'fake-uuid-from-katello')
 
         ::Katello::RegistrationManager.register_host(@host, rhsm_params, [@content_view_environment])
       end
@@ -407,8 +404,7 @@ module Katello
         # Mock the necessary methods for re-registration
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
-        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([@content_view_environment.cp_id], rhsm_params, [], @content_view.organization).returns(:uuid => 'fake-uuid-from-katello')
-        ::Katello::Resources::Candlepin::Consumer.expects(:get).once.with('fake-uuid-from-katello').returns({})
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).with([@content_view_environment.cp_id], rhsm_params, [], @content_view.organization).returns('uuid' => 'fake-uuid-from-katello')
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_hypervisor).twice
         ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_guests).twice
         ::Host::Managed.any_instance.stubs(:refresh_statuses)


### PR DESCRIPTION
## What are the changes introduced in this pull request?

Every `POST /rhsm/consumers` previously made three HTTP calls to Candlepin:

1. `POST /candlepin/consumers` — creates the consumer, returns full JSON (unavoidable)
2. `GET /candlepin/consumers/{uuid}` — in `finalize_registration`, to feed `update_from_consumer_attributes`
3. `GET /candlepin/consumers/{uuid}` — in the controller, for the final render returned to subscription-manager

This PR eliminates calls 2 and 3 by passing the POST response through the call chain. Additionally removes a redundant `Host.find` re-fetch in `finalize_registration` and a `host.reload` in `consumer_activate` that existed solely to support the now-eliminated GET.

Net result: **2 fewer Candlepin GET calls and 2 fewer DB SELECTs per registration**.

## Considerations taken when implementing this change?

Calls 2 and 3 are pure overhead: the POST response already contains the complete, canonical consumer state. Candlepin applies activation key entitlements synchronously before returning, and nothing between call 1 and call 3 writes to Candlepin — only Foreman DB operations occur in between. The consumer state is therefore identical at all three points.

Under concurrent bulk registration these savings compound proportionally with the number of hosts, contributing to reduced Candlepin saturation.

`finalize_registration` accepts `consumer_attributes = nil` as a safe fallback — if called without consumer data (e.g. from future callers or unforeseen paths) it falls back to the existing `GET /candlepin/consumers/{uuid}` behaviour, so no regression is possible.

## What are the testing steps for this pull request?

- Run concurrent bulk registration (500+ hosts) and verify reduced Candlepin call volume
- Verify `consumer_activate` and `consumer_create` return correct consumer JSON
- Verify re-registration (existing host) works correctly
- Run existing Katello registration tests

Fixes #39202

## Summary by Sourcery

Reduce redundant Candlepin and database lookups during host registration by reusing the initial consumer creation response throughout the registration workflow.

Enhancements:
- Propagate Candlepin consumer creation data through the registration flow to avoid subsequent GET /candlepin/consumers calls.
- Simplify finalize_registration to optionally accept pre-fetched consumer attributes and remove unnecessary Host reloads and refetches.
- Adjust RHSM and host subscription controllers to render the cached consumer data instead of re-querying Candlepin.

Tests:
- Update controller and service tests to expect the new RegistrationManager return shape and to stop stubbing Candlepin Consumer.get during registration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Registration now returns and surfaces the full consumer payload alongside host data.
* **Bug Fixes / Behavior**
  * Registration and activation endpoints return the provided consumer payload and avoid redundant external lookups or extra host reloads.
* **Tests**
  * Tests updated to expect the consumer payload from registration and to assert external consumer fetches are not performed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->