### PR TITLE
Fixes #39280 - Move host/hostgroup association cleanup into KTEnviron…

### DIFF
--- a/app/lib/actions/katello/environment/destroy.rb
+++ b/app/lib/actions/katello/environment/destroy.rb
@@ -24,18 +24,11 @@ module Actions
             end
 
             if organization_destroy
-              delete_host_and_hostgroup_associations(environment: env)
+              env.delete_host_and_hostgroup_associations
             end
 
             plan_self
           end
-        end
-
-        def delete_host_and_hostgroup_associations(environment:)
-          environment.hostgroups.delete_all
-          host_ids = environment.hosts.ids
-          ::Katello::Host::ContentFacet.where(:host_id => host_ids).delete_all
-          ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids).delete_all
         end
 
         def humanized_name

--- a/app/models/katello/kt_environment.rb
+++ b/app/models/katello/kt_environment.rb
@@ -273,6 +273,14 @@ module Katello
       self.repositories.map(&:minor).compact.uniq.sort
     end
 
+    def delete_host_and_hostgroup_associations
+      hgcf_ids = hostgroup_content_facets.ids
+      ::Katello::Hostgroup::ContentFacet.where(id: hgcf_ids).destroy_all
+      host_ids = hosts.ids
+      ::Katello::Host::ContentFacet.where(:host_id => host_ids).destroy_all
+      ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids).destroy_all
+    end
+
     def self.humanize_class_name
       _("Lifecycle Environment")
     end

--- a/test/actions/katello/environment_test.rb
+++ b/test/actions/katello/environment_test.rb
@@ -65,9 +65,7 @@ module ::Actions::Katello::Environment
       action.stubs(:action_subject).with(environment)
       environment.expects(:content_view_environments).returns([cve])
       environment.expects(:deletable?).returns(true)
-      environment.expects(:hostgroups).returns(::Hostgroup.none)
-      environment.expects(:hosts).returns(::Host.none)
-      environment.expects(:hosts=).never
+      environment.expects(:delete_host_and_hostgroup_associations)
       plan_action(action, environment, :organization_destroy => true)
       assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => true)
     end

--- a/test/models/kt_environment_test.rb
+++ b/test/models/kt_environment_test.rb
@@ -129,4 +129,26 @@ module Katello
       assert_equal succ.prior, @dev
     end
   end
+
+  class KTEnvironmentDeleteAssociationsTest < KTEnvironmentTestBase
+    def test_delete_host_and_hostgroup_associations_removes_content_facets
+      assert @dev.content_facets.any?, "expected dev environment to have content facets via fixtures"
+      @dev.delete_host_and_hostgroup_associations
+      assert_empty @dev.reload.content_facets
+    end
+
+    def test_delete_host_and_hostgroup_associations_removes_subscription_facets
+      host_ids = @dev.hosts.ids
+      assert host_ids.any?, "expected dev environment to have hosts via fixtures"
+      @dev.delete_host_and_hostgroup_associations
+      assert_empty ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids)
+    end
+
+    def test_delete_host_and_hostgroup_associations_does_not_raise_on_nested_through
+      # Regression: calling destroy on a doubly-nested has_many :through raises
+      # HasManyThroughNestedAssociationsAreReadonly. The method must operate on
+      # the join model directly rather than environment.hostgroups.
+      assert_nothing_raised { @dev.delete_host_and_hostgroup_associations }
+    end
+  end
 end


### PR DESCRIPTION
…ment

#### What are the changes introduced in this pull request?
When deleting an organization, Environment::Destroy called environment.hostgroups.delete_all to clean up host group associations. This raises ActiveRecord::HasManyThroughNestedAssociationsAreReadonly because KTEnvironment#hostgroups is a doubly-nested has_many :through — Rails does not allow write operations on associations with more than one level of indirection.

This PR moves the cleanup logic into a new KTEnvironment#delete_host_and_hostgroup_associations method that works directly on the intermediate join models (Hostgroup::ContentFacet, Host::ContentFacet, Host::SubscriptionFacet) instead of going through the nested association. The action calls this method instead of inlining the logic. This mirrors the equivalent pattern already used in ContentView::Remove.

#### Considerations taken when implementing this change?

The new model method uses destroy_all rather than delete_all. Host::ContentFacet and Host::SubscriptionFacet both have dependent: :destroy child associations and are audited. Using delete_all would skip those callbacks, leaving orphaned rows and no audit trail. ContentView::Remove#destroy_host_and_hostgroup_associations uses destroy_all for the same reason, and this change stays consistent with that.

#### What are the testing steps for this pull request?

Unit tests are included for both the action and the model:

- Actions::Katello::Environment::DestroyWithOrganizationDestroyTest — updated to verify the action delegates to env.delete_host_and_hostgroup_associations
- Katello::KTEnvironmentDeleteAssociationsTest — three new tests verifying content facets are removed, subscription facets are removed, and the method does not raise HasManyThroughNestedAssociationsAreReadonly

To test manually, delete an organization via hammer organization delete --name <org> and confirm it completes without a HasManyThroughNestedAssociationsAreReadonly error.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of host and hostgroup cleanup operations during environment deletion. Functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->