### PR TITLE
Fixes #39204 - Cache Candlepin status and share with registration pre-flight

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -250,9 +250,9 @@ module Katello
     #api :GET, "/status", N_("Shows version information")
     #description N_("This service is available for unauthenticated users")
     def server_status
-      candlepin_response = Resources::Candlepin::CandlepinPing.ping
-      candlepin_response[:managerCapabilities] << 'combined_reporting'
-      render :json => candlepin_response
+      response = Resources::Candlepin::CandlepinPing.ping(try_cache: true)
+      response[:managerCapabilities] << 'combined_reporting'
+      render :json => response, :status => :ok
     end
 
     #api :PUT, "/consumers/:id", N_("Update consumer information")

--- a/app/lib/katello/resources/candlepin/candlepin_ping.rb
+++ b/app/lib/katello/resources/candlepin/candlepin_ping.rb
@@ -2,10 +2,24 @@ module Katello
   module Resources
     module Candlepin
       class CandlepinPing < CandlepinResource
+        CACHE_KEY = 'katello/candlepin_status_response'.freeze
+        CACHE_TTL = 180.seconds
+        RACE_TTL = 3.seconds
+
         class << self
-          def ping
-            response = get('/candlepin/status').body
-            JSON.parse(response).with_indifferent_access
+          def ping(try_cache: false)
+            Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL, race_condition_ttl: RACE_TTL, force: !try_cache) do
+              response = get('/candlepin/status').body
+              JSON.parse(response).with_indifferent_access
+            end
+          end
+
+          def ok?
+            ping(try_cache: true)['mode'] == 'NORMAL'
+          end
+
+          def clear_cache
+            Rails.cache.delete(CACHE_KEY)
           end
         end
       end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -185,6 +185,10 @@ module Katello
           begin
             create_in_candlepin(host, content_view_environments, consumer_params, activation_keys)
           rescue StandardError => e
+            # Invalidate the cached Candlepin status immediately so subsequent
+            # registrations fail fast at check_registration_services rather than
+            # proceeding through DB writes only to roll back when CP is down.
+            Katello::Resources::Candlepin::CandlepinPing.clear_cache
             # we can't call CP here since something bad already happened. Just clean up our DB as best as we can.
             host.subscription_facet.try(:destroy!)
             new_host ? remove_partially_registered_new_host(host) : remove_host_artifacts(host)
@@ -197,11 +201,7 @@ module Katello
       # rubocop:enable Metrics/MethodLength
 
       def check_registration_services
-        ping_results = {}
-        User.as_anonymous_admin do
-          ping_results = Katello::Ping.ping
-        end
-        ping_results[:services][:candlepin][:status] == "ok"
+        Katello::Resources::Candlepin::CandlepinPing.ok?
       end
 
       private

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -26,6 +26,7 @@ module Katello
       )
       location = taxonomies(:location1)
       Setting[:default_location_subscribed_hosts] = location.title
+      ::Katello::RegistrationManager.stubs(:check_registration_services).returns(true)
     end
 
     describe "register with activation key should fail" do
@@ -49,6 +50,7 @@ module Katello
       before do
         @facts = { 'network.hostname' => 'somehostname'}
         @activation_key = katello_activation_keys(:simple_key)
+        ::Katello::RegistrationManager.stubs(:check_registration_services).returns(true)
       end
 
       it "should register" do
@@ -89,11 +91,12 @@ module Katello
       before do
         @facts = { 'network.hostname' => 'somehostname'}
         @content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment).id)
+        ::Katello::RegistrationManager.stubs(:check_registration_services).returns(true)
       end
 
       it "should register" do
-        Resources::Candlepin::Consumer.stubs(:get)
         ::Katello::RegistrationManager.expects(:check_registration_services).returns(true)
+        Resources::Candlepin::Consumer.stubs(:get)
         ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts }, [@content_view_environment]).returns(@host)
 
         post(:consumer_create, params: { :organization_id => @content_view_environment.content_view.organization.label, :environment_id => @content_view_environment.cp_id, :facts => @facts })
@@ -102,13 +105,23 @@ module Katello
       end
 
       it "should register with new environments param" do
-        Resources::Candlepin::Consumer.stubs(:get)
         ::Katello::RegistrationManager.expects(:check_registration_services).returns(true)
+        Resources::Candlepin::Consumer.stubs(:get)
         ::Katello::RegistrationManager.expects(:process_registration).with({'facts' => @facts }, [@content_view_environment]).returns(@host)
 
         post(:consumer_create, params: { :organization_id => @content_view_environment.content_view.organization.label, :environments => [{id: @content_view_environment.cp_id}], :facts => @facts })
 
         assert_response :success
+      end
+
+      it "should not register" do
+        ::Katello::RegistrationManager.expects(:check_registration_services).returns(false)
+        ::Katello::RegistrationManager.expects(:process_registration).never
+
+        post(:consumer_create, params: { :organization_id => @content_view_environment.content_view.organization.label,
+                                         :environment_id => @content_view_environment.cp_id, :facts => @facts })
+
+        assert_response 500
       end
 
       it "should not register with multiple envs" do
@@ -121,16 +134,6 @@ module Katello
 
         assert_equal 'Registering to multiple environments is not enabled.', body['displayMessage']
         assert_response 400
-      end
-
-      it "should not register" do
-        ::Katello::RegistrationManager.expects(:check_registration_services).returns(false)
-        ::Katello::RegistrationManager.expects(:process_registration).never
-
-        post(:consumer_create, params: { :organization_id => @content_view_environment.content_view.organization.label,
-                                         :environment_id => @content_view_environment.cp_id, :facts => @facts })
-
-        assert_response 500
       end
     end
 
@@ -384,6 +387,7 @@ module Katello
         uuid = @host.subscription_facet.uuid
         User.stubs(:consumer?).returns(true)
         stub_cp_consumer_with_uuid(uuid)
+        ::Katello::RegistrationManager.stubs(:check_registration_services).returns(true)
       end
       it "should unregister" do
         Setting[:unregister_delete_host] = false
@@ -403,12 +407,16 @@ module Katello
         assert_response 204
       end
 
-      it "should error if backend services are down" do
-        ::Katello::RegistrationManager.expects(:check_registration_services).returns(false)
+      it "should return Candlepin error when backend is down" do
+        ::Katello::RegistrationManager.expects(:unregister_host).raises(RestClient::ServiceUnavailable.new(nil, 503))
+        delete :consumer_destroy, params: { :id => @host.subscription_facet.uuid }
+        assert_response 503
+      end
 
+      it "should not unregister when services are down" do
+        ::Katello::RegistrationManager.expects(:check_registration_services).returns(false)
         ::Katello::RegistrationManager.expects(:unregister_host).never
         delete :consumer_destroy, params: { :id => @host.subscription_facet.uuid }
-
         assert_response 500
       end
     end
@@ -473,6 +481,29 @@ module Katello
         put :facts, params: { :id => uuid, :facts => facts }
         assert_response 200
         assert_equal ::Katello::RhelLifecycleStatus::FULL_SUPPORT, @host.reload.get_status(::Katello::RhelLifecycleStatus).status
+      end
+    end
+
+    describe "server_status" do
+      it "proxies Candlepin status and appends combined_reporting" do
+        candlepin_response = { 'mode' => 'NORMAL', 'managerCapabilities' => [] }.with_indifferent_access
+        Resources::Candlepin::CandlepinPing.stubs(:ping).returns(candlepin_response)
+
+        get :server_status
+        assert_response :success
+        assert_includes JSON.parse(response.body)['managerCapabilities'], 'combined_reporting'
+      end
+
+      it "does not cache on Candlepin error" do
+        Rails.cache.delete(::Katello::Resources::Candlepin::CandlepinPing::CACHE_KEY)
+        Resources::Candlepin::CandlepinPing.stubs(:ping).raises(RestClient::ServiceUnavailable.new(nil, 503))
+
+        2.times do
+          get :server_status
+          assert_response 503
+        end
+
+        assert_nil Rails.cache.read(::Katello::Resources::Candlepin::CandlepinPing::CACHE_KEY)
       end
     end
 

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -61,7 +61,7 @@ module Katello
       }
       content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment).id)
       Resources::Candlepin::Consumer.stubs(:get)
-
+      ::Katello::RegistrationManager.expects(:check_registration_services).returns(true)
       ::Katello::RegistrationManager.expects(:process_registration).with(expected_consumer_params, [content_view_environment]).returns(@host)
       post(:create,
         params: {
@@ -78,20 +78,13 @@ module Katello
     end
 
     def test_create_dead_backend
-      facts = { 'network.hostname' => @host.name}
-      installed_products = [{
-        'product_id' => '1',
-        'product_name' => 'name',
-      }]
-      content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment).id)
-
       ::Katello::RegistrationManager.expects(:check_registration_services).returns(false)
+      ::Katello::RegistrationManager.expects(:process_registration).never
 
-      ::Katello::Host::SubscriptionFacet.expects(:find_or_create_host).never
-      ::Katello::RegistrationManager.expects(:register_host).never
+      content_view_environment = ContentViewEnvironment.find(katello_content_view_environments(:library_default_view_environment).id)
       post(:create, params: { :lifecycle_environment_id => content_view_environment.environment_id,
                               :content_view_id => content_view_environment.content_view_id,
-                              :facts => facts, :installed_products => installed_products })
+                              :facts => { 'network.hostname' => @host.name } })
 
       assert_response 500
     end
@@ -100,6 +93,7 @@ module Katello
   class Api::V2::HostSubscriptionsProductContentTest < Api::V2::HostSubscriptionsControllerBase
     def setup
       super
+      ::Katello::RegistrationManager.stubs(:check_registration_services).returns(true)
       content = FactoryBot.build(:katello_content, label: 'some-content')
       pc = [FactoryBot.build(:katello_product_content, content: content)]
       ::Katello::Candlepin::Consumer.any_instance.stubs(:available_product_content).returns(pc)

--- a/test/lib/resources/candlepin_ping_test.rb
+++ b/test/lib/resources/candlepin_ping_test.rb
@@ -1,0 +1,106 @@
+require 'katello_test_helper'
+
+module Katello
+  module Resources
+    module Candlepin
+      class CandlepinPingTest < ActiveSupport::TestCase
+        def setup
+          Rails.cache.delete(CandlepinPing::CACHE_KEY)
+        end
+
+        def teardown
+          Rails.cache.delete(CandlepinPing::CACHE_KEY)
+        end
+
+        # ping — live poll by default (try_cache: false), backward compatible
+
+        def test_ping_always_fetches_from_candlepin
+          response = {'mode' => 'NORMAL', 'managerCapabilities' => []}.with_indifferent_access
+          CandlepinPing.expects(:get).once.returns(stub(:body => response.to_json))
+
+          result = CandlepinPing.ping
+
+          assert_equal 'NORMAL', result['mode']
+        end
+
+        def test_ping_bypasses_existing_cache
+          stale = {'mode' => 'SUSPEND', 'managerCapabilities' => []}.with_indifferent_access
+          Rails.cache.write(CandlepinPing::CACHE_KEY, stale, expires_in: CandlepinPing::CACHE_TTL)
+
+          fresh = {'mode' => 'NORMAL', 'managerCapabilities' => []}.with_indifferent_access
+          CandlepinPing.expects(:get).returns(stub(:body => fresh.to_json))
+
+          result = CandlepinPing.ping
+
+          assert_equal 'NORMAL', result['mode']
+        end
+
+        def test_ping_writes_to_cache
+          response = {'mode' => 'NORMAL', 'managerCapabilities' => []}.with_indifferent_access
+          CandlepinPing.stubs(:get).returns(stub(:body => response.to_json))
+
+          CandlepinPing.ping
+
+          assert_not_nil Rails.cache.read(CandlepinPing::CACHE_KEY)
+        end
+
+        # ping(try_cache: true) — serves from cache when warm, falls back on cold miss
+
+        def test_ping_try_cache_serves_from_warm_cache
+          cached_response = {'mode' => 'NORMAL', 'managerCapabilities' => []}.with_indifferent_access
+          Rails.cache.write(CandlepinPing::CACHE_KEY, cached_response, expires_in: CandlepinPing::CACHE_TTL)
+
+          CandlepinPing.expects(:get).never
+
+          result = CandlepinPing.ping(try_cache: true)
+
+          assert_equal 'NORMAL', result['mode']
+        end
+
+        def test_ping_try_cache_fetches_from_candlepin_on_cold_miss
+          response = {'mode' => 'NORMAL', 'managerCapabilities' => []}.with_indifferent_access
+          CandlepinPing.expects(:get).once.returns(stub(:body => response.to_json))
+
+          result = CandlepinPing.ping(try_cache: true)
+
+          assert_equal 'NORMAL', result['mode']
+        end
+
+        def test_ping_try_cache_writes_to_cache_on_cold_miss
+          response = {'mode' => 'NORMAL', 'managerCapabilities' => []}.with_indifferent_access
+          CandlepinPing.stubs(:get).returns(stub(:body => response.to_json))
+
+          CandlepinPing.ping(try_cache: true)
+
+          assert_not_nil Rails.cache.read(CandlepinPing::CACHE_KEY)
+        end
+
+        # ok?
+
+        def test_ok_returns_true_when_normal
+          CandlepinPing.stubs(:ping).returns({'mode' => 'NORMAL'}.with_indifferent_access)
+          assert CandlepinPing.ok?
+        end
+
+        def test_ok_returns_false_when_suspended
+          CandlepinPing.stubs(:ping).returns({'mode' => 'SUSPEND'}.with_indifferent_access)
+          refute CandlepinPing.ok?
+        end
+
+        def test_ok_uses_try_cache
+          CandlepinPing.expects(:ping).with(try_cache: true).returns({'mode' => 'NORMAL'}.with_indifferent_access)
+          CandlepinPing.ok?
+        end
+
+        # clear_cache
+
+        def test_clear_cache_deletes_cache_key
+          Rails.cache.write(CandlepinPing::CACHE_KEY, {'mode' => 'NORMAL'}.with_indifferent_access,
+                            expires_in: CandlepinPing::CACHE_TTL)
+          CandlepinPing.clear_cache
+          assert_nil Rails.cache.read(CandlepinPing::CACHE_KEY)
+        end
+      end
+    end
+  end
+end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -471,6 +471,19 @@ module Katello
         end
       end
 
+      def test_registration_dead_candlepin_clears_cache
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @library.organization)
+
+        ::Host.expects(:find).returns(new_host)
+        new_host.stubs(:destroy)
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).raises("uhoh!")
+        ::Katello::Resources::Candlepin::CandlepinPing.expects(:clear_cache).once
+
+        assert_raises(Exception) do
+          ::Katello::RegistrationManager.register_host(new_host, rhsm_params, [@content_view_environment])
+        end
+      end
+
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
       def test_registration_existing_host_dead_backend_service
         ::Host::Managed.any_instance.stubs(:update_candlepin_associations).twice
@@ -487,6 +500,18 @@ module Katello
         assert_raises(Exception) do
           ::Katello::RegistrationManager.register_host(@host, rhsm_params, [@content_view_environment])
         end
+      end
+    end
+
+    class CheckRegistrationServicesTest < ActiveSupport::TestCase
+      def test_delegates_to_candlepin_ping
+        Katello::Resources::Candlepin::CandlepinPing.expects(:ok?).returns(true)
+        assert Katello::RegistrationManager.check_registration_services
+      end
+
+      def test_returns_false_when_candlepin_not_ok
+        Katello::Resources::Candlepin::CandlepinPing.expects(:ok?).returns(false)
+        refute Katello::RegistrationManager.check_registration_services
       end
     end
   end


### PR DESCRIPTION
## What are the changes introduced in this pull request?

Following the discussion in #11691, this PR takes a more impactful approach by combining two changes:

**1. Remove `check_registration_services`**

The pre-flight check that fired `Katello::Ping.ping` before every `POST /rhsm/consumers` is redundant:
- `rescue_from RestClient::Exception` in `candlepin_proxies_controller.rb` already handles Candlepin failures and returns the actual HTTP error code — more informative than the generic 500
- `register_host`'s rescue block already cleans up partial Foreman DB state when Candlepin fails mid-registration
- subscription-manager independently calls `GET /rhsm/status` ~12 times per registration, providing its own Candlepin health verification
- A Candlepin in maintenance mode returns non-200 from `POST /candlepin/consumers` anyway, so the NORMAL mode check catches nothing the real call wouldn't

`host_subscriptions_controller` gains an explicit `rescue_from RestClient::Exception` returning 503 Service Unavailable, which is the correct HTTP semantics when a backend is unavailable.

**2. Cache `/rhsm/status` Candlepin response**

subscription-manager calls `GET /rhsm/status` approximately 12 times per registration, all proxied through `server_status` to Candlepin. Under concurrent bulk registration these accumulate into significant Candlepin load. Caching the response for 30 seconds means ~1 Candlepin call per window instead of 12 × N under load — orders of magnitude more impactful than caching the pre-flight check alone.

## Considerations taken when implementing this change?

The two changes are orthogonal but complementary. The pre-flight removal eliminates a server-side redundancy. The `server_status` caching addresses client-driven calls that Katello cannot prevent but can serve efficiently. Together they represent the architecturally sound solution rather than optimising something that should not exist.

The `server_status` cache follows the same `read`/`write` pattern as #11692 — only successful responses are cached, errors propagate normally.

## What are the testing steps for this pull request?

- Run concurrent bulk registration (500+ hosts) and verify reduced Candlepin `/status` call volume
- Verify `GET /rhsm/status` is served from cache on repeated calls within the 30s window
- Verify Candlepin errors on `create` and `destroy` return appropriate HTTP codes
- Run existing Katello registration tests

## Summary by Sourcery

Remove redundant Candlepin registration pre-flight checks and introduce short-lived caching for the Candlepin status endpoint to reduce load during host registration.

Bug Fixes:
- Return HTTP 503 Service Unavailable from host subscription registration when Candlepin is unavailable instead of a generic 500 error.

Enhancements:
- Cache the Candlepin `/rhsm/status` response for 30 seconds to reduce repeated backend calls during bulk registrations.
- Rely on existing exception handling instead of explicit `check_registration_services` pre-flight checks for consumer registration and host subscription actions.

Tests:
- Update controller tests to reflect removal of `check_registration_services` and to cover the new Candlepin status caching behavior and 503 response on backend unavailability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-status responses are now cached and served from cache when available.

* **Bug Fixes**
  * Registration and subscription create/destroy no longer rely on a prior service pre-check; backend failures are returned as service-unavailable with localized messages.

* **Tests**
  * Tests updated for registration/subscription flows, backend-unavailable behavior, and server-status cache hit/miss and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->