### PR TITLE
Fixes #39258 - Unable to save host configuration due to missing variant_repos method

### DIFF
--- a/app/services/katello/managed_content_medium_provider.rb
+++ b/app/services/katello/managed_content_medium_provider.rb
@@ -17,7 +17,7 @@ module Katello
     # If there are any 'AppStream' variants, we need to make them
     # available to Anaconda
     def additional_media
-      appstream_repos = entity.operatingsystem.variant_repos(entity, 'AppStream')
+      appstream_repos = entity.operatingsystem.try(:variant_repos, entity, 'AppStream') || []
       super + (appstream_repos.present? ? appstream_repos : [])
     end
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR fixes an issue where the `entity.operatingsystem` object doesn't provide the variant_repos method by checking to see it if exists, first.

This fixes a bug that prevents the user from being able to save changes made to a Debian or Ubuntu host with the message:

```
Failed to render template 'Preseed default', error: undefined method 'variant_repos' for #<Debian id: .............
```

#### Considerations taken when implementing this change?

Continuing to provide the functionality when the method exists, but failing gracefully if it does not.

#### What are the testing steps for this pull request?

Configure a content host for deployment with RHEL, then try switching to using Ubuntu or Debian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when gathering AppStream variant repositories by safely handling cases where variant repository information is missing; operations now default to an empty set instead of failing, preventing errors during content management workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->