### PR TITLE
Fixes #39257 - Filter for content proxies in get_content_source_id

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -278,7 +278,7 @@ module Katello
     end
 
     def get_content_source_id(hostname)
-      proxies = SmartProxy.unscoped.authorized.with_content.filter do |sp|
+      proxies = SmartProxy.unscoped.authorized.with_content.order(:id).filter do |sp|
         hostname == URI.parse(sp.url).hostname
       end
       return nil if proxies.empty?

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -278,10 +278,15 @@ module Katello
     end
 
     def get_content_source_id(hostname)
-      proxies = SmartProxy.unscoped.authorized.filter do |sp|
+      proxies = SmartProxy.unscoped.authorized.with_content.filter do |sp|
         hostname == URI.parse(sp.url).hostname
       end
-      return nil if proxies.length != 1
+      return nil if proxies.empty?
+
+      if proxies.length > 1
+        Rails.logger.warn "Multiple content proxies found for hostname #{hostname}: #{proxies.map(&:name).join(', ')}. Using #{proxies.first.name}."
+      end
+
       proxies.first.id
     end
 

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -492,10 +492,10 @@ module Katello
     end
 
     describe "get content source id" do
-      let(:hostname) { "satellite.example.com" }
+      let(:hostname) { "content-source-test-#{SecureRandom.hex(8)}.example.com" }
 
       it "returns nil when no proxies match hostname" do
-        result = @controller.get_content_source_id("nonexistent.example.com")
+        result = @controller.get_content_source_id("nonexistent-#{SecureRandom.hex(8)}.example.com")
         assert_nil result
       end
 
@@ -509,9 +509,14 @@ module Katello
       end
 
       it "returns nil when no content proxies match hostname" do
-        unique_hostname = "definitely-nonexistent-#{SecureRandom.hex(8)}.example.com"
-        # Don't create any proxies with this hostname
-        result = @controller.get_content_source_id(unique_hostname)
+        no_content_hostname = "no-content-#{SecureRandom.hex(8)}.example.com"
+        proxy = FactoryBot.create(:smart_proxy, :url => "https://#{no_content_hostname}:9090")
+        proxy.smart_proxy_features.where(
+          :feature_id => Feature.where(:name => [SmartProxy::PULP_FEATURE, SmartProxy::PULP_NODE_FEATURE, SmartProxy::PULP3_FEATURE])
+        ).destroy_all
+        proxy.reload
+
+        result = @controller.get_content_source_id(no_content_hostname)
         assert_nil result
       end
 
@@ -528,7 +533,7 @@ module Katello
         assert_equal content_proxy.id, result
       end
 
-      it "returns first proxy id when multiple content proxies match hostname" do
+      it "returns lowest-id proxy when multiple content proxies match hostname" do
         pulp3_feature = Feature.find_or_create_by(:name => SmartProxy::PULP3_FEATURE)
         proxy1 = FactoryBot.create(:smart_proxy, :url => "https://#{hostname}:9090")
         proxy1.features << pulp3_feature unless proxy1.features.include?(pulp3_feature)

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -490,5 +490,57 @@ module Katello
         assert_equal 'foreman.example.com', @controller.get_parent_host(nil_host)
       end
     end
+
+    describe "get content source id" do
+      let(:hostname) { "satellite.example.com" }
+
+      it "returns nil when no proxies match hostname" do
+        result = @controller.get_content_source_id("nonexistent.example.com")
+        assert_nil result
+      end
+
+      it "returns proxy id when single content proxy matches hostname" do
+        pulp3_feature = Feature.find_or_create_by(:name => SmartProxy::PULP3_FEATURE)
+        proxy = FactoryBot.create(:smart_proxy, :url => "https://#{hostname}:9090")
+        proxy.features << pulp3_feature unless proxy.features.include?(pulp3_feature)
+
+        result = @controller.get_content_source_id(hostname)
+        assert_equal proxy.id, result
+      end
+
+      it "returns nil when no content proxies match hostname" do
+        unique_hostname = "definitely-nonexistent-#{SecureRandom.hex(8)}.example.com"
+        # Don't create any proxies with this hostname
+        result = @controller.get_content_source_id(unique_hostname)
+        assert_nil result
+      end
+
+      it "returns content proxy id when multiple proxies match but only one has content features" do
+        pulp3_feature = Feature.find_or_create_by(:name => SmartProxy::PULP3_FEATURE)
+        content_proxy = FactoryBot.create(:smart_proxy, :url => "https://#{hostname}:9090")
+        content_proxy.features << pulp3_feature unless content_proxy.features.include?(pulp3_feature)
+
+        dev_feature = Feature.find_or_create_by(:name => "Development")
+        non_content_proxy = FactoryBot.create(:smart_proxy, :url => "https://#{hostname}:9091")
+        non_content_proxy.features << dev_feature unless non_content_proxy.features.include?(dev_feature)
+
+        result = @controller.get_content_source_id(hostname)
+        assert_equal content_proxy.id, result
+      end
+
+      it "returns first proxy id when multiple content proxies match hostname" do
+        pulp3_feature = Feature.find_or_create_by(:name => SmartProxy::PULP3_FEATURE)
+        proxy1 = FactoryBot.create(:smart_proxy, :url => "https://#{hostname}:9090")
+        proxy1.features << pulp3_feature unless proxy1.features.include?(pulp3_feature)
+
+        proxy2 = FactoryBot.create(:smart_proxy, :url => "https://#{hostname}:9091")
+        proxy2.features << pulp3_feature unless proxy2.features.include?(pulp3_feature)
+
+        Rails.logger.expects(:warn).with(includes("Multiple content proxies found"))
+
+        result = @controller.get_content_source_id(hostname)
+        assert_equal proxy1.id, result
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem

In foremanctl setups, multiple SmartProxy records may share the same hostname (e.g., "satellite.example.com-pulp", "satellite.example.com-dev"). The `get_content_source_id` method was matching all proxies by hostname without filtering for Pulp/content features, causing the length check to fail and leaving hosts with `nil content_source_id` during registration.

## Solution

This PR updates the `get_content_source_id` method to:
- Add `.with_content` to filter for Pulp-capable proxies only
- Change the length check from `!= 1` to `empty?` to allow multiple content proxies with the same hostname (uses the first one)
- Add warning logging when multiple content proxies match for diagnosability

<img width="3840" height="1854" alt="image" src="https://github.com/user-attachments/assets/4f169b2c-0b2e-4b5f-af41-37a61afc56b8" />



## Load Balancer Compatibility

The fix maintains full compatibility with load-balanced proxy scenarios. The `SmartProxy.behind_load_balancer` method already uses `.with_content` internally, so the load balancer override path continues to work correctly.

## Testing

- Added comprehensive test coverage for all scenarios:
  - No proxies match hostname → returns nil
  - Single content proxy matches → returns its ID
  - Multiple proxies but only one has content features → returns the content proxy ID
  - Multiple content proxies match → returns first one with warning
- All existing tests pass (54 tests, 103 assertions, 0 failures)

Fixes: https://projects.theforeman.org/issues/39257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Content proxy selection now handles multiple matching proxies more gracefully, choosing a deterministic proxy and emitting diagnostic warnings when duplicates exist.

* **Tests**
  * Added comprehensive tests for content proxy selection covering no-match, single-match, content-enabled filtering, and multi-proxy warning/selection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->