### PR TITLE
Fixes #39270 - Move theforeman-rubocop dep into Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 Dir[File.join(__dir__, 'gemfile.d', '*.rb')].each do |bundle|
   eval_gemfile(bundle)
 end
+
+gem 'theforeman-rubocop', '~> 0.1.2', require: false, groups: %i[development rubocop]

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -65,6 +65,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency "deface", '>= 1.0.2', '< 2.0.0'
   gem.add_dependency "angular-rails-templates", "~> 1.1"
   gem.add_dependency "jquery-ui-rails", "~> 6.0"
-
-  gem.add_development_dependency "theforeman-rubocop", '~> 0.1.0'
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Move theforeman-rubocop dependency to Gemfile instead of specifying it in gemspec.

#### Considerations taken when implementing this change?

With newer bundler and the way we setup the Foreman with plugins, there are resolution failures due to duplicated dependencies.

Another fix would be using `gemfile.d` instead of Gemfile.

#### What are the testing steps for this pull request?

Run `bundle install` with any other plugin that has the same dependency with a different version.

Before: fails to resolve (or there are warnings on older bundler version)
After: passes without any issue, rubocop still works locally and in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependency management for code quality tooling by reorganizing gem declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->