### PR TITLE
Fixes #39252 - Filter activation keys by environment_id

### DIFF
--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -5,6 +5,7 @@ module Katello
     include Katello::Concerns::Api::V2::MultiCVParamsHandling
     before_action :verify_presence_of_organization_or_environment, :only => [:index]
     before_action :find_optional_organization, :only => [:index, :create, :show]
+    before_action :find_optional_environment, :only => [:index]
     before_action :find_authorized_katello_resource, :only => [:show, :update, :destroy, :available_releases,
                                                                :available_host_collections, :add_host_collections, :remove_host_collections,
                                                                :content_override]
@@ -219,7 +220,11 @@ module Katello
       activation_keys = activation_keys.where(:organization_id => @organization) if @organization
       activation_keys = activation_keys.with_content_view_environments(@content_view_environments) if @content_view_environments
       activation_keys = activation_keys.with_content_views(params[:content_view_id]) if params[:content_view_id]
-      activation_keys = activation_keys.with_environments(params[:lifecycle_environments]) if params[:lifecycle_environments]
+      if @environment
+        activation_keys = activation_keys.with_environments([@environment.id])
+      elsif params[:lifecycle_environments]
+        activation_keys = activation_keys.with_environments(params[:lifecycle_environments])
+      end
       activation_keys
     end
 
@@ -305,6 +310,11 @@ module Katello
         fail HttpErrors::NotFound, _("Couldn't find host collection '%s'") % host_collection_id if host_collection.nil?
         @host_collections << host_collection
       end
+    end
+
+    def find_optional_environment
+      return unless params[:environment_id]
+      @environment = KTEnvironment.readable.find(params[:environment_id])
     end
 
     def verify_presence_of_organization_or_environment

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -62,6 +62,50 @@ module Katello
       assert_equal results["results"].size, 5
     end
 
+    def test_index_filter_by_environment
+      dev = katello_environments(:dev)
+      results = JSON.parse(get(:index, params: { :environment_id => dev.id }).body)
+
+      assert_response :success
+      assert_equal 1, results['results'].size
+      result_ids = results['results'].map { |r| r['id'] }
+      assert_includes result_ids, katello_activation_keys(:library_dev_staging_view_key).id
+      refute_includes result_ids, @activation_key.id
+    end
+
+    def test_index_filter_by_environment_with_no_activation_keys
+      staging = katello_environments(:staging)
+      results = JSON.parse(get(:index, params: { :environment_id => staging.id }).body)
+
+      assert_response :success
+      assert_equal 0, results['results'].size
+    end
+
+    def test_index_filter_by_nonexistent_environment
+      get :index, params: { :environment_id => -1 }
+      assert_response :not_found
+    end
+
+    def test_index_filter_by_environment_and_content_view
+      dev = katello_environments(:dev)
+      cv = katello_content_views(:library_dev_staging_view)
+      results = JSON.parse(get(:index, params: { :environment_id => dev.id, :content_view_id => cv.id }).body)
+
+      assert_response :success
+      assert_equal 1, results['results'].size
+      assert_equal katello_activation_keys(:library_dev_staging_view_key).id, results['results'].first['id']
+    end
+
+    def test_index_filter_by_environment_id_and_lifecycle_environments_with_different_values
+      dev = katello_environments(:dev)
+      library = @organization.library
+      results = JSON.parse(get(:index, params: { :environment_id => dev.id, :lifecycle_environments => library.id }).body)
+
+      assert_response :success
+      assert_equal 1, results['results'].size
+      assert_equal katello_activation_keys(:library_dev_staging_view_key).id, results['results'].first['id']
+    end
+
     def test_show
       results = JSON.parse(get(:show, params: { :id => @activation_key.id }).body)
 

--- a/test/fixtures/models/katello_activation_keys.yml
+++ b/test/fixtures/models/katello_activation_keys.yml
@@ -26,7 +26,7 @@ dev_key:
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 
 library_dev_staging_view_key:
-  name: Lib Dev Stating Activation Key
+  name: Lib Dev Staging Activation Key
   description: Here we go again!
   organization_id: <%= ActiveRecord::FixtureSet.identify(:empty_organization) %>
 


### PR DESCRIPTION
## Summary
- The `/katello/api/environments/:environment_id/activation_keys` endpoint
  was returning all activation keys in the organization instead of filtering
  by the specified lifecycle environment.
- The `environment_id` URL path parameter was accepted but never used in
  `index_relation` to filter results. Added the missing filter using the
  existing `with_environments` scope.
- Fixed typo in activation key fixture name ("Stating" → "Staging").
## Testing steps
- Have a Satellite and in a Default Organization create `Dev` environment with `Library` as prior LCE
- Create a CV=`Cv1` and publish a new version to both `Dev` and `Library` LCEs
- Create 1 AK `AK-Library-Test` with LCE=`Library` and CV=`Cv1`
- Create 1 AK `AK-Dev-Test` with LCE=`Dev` and CV=`Cv1`
Then check the API responses of the queries on AK from a specific Environments:
 ```
curl -s -u usrname:psswd 'https://localhost/katello/api/environments/<LCE_ID>/activation_keys' -k | python3 -m json.tool | grep -E '"(name|total|subtotal)"'
```
```
curl -s -u usrname:psswd 'https://localhost/katello/api/environments/<LCE_ID>/activation_keys' -k | python3 -m json.tool | grep -E '"(name|total|subtotal)"'
```

^^^ They should return only AK for the specific Environment, NOT all AK in the Organization
## Test plan
- [x] Added `test_index_filter_by_environment` to verify only activation
  keys belonging to the specified environment are returned
- [ ] Verify manually:
  - `curl -s -u usrname:psswd 'https://localhost/katello/api/environments/2/activation_keys' -k`
    returns only keys in environment 2
  - `curl -s -u usrname:psswd 'https://localhost/katello/api/environments/1/activation_keys' -k`
    returns only keys in environment 1
- [ ] Run full activation keys controller test suite:
  `ktest test/controllers/api/v2/activation_keys_controller_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activation keys API now supports filtering results by environment ID.

* **Bug Fixes**
  * Corrected a fixture name typo to ensure accurate test data.

* **Tests**
  * Added tests covering environment-based filtering, combined filters, empty results, and handling of nonexistent environment IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->