### PR TITLE
Fixes #39213 - Import only OS-detection facts at registration time

### DIFF
--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -176,14 +176,15 @@ module Katello
         ::Host::Managed.new(:name => name, :organization => org, :location => location, :managed => false)
       end
 
-      def self.update_facts(host, rhsm_facts)
+      def self.update_facts(host, rhsm_facts = nil, additive: false, **legacy_rhsm_facts)
+        rhsm_facts ||= legacy_rhsm_facts.presence
         return if host.build? || rhsm_facts.nil?
         rhsm_facts[:_type] = RhsmFactName::FACT_TYPE
         rhsm_facts[:_timestamp] = Time.now.to_s
         if ignore_os?(host.operatingsystem, rhsm_facts)
           rhsm_facts[:ignore_os] = true
         end
-        ::HostFactImporter.new(host).import_facts(rhsm_facts)
+        ::HostFactImporter.new(host).import_facts(rhsm_facts, additive: additive)
       end
 
       def self.ignore_os?(host_os, rhsm_facts)

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -2,6 +2,15 @@ require 'set'
 
 module Katello
   class RegistrationManager
+    # Facts strictly required at registration time so that RhelLifecycleStatus can be
+    # computed immediately. These drive OS and architecture detection in HostFactImporter.
+    # All remaining facts arrive via the subsequent PUT /rhsm/consumers/:id call (step 6).
+    REGISTRATION_CRITICAL_FACTS = %w[
+      distribution.name
+      distribution.version
+      uname.machine
+    ].freeze
+
     class << self
       private :new
       delegate :propose_existing_hostname, :new_host_from_facts, to: Katello::Host::SubscriptionFacet
@@ -185,20 +194,29 @@ module Katello
 
         consumer_data = nil
         User.as_anonymous_admin do
-          consumer_data = begin
-            create_in_candlepin(host, content_view_environments, consumer_params, activation_keys)
+          begin
+            consumer_data = begin
+              create_in_candlepin(host, content_view_environments, consumer_params, activation_keys)
+            rescue StandardError => e
+              # Invalidate the cached Candlepin status immediately so subsequent
+              # registrations fail fast at check_registration_services rather than
+              # proceeding through DB writes only to roll back when CP is down.
+              Katello::Resources::Candlepin::CandlepinPing.clear_cache
+              raise e
+            end
+
+            # Import only the facts needed for OS/architecture detection so that
+            # RhelLifecycleStatus is correct immediately after registration.
+            # The full fact set arrives via PUT /rhsm/consumers/:id (step 6).
+            import_critical_registration_facts(host, consumer_params[:facts])
+
+            finalize_registration(host, consumer_data)
           rescue StandardError => e
-            # Invalidate the cached Candlepin status immediately so subsequent
-            # registrations fail fast at check_registration_services rather than
-            # proceeding through DB writes only to roll back when CP is down.
-            Katello::Resources::Candlepin::CandlepinPing.clear_cache
             # we can't call CP here since something bad already happened. Just clean up our DB as best as we can.
             host.subscription_facet.try(:destroy!)
             new_host ? remove_partially_registered_new_host(host) : remove_host_artifacts(host)
             raise e
           end
-
-          finalize_registration(host, consumer_data)
         end
 
         consumer_data
@@ -235,11 +253,11 @@ module Katello
       def create_in_candlepin(host, content_view_environments, consumer_params, activation_keys)
         # if CP fails, nothing to clean up yet w.r.t. backend services
         cp_create = ::Katello::Resources::Candlepin::Consumer.create(content_view_environments.map(&:cp_id), consumer_params, activation_keys.map(&:cp_name), host.organization)
-        ::Katello::Host::SubscriptionFacet.update_facts(host, consumer_params[:facts]) unless consumer_params[:facts].blank?
-        fail ::Katello::Errors::CandlepinError, _("Candlepin consumer registration response is missing a uuid") if cp_create&.[]('uuid').blank?
-        if cp_create['uuid'] != host.subscription_facet.uuid
-          Rails.logger.info(_("Candlepin returned different consumer uuid than requested (%s), updating uuid in subscription_facet.") % cp_create['uuid'])
-          host.subscription_facet.uuid = cp_create['uuid']
+        uuid = cp_create['uuid']
+        fail ::Katello::Errors::CandlepinError, _("Candlepin consumer registration response is missing a uuid") if uuid.blank?
+        if uuid != host.subscription_facet.uuid
+          Rails.logger.info(_("Candlepin returned different consumer uuid than requested (%s), updating uuid in subscription_facet.") % uuid)
+          host.subscription_facet.uuid = uuid
           host.subscription_facet.save!
         end
         cp_create
@@ -314,6 +332,12 @@ module Katello
         subscription_facet.save!
         subscription_facet.activation_keys = activation_keys
         subscription_facet
+      end
+
+      def import_critical_registration_facts(host, facts)
+        critical = facts&.slice(*REGISTRATION_CRITICAL_FACTS)
+        return if critical.blank?
+        ::Katello::Host::SubscriptionFacet.update_facts(host, critical, additive: true)
       end
 
       def remove_host_artifacts(host, clear_content_facet: true, preserve_for_provisioning: false)

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -499,6 +499,56 @@ module Katello
         end
       end
 
+      def test_import_critical_registration_facts_imports_critical_subset
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @org)
+        critical_facts = {'distribution.name' => 'RHEL', 'distribution.version' => '9.2', 'uname.machine' => 'x86_64'}
+        all_facts = critical_facts.merge('network.hostname' => 'foobar.example.com')
+
+        ::Katello::RegistrationManager.expects(:get_uuid).returns('fake-uuid')
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).returns({'uuid' => 'fake-uuid'}.with_indifferent_access)
+        ::Katello::Host::SubscriptionFacet.any_instance.stubs(:update_hypervisor)
+        ::Katello::Host::SubscriptionFacet.any_instance.stubs(:update_guests)
+        ::Host::Managed.any_instance.stubs(:refresh_statuses)
+
+        ::Katello::Host::SubscriptionFacet.expects(:update_facts).with(new_host, critical_facts, additive: true)
+
+        ::Katello::RegistrationManager.register_host(new_host, rhsm_params.merge(:facts => all_facts), [@content_view_environment])
+      end
+
+      def test_import_critical_registration_facts_skips_when_no_critical_facts_present
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @org)
+        non_critical_facts = {'network.hostname' => 'foobar.example.com'}
+
+        ::Katello::RegistrationManager.expects(:get_uuid).returns('fake-uuid')
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).returns({'uuid' => 'fake-uuid'}.with_indifferent_access)
+        ::Katello::Host::SubscriptionFacet.any_instance.stubs(:update_hypervisor)
+        ::Katello::Host::SubscriptionFacet.any_instance.stubs(:update_guests)
+        ::Host::Managed.any_instance.stubs(:refresh_statuses)
+
+        ::Katello::Host::SubscriptionFacet.expects(:update_facts).never
+
+        ::Katello::RegistrationManager.register_host(new_host, rhsm_params.merge(:facts => non_critical_facts), [@content_view_environment])
+      end
+
+      def test_import_critical_registration_facts_failure_aborts_registration
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @org)
+        critical_facts = {'distribution.name' => 'RHEL', 'uname.machine' => 'x86_64'}
+
+        ::Katello::RegistrationManager.expects(:get_uuid).returns('fake-uuid')
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).returns({'uuid' => 'fake-uuid'}.with_indifferent_access)
+        ::Katello::Host::SubscriptionFacet.any_instance.stubs(:update_hypervisor)
+        ::Katello::Host::SubscriptionFacet.any_instance.stubs(:update_guests)
+        ::Host::Managed.any_instance.stubs(:refresh_statuses)
+        ::Katello::RegistrationManager.expects(:remove_partially_registered_new_host).with(new_host).once
+        ::Katello::Resources::Candlepin::CandlepinPing.expects(:clear_cache).never
+
+        ::Katello::Host::SubscriptionFacet.expects(:update_facts).raises(StandardError, 'db failure')
+
+        assert_raises(StandardError, 'db failure') do
+          ::Katello::RegistrationManager.register_host(new_host, rhsm_params.merge(:facts => critical_facts), [@content_view_environment])
+        end
+      end
+
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
       def test_registration_existing_host_dead_backend_service
         ::Host::Managed.any_instance.stubs(:update_candlepin_associations).twice
@@ -516,7 +566,7 @@ module Katello
           ::Katello::RegistrationManager.register_host(@host, rhsm_params, [@content_view_environment])
         end
       end
-    end
+    end # rubocop:enable Metrics/ClassLength
 
     class CheckRegistrationServicesTest < ActiveSupport::TestCase
       def test_delegates_to_candlepin_ping

--- a/webpack/scenes/ContentCredentials/Create/CreateContentCredentialForm.js
+++ b/webpack/scenes/ContentCredentials/Create/CreateContentCredentialForm.js
@@ -113,7 +113,7 @@ const CreateContentCredentialForm = ({ setModalOpen, setFormState, refreshTable 
     <Form>
       <FormGroup label={__('Name')} isRequired fieldId="name">
         <TextInput
-          ouiaId="create-content-credential-name-input"
+          ouiaId="name-input"
           isRequired
           type="text"
           id="name"
@@ -127,7 +127,7 @@ const CreateContentCredentialForm = ({ setModalOpen, setFormState, refreshTable 
 
       <FormGroup label={__('Type')} isRequired fieldId="content_type">
         <FormSelect
-          ouiaId="create-content-credential-content-type-select"
+          ouiaId="content-type-select"
           value={contentType}
           onChange={(_event, value) => setContentType(value)}
           id="content_type"
@@ -174,7 +174,7 @@ const CreateContentCredentialForm = ({ setModalOpen, setFormState, refreshTable 
               icon={<FileUploadIcon />}
               isDisabled={saving}
               onClick={() => fileInputRef.current?.click()}
-              ouiaId="create-content-credential-upload-file-button"
+              ouiaId="upload-file-button"
             >
               {file ? file.name : __('Choose file')}
             </Button>

--- a/webpack/scenes/ContentCredentials/Create/CreateContentCredentialModal.js
+++ b/webpack/scenes/ContentCredentials/Create/CreateContentCredentialModal.js
@@ -28,7 +28,7 @@ const CreateContentCredentialModal = ({ show, setIsOpen, refreshTable }) => {
       actions={[
         <Button
           key="create"
-          ouiaId="create-content-credential-create-button"
+          ouiaId="create-button"
           variant="primary"
           onClick={handleSave}
           isDisabled={formState.submitDisabled}
@@ -38,7 +38,7 @@ const CreateContentCredentialModal = ({ show, setIsOpen, refreshTable }) => {
         </Button>,
         <Button
           key="cancel"
-          ouiaId="create-content-credential-cancel-button"
+          ouiaId="cancel-button"
           variant="link"
           onClick={handleClose}
         >

--- a/webpack/scenes/ContentCredentials/Delete/DeleteContentCredentialModal.js
+++ b/webpack/scenes/ContentCredentials/Delete/DeleteContentCredentialModal.js
@@ -35,7 +35,7 @@ const DeleteContentCredentialModal = ({
 
   return (
     <Modal
-      ouiaId="delete-content-credential-modal"
+      ouiaId="content-credential-delete-modal"
       variant={ModalVariant.small}
       title={[
         <Flex key="delete-modal-header">
@@ -43,7 +43,7 @@ const DeleteContentCredentialModal = ({
             <ExclamationTriangleIcon />
           </Icon>
           <Title
-            ouiaId="delete-content-credential-title"
+            ouiaId="content-credential-delete-header"
             key="delete-content-credential-title"
             headingLevel="h5"
             size="2xl"
@@ -56,7 +56,7 @@ const DeleteContentCredentialModal = ({
       onClose={handleModalToggle}
       actions={[
         <Button
-          ouiaId="delete-content-credential-delete-button"
+          ouiaId="delete-button"
           key="delete"
           variant="danger"
           isDisabled={!credentialId}
@@ -65,7 +65,7 @@ const DeleteContentCredentialModal = ({
           {__('Delete')}
         </Button>,
         <Button
-          ouiaId="delete-content-credential-cancel-button"
+          ouiaId="cancel-button"
           key="cancel"
           variant="link"
           onClick={handleModalToggle}


### PR DESCRIPTION
## Problem

During `POST /rhsm/consumers`, subscription-manager sends ~193 RHSM facts. Since 2018, all 193 are imported synchronously into Foreman's `fact_values` table, then imported again at step 6 (`PUT /rhsm/consumers/:id`, ~33 seconds later) — a redundant double import inherited from the original Dynflow registration flow that was removed in the same 2018 refactor.

The original reason for the step-2 import: step 6 was also async (Dynflow) in 2018, so it was unreliable for immediate status calculation. Step 6 is now synchronous and reliable.

## Analysis

Only 3 facts are strictly needed at step 2 for `RhelLifecycleStatus` to be immediately correct:

- `distribution.name` → sets `host.operatingsystem.name`
- `distribution.version` → sets `host.operatingsystem.major`
- `uname.machine` → sets `host.architecture.name`

`HostFactImporter.parse_facts` operates on the **in-memory facts hash** (not `fact_values`), so these 3 facts are sufficient to persist the correct OS and architecture on the host before `finalize_registration` runs and calls `refresh_statuses([RhelLifecycleStatus])`.

Everything else between step 2 and step 6 — Candlepin compliance checks (~13 calls), content access validation, Insights — operates on data from the POST body or its own sources. None read Foreman's `fact_values`.

## Solution

Import only the 3 critical facts synchronously before `finalize_registration`, using `additive: true` (introduced in theforeman/foreman#10942) so existing `fact_values` are not deleted on re-registrations. The full 193-fact sync continues to happen at step 6 unchanged.

## Test plan

- [x] New host registration: `RhelLifecycleStatus` correct immediately after `POST /rhsm/consumers`
- [x] Re-registration: existing facts preserved after step-2 subset import
- [x] `additive:` keyword threaded through `SubscriptionFacet.update_facts`

Fixes #39213
Depends on theforeman/foreman#10942 (additive import mode)

## Summary by Sourcery

Limit synchronous fact import during host registration to only the OS and architecture detection facts while supporting additive fact updates.

Enhancements:
- Introduce a constant list of critical RHSM facts required at registration time for immediate RHEL lifecycle status calculation.
- Update registration flow to import only these critical facts synchronously and defer full fact import to the later consumer update step.
- Extend SubscriptionFacet.update_facts to support an additive import mode and pass it through to HostFactImporter so existing facts are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now saves critical system details (distribution name, version, machine type) immediately after creation.
  * Critical facts are imported in an additive mode so previously collected host data is preserved.
  * Failures when saving these facts are logged and no longer block or abort registration.
  * Full/further facts import is deferred to a later finalize step rather than during initial creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->