### PR TITLE
Fixes #39259 - Remove content_facet.uuid usage in favor of subscription_facet.uuid

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -52,7 +52,7 @@ module Katello
         auth = authenticate_client
         if auth
           ::User.current = ::User.anonymous_admin
-          @host = Katello::Host::ContentFacet.find_by(uuid: uuid)&.host
+          @host = Katello::Host::SubscriptionFacet.find_by(uuid: uuid)&.host
         end
       end
     end
@@ -79,7 +79,7 @@ module Katello
           return false
         end
       elsif header_host_uuid
-        @host = Katello::Host::ContentFacet.find_by(uuid: header_host_uuid)&.host
+        @host = Katello::Host::SubscriptionFacet.find_by(uuid: header_host_uuid)&.host
       else
         authenticate_cert_request
       end

--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -129,7 +129,7 @@ module Katello
     def find_editable_host_with_facet
       @host = resource_finder(::Host::Managed.authorized("edit_hosts"), params[:host_id])
       fail HttpErrors::NotFound, _("Couldn't find host with host id '%s'") % params[:host_id] if @host.nil?
-      if @host.content_facet.try(:uuid).nil?
+      if @host.subscription_facet&.uuid.blank?
         fail HttpErrors::NotFound, _("Host has not been registered with subscription-manager.") % params[:host_id]
       end
       @host

--- a/app/lib/actions/katello/host/recalculate_errata_status.rb
+++ b/app/lib/actions/katello/host/recalculate_errata_status.rb
@@ -4,7 +4,7 @@ module Actions
       class RecalculateErrataStatus < Actions::Base
         def run
           ::Host.unscoped.find_each do |host|
-            host.content_facet.update_errata_status if host.content_facet.try(:uuid)
+            host.content_facet&.update_errata_status if host.subscription_facet&.uuid.present?
           rescue StandardError => error
             output[:errors] ||= []
             output[:errors] << (_("Error refreshing status for %s: ") % host.name) + error.message

--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -40,7 +40,7 @@ module Katello
       def readable_docker_catalog(host = nil)
         #If host is identified in the request via certs or IP addr, and the host is registered (uuid != nil), show only
         # available repos in host's LCE scope
-        if host && host&.content_facet&.uuid
+        if host&.subscription_facet&.uuid.present?
           repo_ids = []
           if host&.content_view_environments&.any?
             repo_ids = host.content_view_environments.flat_map do |cve|

--- a/app/models/katello/errata_status.rb
+++ b/app/models/katello/errata_status.rb
@@ -70,7 +70,7 @@ module Katello
     end
 
     def relevant?(_options = {})
-      host.content_facet.try(:uuid)
+      host.subscription_facet.try(:uuid)
     end
   end
 end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -6,6 +6,12 @@ module Katello
       self.table_name = 'katello_content_facets'
       include Facets::Base
 
+      # Delegate uuid to subscription_facet since UUID is a subscription/consumer concept
+      # The uuid column was removed from content_facets table
+      def uuid
+        host&.subscription_facet&.uuid
+      end
+
       HOST_TOOLS_PACKAGE_NAME = 'katello-host-tools'.freeze
       HOST_TOOLS_TRACER_PACKAGE_NAME = 'katello-host-tools-tracer'.freeze
       SUBSCRIPTION_MANAGER_PACKAGE_NAME = 'subscription-manager'.freeze

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -50,8 +50,8 @@ module Katello
       consumer_ids = []
 
       self.hosts.each do |host|
-        if host.content_facet
-          consumer_ids.push(host.content_facet.uuid)
+        if host.subscription_facet
+          consumer_ids.push(host.subscription_facet.uuid)
         end
       end
 

--- a/app/models/katello/trace_status.rb
+++ b/app/models/katello/trace_status.rb
@@ -51,7 +51,7 @@ module Katello
     def relevant?(_options = {})
       # traces cannot be reported from hosts lower than el7
       return false if host.operatingsystem.try(:major).to_i.between?(1, 6) || !host.content_facet&.tracer_installed?
-      host.content_facet.try(:uuid).present?
+      host.subscription_facet.try(:uuid).present?
     end
   end
 end

--- a/app/services/katello/host/package_profile_uploader.rb
+++ b/app/services/katello/host/package_profile_uploader.rb
@@ -25,8 +25,8 @@ module Katello
         host = ::Host.find_by(:id => host_id)
         if host.nil?
           Rails.logger.warn("Host with ID %s not found; continuing" % host_id)
-        elsif host.content_facet.nil? || host.content_facet.uuid.nil?
-          Rails.logger.warn("Host with ID %s has no content facet; continuing" % host_id)
+        elsif host.subscription_facet&.uuid.blank?
+          Rails.logger.warn("Host with ID %s has no subscription facet; continuing" % host_id)
         else
           begin
             simple_packages = profile.map { |item| ::Katello::SimplePackage.new(item) }

--- a/app/services/katello/host/profiles_uploader.rb
+++ b/app/services/katello/host/profiles_uploader.rb
@@ -11,7 +11,10 @@ module Katello
         if @host.nil?
           Rails.logger.warn("Host was not specified; skipping")
           return false
-        elsif @host.content_facet.nil? || @host.content_facet.uuid.nil?
+        elsif @host.subscription_facet&.uuid.blank?
+          Rails.logger.warn("Host with ID %s has no subscription facet UUID; skipping" % @host.id)
+          return false
+        elsif @host.content_facet.nil?
           Rails.logger.warn("Host with ID %s has no content facet; skipping" % @host.id)
           return false
         end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -176,7 +176,7 @@ module Katello
 
         host_uuid = get_uuid(consumer_params)
         consumer_params[:uuid] = host_uuid
-        host.content_facet = populate_content_facet(host, content_view_environments, host_uuid)
+        host.content_facet = populate_content_facet(host, content_view_environments)
         host.content_facet.cves_changed = false # prevent backend_update_needed from triggering an update on a nonexistent consumer
         host.subscription_facet = populate_subscription_facet(host, activation_keys, consumer_params, host_uuid)
         host.save! # the host has content and subscription facets at this point
@@ -295,10 +295,9 @@ module Katello
         Rails.logger.warn(_("Candlepin consumer %s has already been removed") % host_uuid)
       end
 
-      def populate_content_facet(host, content_view_environments, uuid)
+      def populate_content_facet(host, content_view_environments)
         content_facet = host.content_facet || ::Katello::Host::ContentFacet.new(:host => host)
         content_facet.content_view_environments = content_view_environments
-        content_facet.uuid = uuid
         content_facet.save!
         content_facet
       end
@@ -319,7 +318,6 @@ module Katello
         if host.content_facet && clear_content_facet
           host.content_facet.bound_repositories = []
           host.content_facet.applicable_errata = []
-          host.content_facet.uuid = nil
 
           # Clear or retain provisioning information based on setting
           unless Setting[:retain_build_profile_upon_unregistration] || preserve_for_provisioning

--- a/db/migrate/20260423131700_remove_uuid_from_content_facets.rb
+++ b/db/migrate/20260423131700_remove_uuid_from_content_facets.rb
@@ -1,0 +1,24 @@
+class RemoveUuidFromContentFacets < ActiveRecord::Migration[7.0]
+  def up
+    # No data migration needed - subscription_facet.uuid is already the authoritative source
+    # The ContentFacet model has delegation methods that automatically return subscription_facet.uuid
+    # Any data in content_facet.uuid is either:
+    # 1. Redundant (same as subscription_facet.uuid) - delegation handles it
+    # 2. Stale/orphaned (different from subscription_facet.uuid) - should not be copied
+    # 3. Present when subscription_facet.uuid is NULL - indicates unregistered/stale state
+    remove_column :katello_content_facets, :uuid
+  end
+
+  def down
+    add_column :katello_content_facets, :uuid, :string, limit: 255
+
+    # Populate from subscription_facet on rollback
+    execute <<-SQL
+      UPDATE katello_content_facets cf
+      SET uuid = sf.uuid
+      FROM katello_subscription_facets sf
+      WHERE sf.host_id = cf.host_id
+        AND sf.uuid IS NOT NULL
+    SQL
+  end
+end

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host.factory.js
@@ -16,7 +16,7 @@ angular.module('Bastion.hosts').factory('Host',
             autocomplete: {method: 'GET', isArray: true, params: {id: 'auto_complete_search'}}
         });
         resource.prototype.hasContent = function () {
-            return angular.isDefined(this.content_facet_attributes) && angular.isDefined(this.content_facet_attributes.uuid);
+            return angular.isDefined(this.content_facet_attributes) && angular.isDefined(this.subscription_facet_attributes) && angular.isDefined(this.subscription_facet_attributes.uuid);
         };
         resource.prototype.hasSubscription = function () {
             return angular.isDefined(this.subscription_facet_attributes) && angular.isDefined(this.subscription_facet_attributes.uuid);

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -382,7 +382,7 @@ module Katello
                                  :organization => @organization)
 
         # Mock certificate authentication for the host
-        uuid = host.content_facet.uuid
+        uuid = host.subscription_facet.uuid
         client_cert = mock('client_cert')
         client_cert.stubs(:uuid).returns(uuid)
         ::Cert::RhsmClient.expects(:new).returns(client_cert)
@@ -1438,7 +1438,7 @@ module Katello
       end
 
       it "authenticates with client certificate and sets host" do
-        uuid = @host.content_facet.uuid
+        uuid = @host.subscription_facet.uuid
 
         # Mock certificate authentication
         client_cert = mock('client_cert')
@@ -1577,7 +1577,7 @@ module Katello
       end
 
       it "filters repositories based on host permissions" do
-        uuid = @host.content_facet.uuid
+        uuid = @host.subscription_facet.uuid
 
         # Mock certificate authentication
         client_cert = mock('client_cert')

--- a/test/controllers/api/v2/host_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/host_subscriptions_controller_test.rb
@@ -289,7 +289,7 @@ module Katello
     end
 
     def test_enabled_repositories
-      @host.content_facet = ::Katello::Host::ContentFacet.find_by(uuid: 'content_facet_one')
+      @host.content_facet = katello_content_facets(:content_facet_one)
 
       get :enabled_repositories, params: { :host_id => @host.id }
       response_body_hash = JSON.parse(response.body)

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -293,6 +293,5 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
     post :create, params: attrs
     assert_response :success # the uuid is simply filtered out which allows the host to be still saved
-    refute Katello::Host::ContentFacet.where(:uuid => cf_attrs[:uuid]).exists?
   end
 end

--- a/test/factories/content_facet_factory.rb
+++ b/test/factories/content_facet_factory.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :katello_content_facets, :aliases => [:content_facet], :class => ::Katello::Host::ContentFacet do
-    sequence(:uuid) { |n| "uuid-#{n}" }
+    # UUID removed - it belongs to subscription_facet, not content_facet
   end
 end

--- a/test/fixtures/models/katello_content_facets.yml
+++ b/test/fixtures/models/katello_content_facets.yml
@@ -1,11 +1,8 @@
 content_facet_one:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:one) %>
-  uuid: "content_facet_one"
 
 content_facet_two:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:two) %>
-  uuid: "content_facet_two"
 
 without_errata:
   host_id:  <%= ActiveRecord::FixtureSet.identify(:without_errata) %>
-  uuid: "without_errata"

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -60,7 +60,7 @@ module Katello
       host.save!
       host.reload.content_facet.reload
 
-      refute_nil host.content_facet.uuid # not reset to nil
+      refute_nil host.subscription_facet.uuid # not reset to nil
       host_cve = host.content_view_environments.first
       assert_equal dev.id, host_cve.environment_id # unchanged
       assert_equal view2.id, host_cve.content_view_id # changed
@@ -73,7 +73,7 @@ module Katello
       host.subscription_facet.expects(:backend_update_needed?).returns(false)
       host.update!(:content_facet_attributes => { :content_source_id => proxy.id })
       host.reload.content_facet.reload
-      refute_nil host.content_facet.uuid # not reset to nil
+      refute_nil host.subscription_facet.uuid # not reset to nil
       assert_equal proxy.id, host.content_facet.content_source_id # changed
     end
 

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -352,7 +352,8 @@ module Katello
         # Verify other data is still cleared as expected
         assert_empty @host.content_facet.bound_repositories
         assert_empty @host.content_facet.applicable_errata
-        assert_nil @host.content_facet.uuid
+        # Reload to clear cached association - subscription_facet is destroyed, so uuid is nil
+        assert_nil @host.reload.subscription_facet&.uuid
       end
 
       def test_unregister_host_retains_build_profile_when_setting_enabled
@@ -381,7 +382,8 @@ module Katello
         # Verify other data is still cleared as expected
         assert_empty @host.content_facet.bound_repositories
         assert_empty @host.content_facet.applicable_errata
-        assert_nil @host.content_facet.uuid
+        # Reload to clear cached association - subscription_facet is destroyed, so uuid is nil
+        assert_nil @host.reload.subscription_facet&.uuid
       end
 
       def test_re_register_host_preserves_build_profile_regardless_of_setting # rubocop:disable Metrics/AbcSize
@@ -422,7 +424,7 @@ module Katello
         # Verify other data is still cleared as expected during unregistration
         assert_empty @host.content_facet.bound_repositories
         assert_empty @host.content_facet.applicable_errata
-        assert_equal 'fake-uuid-from-katello', @host.content_facet.uuid
+        assert_equal 'fake-uuid-from-katello', @host.subscription_facet.uuid
       end
 
       def test_destroy_host_not_found


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- Removed the `uuid` column from `katello_content_facets` table since UUID is fundamentally a subscription/consumer concept that belongs to `subscription_facet`
- Updated all code references from `content_facet.uuid` to `subscription_facet.uuid` throughout the codebase
- Added backward-compatible delegation methods to `ContentFacet` model that automatically route uuid reads/writes to `subscription_facet`

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
-  Run bundle exec rake test:katello to ensure all tests pass
- Verify host registration creates subscription_facet with uuid, not content_facet
-  Verify host unregistration properly clears subscription_facet.uuid
-  Test registry authentication with certificate-based hosts
-  Verify errata and trace status checks work correctly for registered hosts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Database migration consolidates host identity to a single authoritative identifier for improved consistency.

* **Bug Fixes / Improvements**
  * Host authentication, repository visibility, package/profile imports, and status/trace checks consistently use the consolidated identifier, improving reliability of host-scoped actions and filtering.
  * Host registration/unregistration no longer overwrites the authoritative identifier, preventing accidental identity loss.
  * Client-side content detection now requires both content and subscription identifiers to be present.

* **Tests**
  * Fixtures, mocks, and assertions updated to reflect the identifier consolidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->