### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -51,7 +51,7 @@ module Katello
     private
 
     def find_repository
-      @repository = Repository.find(params[:repository_id])
+      @repository = Repository.editable.find(params[:repository_id])
     end
   end
 end

--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -11,12 +11,8 @@ module Katello
     param_group :search, Api::V2::ApiController
     def bootc_images
       params[:sort_by] = sanitize_sort_column(params[:sort_by])
-      params[:sort_order] ||= 'asc'
-      if params[:order]
-        params[:order] = "#{params[:order].split(' ')[0]} #{sanitize_sort_order(params[:order].split(' ')[1])}"
-      else
-        params[:order] = "#{params[:sort_by]} #{sanitize_sort_order(params[:sort_order])}"
-      end
+      params[:sort_order] = sanitize_sort_order(params[:sort_order])
+      params[:order] = "#{params[:sort_by]} #{params[:sort_order]}"
       per_page = params[:per_page].present? ? params[:per_page].to_i : Setting[:entries_per_page]
       page = params[:page].present? ? params[:page].to_i : 1
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `app/controllers/katello/api/v2/host_bootc_images_controller.rb:L16`

The `bootc_images` action partially sanitizes sorting, but when `params[:order]` is provided it keeps the first token unsanitized and later passes it directly into ActiveRecord `.order(params[:order])`. An attacker can supply crafted SQL in the column portion of `order`, which may result in SQL injection depending on adapter/rails protections and query context.

## Solution

Do not accept raw `order` input. Ignore `params[:order]` entirely and build ordering only from an allowlist of known columns + allowlisted direction (asc/desc), e.g. `order(Arel.sql("#{allowed_column} #{allowed_dir}"))` where both parts are strictly validated against constants.

## Changes

- `app/controllers/katello/api/v2/host_bootc_images_controller.rb` (modified)
- `app/controllers/katello/api/v2/content_uploads_controller.rb` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repositories marked as non-editable are now properly restricted from modification operations through the API.

* **Improvements**
  * Sort parameter handling for bootc image listings has been enhanced for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->