### PR TITLE
Fixes #39211 - Defer capsule distribution refreshes after all syncs

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -49,6 +49,14 @@ module Actions
                 end
               end
             end
+
+            repos.select { |repo| smart_proxy.pulp3_support?(repo) }.in_groups_of(Setting[:foreman_proxy_content_batch_size], false) do |repo_batch|
+              concurrence do
+                repo_batch.each do |repo|
+                  plan_action(Actions::Pulp3::CapsuleContent::RefreshDistribution, repo, smart_proxy)
+                end
+              end
+            end
           end
         end
         # rubocop:enable Metrics/MethodLength

--- a/app/lib/actions/pulp3/capsule_content/generate_metadata.rb
+++ b/app/lib/actions/pulp3/capsule_content/generate_metadata.rb
@@ -5,13 +5,9 @@ module Actions
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
         def plan(repository, smart_proxy, options = {})
           options[:contents_changed] = (options && options.key?(:contents_changed)) ? options[:contents_changed] : true
-          sequence do
-            unless repository.repository_type.pulp3_skip_publication
-              plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id,
-                         :options => options).output
-            end
-            plan_action(RefreshDistribution, repository, smart_proxy,
-                          :contents_changed => options[:contents_changed])
+          unless repository.repository_type.pulp3_skip_publication
+            plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id,
+                       :options => options).output
           end
         end
 

--- a/app/lib/actions/pulp3/capsule_content/refresh_distribution.rb
+++ b/app/lib/actions/pulp3/capsule_content/refresh_distribution.rb
@@ -2,19 +2,46 @@ module Actions
   module Pulp3
     module CapsuleContent
       class RefreshDistribution < Pulp3::AbstractAsyncTask
-        include Helpers::Presenter
-        middleware.use Actions::Middleware::ExecuteIfContentsChanged
-
-        def plan(repository, smart_proxy, options = {})
+        def plan(repository, smart_proxy)
           plan_self(:repository_id => repository.id,
-                             :smart_proxy_id => smart_proxy.id,
-                             :options => options)
+                             :smart_proxy_id => smart_proxy.id)
         end
 
         def invoke_external_task
-          smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
-          repo = ::Katello::Repository.find(input[:repository_id])
           repo.backend_service(smart_proxy).with_mirror_adapter.refresh_distributions
+        end
+
+        def rescue_external_task(error)
+          if distribution_uniqueness_conflict?(error) && !retried_distribution_refresh?
+            # A concurrent RefreshDistribution created this distribution first.
+            # Re-invoke so refresh_distributions finds the existing distribution
+            # and issues a partial_update instead. Dynflow will poll the new task.
+            # Only retry once; if the follow-up refresh still conflicts, fall back
+            # to the parent error handling rather than replaying indefinitely.
+            output[:retried_distribution_refresh] = true
+            self.external_task = invoke_external_task
+          else
+            super
+          end
+        end
+
+        private
+
+        def repo
+          @repo ||= ::Katello::Repository.find(input[:repository_id])
+        end
+
+        def smart_proxy
+          @smart_proxy ||= super
+        end
+
+        def distribution_uniqueness_conflict?(error)
+          error.is_a?(::Katello::Errors::Pulp3Error) &&
+            ::Katello::Pulp3::DistributionConflict.create_race?(error)
+        end
+
+        def retried_distribution_refresh?
+          output[:retried_distribution_refresh]
         end
       end
     end

--- a/app/services/katello/pulp3/distribution_conflict.rb
+++ b/app/services/katello/pulp3/distribution_conflict.rb
@@ -1,0 +1,20 @@
+module Katello
+  module Pulp3
+    module DistributionConflict
+      # Matches Pulp3 errors indicating a distribution base_path conflict
+      # from a concurrent create: either a uniqueness violation or an overlap.
+      CREATE_RACE_PATTERN = /
+        ["']base_path["'].*?
+        (
+          must\ be\ unique | code=['"]unique |
+          Overlaps\ with\ existing\ distribution
+        )
+      /mx
+
+      def self.create_race?(error_or_message)
+        message = error_or_message.respond_to?(:message) ? error_or_message.message : error_or_message.to_s
+        message.match?(CREATE_RACE_PATTERN)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -240,7 +240,7 @@ module Katello
 
       def sync_url_params(_sync_options)
         params = {remote: repo.remote_href, mirror: repo.root.mirroring_policy == Katello::RootRepository::MIRRORING_POLICY_CONTENT}
-        params[:skip_types] = skip_types if (skip_types && repo.root.mirroring_policy != Katello::RootRepository::MIRRORING_POLICY_COMPLETE)
+        params[:skip_types] = skip_types if skip_types && repo.root.mirroring_policy != Katello::RootRepository::MIRRORING_POLICY_COMPLETE
         params
       end
 
@@ -291,8 +291,7 @@ module Katello
           create_distribution(relative_path)
         rescue api.client_module::ApiError => e
           # Now it seems there is a distribution. Fetch it and save the reference.
-          if e.message.include?("\"base_path\":[\"This field must be unique.\"]") ||
-              e.message.include?("\"base_path\":[\"Overlaps with existing distribution\"")
+          if ::Katello::Pulp3::DistributionConflict.create_race?(e)
             dist = lookup_distributions(base_path: repo.relative_path).first
             save_distribution_references([dist.pulp_href])
             return update_distribution
@@ -551,7 +550,7 @@ module Katello
       end
 
       def append_proxy_cacert(options)
-        if root.http_proxy&.cacert&.present? && options.key?(:ca_cert)
+        if root.http_proxy&.cacert.present? && options.key?(:ca_cert)
           options[:ca_cert] = [options[:ca_cert], root.http_proxy.cacert].compact.join("\n")
         end
         options

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -64,10 +64,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 yum repo without the proper plugin' do
@@ -104,10 +101,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 docker repo' do
@@ -121,10 +115,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 ansible collection repo' do
@@ -134,10 +125,7 @@ module ::Actions::Katello::CapsuleContent
       repo = katello_repositories(:pulp3_ansible_collection_1)
       tree = plan_action_tree(action_class, capsule_content.smart_proxy, :repository_id => repo.id)
       assert_tree_planned_steps(tree, ::Actions::Pulp3::ContentGuard::Refresh)
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 apt repo' do
@@ -164,10 +152,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp2 apt repo' do
@@ -183,6 +168,7 @@ module ::Actions::Katello::CapsuleContent
                 }
 
       assert_tree_planned_with(tree, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, options)
+      refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::RefreshDistribution)
     end
 
     it 'plans correctly for a pulp yum repo' do
@@ -220,6 +206,7 @@ module ::Actions::Katello::CapsuleContent
       with_pulp3_features(capsule_content.smart_proxy)
       capsule_content.smart_proxy.add_lifecycle_environment(dev_environment)
       repos_in_dev = Katello::Repository.in_environment(dev_environment).pluck(:pulp_id)
+      repo_ids_in_dev = Katello::Repository.in_environment(dev_environment).pluck(:id)
 
       tree = plan_action_tree(action_class, capsule_content.smart_proxy, :environment_id => dev_environment.id)
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
@@ -242,14 +229,16 @@ module ::Actions::Katello::CapsuleContent
         assert_includes repos_in_dev, repo.pulp_id
       end
 
+      assert_refresh_boundary(tree, repo_ids_in_dev)
+    end
+
+    def assert_refresh_boundary(tree, expected_repo_ids)
+      planned_repo_ids = []
       assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
         assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        repo = Katello::Repository.find(input[:repository_id])
-        assert_includes repos_in_dev, repo.pulp_id
-        repos_in_dev.delete(repo.pulp_id)
+        planned_repo_ids << input[:repository_id]
       end
-
-      assert_empty repos_in_dev
+      assert_equal expected_repo_ids.uniq.sort, planned_repo_ids.sort
     end
 
     it 'fails when trying to sync to the default capsule' do

--- a/test/actions/pulp3/capsule_content/refresh_distribution_test.rb
+++ b/test/actions/pulp3/capsule_content/refresh_distribution_test.rb
@@ -1,0 +1,148 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3::CapsuleContent
+  class DistributionConflictTest < ActiveSupport::TestCase
+    it 'matches both async task and direct api race messages' do
+      async_error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+      api_error = RuntimeError.new('{"base_path":["Overlaps with existing distribution"]}')
+
+      assert ::Katello::Pulp3::DistributionConflict.create_race?(async_error)
+      assert ::Katello::Pulp3::DistributionConflict.create_race?(api_error)
+      refute ::Katello::Pulp3::DistributionConflict.create_race?("Remote artifacts cannot be exported")
+    end
+  end
+
+  class GenerateMetadataTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::CapsuleSupport
+    include Support::Actions::RemoteAction
+
+    let(:proxy) { capsule_content.smart_proxy }
+
+    before do
+      set_user
+      SmartProxy.any_instance.stubs(:ping_pulp).returns({})
+      SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
+      SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+    end
+
+    # pulp3_skip_publication: true - plan_self is skipped, tree is empty
+    it 'does not plan RefreshDistribution inline for publication-less repos (e.g. docker)' do
+      repo = katello_repositories(:pulp3_docker_1)
+      tree = plan_action_tree(::Actions::Pulp3::CapsuleContent::GenerateMetadata,
+                              repo, proxy)
+
+      refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+    end
+
+    # pulp3_skip_publication: false - plan_self IS called to create a publication
+    it 'does not plan RefreshDistribution inline for publication-based repos (e.g. file)' do
+      repo = katello_repositories(:pulp3_file_1)
+      tree = plan_action_tree(::Actions::Pulp3::CapsuleContent::GenerateMetadata,
+                              repo, proxy)
+
+      refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+    end
+  end
+
+  class RefreshDistributionTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::CapsuleSupport
+    include Support::Actions::RemoteAction
+
+    let(:proxy) { capsule_content.smart_proxy }
+    let(:repo) { katello_repositories(:pulp3_docker_1) }
+
+    before do
+      set_user
+      SmartProxy.any_instance.stubs(:ping_pulp).returns({})
+      SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
+      SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+    end
+
+    def build_action_with_output
+      action = create_action(::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+      action.stubs(:input).returns('repository_id' => repo.id, 'smart_proxy_id' => proxy.id)
+      action_output = {}
+      action.stubs(:output).returns(action_output)
+      [action, action_output]
+    end
+
+    it 'recovers from a concurrent distribution creation by retrying as an update' do
+      action, action_output = build_action_with_output
+
+      mock_task = mock('pulp_task')
+      action.expects(:invoke_external_task).returns(mock_task)
+      action.expects(:external_task=).with(mock_task)
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+      action.rescue_external_task(error)
+      assert action_output[:retried_distribution_refresh]
+    end
+
+    it 'recovers when both name and base_path are reported as non-unique (real Pulp error format)' do
+      action, action_output = build_action_with_output
+
+      mock_task = mock('pulp_task')
+      action.expects(:invoke_external_task).returns(mock_task)
+      action.expects(:external_task=).with(mock_task)
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'name': [ErrorDetail(string='This field must be unique.', code='unique')], " \
+        "'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+      action.rescue_external_task(error)
+      assert action_output[:retried_distribution_refresh]
+    end
+
+    # Non-Pulp3Errors fall through to the parent's rescue_external_task,
+    # which delegates to Dynflow's default handler. We verify here that
+    # RefreshDistribution does not intercept them for its own retry logic.
+    it 'does not attempt recovery for non-Pulp3Errors' do
+      action, _action_output = build_action_with_output
+      action.expects(:invoke_external_task).never
+
+      action.rescue_external_task(RuntimeError.new("connection refused"))
+    end
+
+    it 'recovers from an overlap conflict (base_path overlaps existing distribution)' do
+      action, action_output = build_action_with_output
+
+      mock_task = mock('pulp_task')
+      action.expects(:invoke_external_task).returns(mock_task)
+      action.expects(:external_task=).with(mock_task)
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': ['Overlaps with existing distribution']}"
+      )
+      action.rescue_external_task(error)
+      assert action_output[:retried_distribution_refresh]
+    end
+
+    it 're-raises the conflict after the one allowed retry is exhausted' do
+      action, action_output = build_action_with_output
+      action_output[:retried_distribution_refresh] = true
+      action.expects(:invoke_external_task).never
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+
+      assert_raises(::Katello::Errors::Pulp3Error) { action.rescue_external_task(error) }
+    end
+
+    it 're-raises Pulp3Errors unrelated to distribution uniqueness' do
+      action, _action_output = build_action_with_output
+      action.expects(:invoke_external_task).never
+
+      error = ::Katello::Errors::Pulp3Error.new("Remote artifacts cannot be exported")
+      assert_raises(::Katello::Errors::Pulp3Error) { action.rescue_external_task(error) }
+    end
+  end
+end


### PR DESCRIPTION
## Problem

When `SyncCapsule` runs multiple repos concurrently, each repo's `RefreshDistribution` was planned inline inside `GenerateMetadata`. Two repos sharing the same Pulp3 distribution (same `base_path`/`name`) could race to create it. The loser fails with a uniqueness `Pulp3Error` that surfaces only during async task polling - too late for a service-level rescue to catch.

Observed under concurrent capsule sync stress tests across multiple content types (RPM, container). Tracked in SAT-31994.

## Solution

Two changes working together:

**1. Deferred distribution refresh — post-sync planning step**

Move distribution refresh out of per-repo `GenerateMetadata` into a post-sync planning step in `SyncCapsule`. After all sync batches complete, `RefreshDistribution` is planned for each repo, batched and run concurrently (`concurrence` block).

This also gives consumers a more consistent view of the capsule: content becomes accessible for all repos together rather than repo-by-repo as each finishes syncing. This mirrors the approach Pulp upstream adopted for its own replication task in pulpcore 3.107.0 (issue #7333).

**2. `rescue_external_task` in `RefreshDistribution`**

If two `RefreshDistribution` actions still race (e.g. two repos sharing the same distribution path), the loser recovers: re-invokes `refresh_distributions`, which finds the existing distribution and issues a `partial_update` instead of a create. Dynflow re-polls the new task automatically via `suspend_and_ping` after the rescue returns without raising (confirmed against Dynflow 2.0.0 source).

## Test plan

- [ ] Existing capsule sync planning tests updated to assert `RefreshDistribution` at the sync level
- [ ] New `GenerateMetadataTest`: verifies `RefreshDistribution` is no longer planned inline
- [ ] New `RefreshDistributionTest`: `rescue_external_task` recovers on uniqueness conflict, re-raises unrelated errors
- [ ] Run capsule sync stress test with concurrent repos to verify no uniqueness failures

Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a concurrent bulk distribution-refresh task to schedule distribution refreshes across multiple Pulp3 repositories.

* **Bug Fixes**
  * Automatic retry for certain distribution-creation conflicts (uniqueness/overlap) during refresh.
  * Capsule sync now schedules Pulp3 distribution refreshes only for Pulp3-supported repositories.
  * Metadata generation no longer inlines distribution refreshes.

* **Tests**
  * Expanded tests covering planning, bulk refresh behavior, and retry/recovery logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
