### PR TITLE
Fixes #39282 - Show Applicable/Installable toggle for multi-CVEnv hosts

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -194,6 +194,19 @@ module Katello
         content_view_environments.first.default_environment?
       end
 
+      def content_view_environments_all_default_or_rolling?
+        return if content_view_environments.blank?
+        # Returns true if all applicable errata are installable, meaning:
+        # - First CVEnv is Library (Default Org View + Library environment), OR
+        # - All CVEnvs are rolling CVs or Library hosts
+        # This determines whether the Applicable/Installable toggle should be hidden.
+        return true if content_view_environments.first.default_environment?
+
+        content_view_environments.all? do |cve|
+          cve.content_view&.rolling? || cve.default_environment?
+        end
+      end
+
       def update_repositories_by_paths(paths)
         prefixes = %w(/pulp/deb/ /pulp/repos/ /pulp/content/)
         relative_paths = []

--- a/app/views/katello/api/v2/content_facet/base.json.rabl
+++ b/app/views/katello/api/v2/content_facet/base.json.rabl
@@ -44,6 +44,10 @@ node :multi_content_view_environment do |content_facet|
   content_facet.multi_content_view_environment?
 end
 
+node :content_view_environments_all_default_or_rolling do |content_facet|
+  content_facet.content_view_environments_all_default_or_rolling?
+end
+
 node :allow_multiple_content_views do
   Setting['allow_multiple_content_views']
 end

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -145,6 +145,41 @@ module Katello
       content_facet_rec = host1.associated_audits.where(auditable_id: content_facet1.id)
       assert content_facet_rec, "No associated audit record for content_facet"
     end
+
+    def test_all_default_or_rolling_returns_nil_when_no_cves
+      content_facet.content_view_environments = []
+      assert_nil content_facet.content_view_environments_all_default_or_rolling?
+    end
+
+    def test_all_default_or_rolling_returns_false_when_non_rolling_non_library
+      non_rolling_cve = katello_content_view_environments(:library_dev_view_dev)
+      content_facet.content_view_environments = [non_rolling_cve]
+      refute content_facet.content_view_environments_all_default_or_rolling?
+    end
+
+    def test_all_default_or_rolling_returns_true_when_first_is_library_with_others
+      library_cve = katello_content_view_environments(:library_default_view_environment)
+      non_rolling_cve = katello_content_view_environments(:library_dev_view_dev)
+      Setting['allow_multiple_content_views'] = true
+      content_facet.content_view_environments = [library_cve, non_rolling_cve]
+      assert content_facet.content_view_environments_all_default_or_rolling?
+    end
+
+    def test_all_default_or_rolling_returns_false_when_rolling_first_non_rolling_second
+      rolling_cve = katello_content_view_environments(:rolling_view_library)
+      non_rolling_cve = katello_content_view_environments(:library_dev_view_dev)
+      Setting['allow_multiple_content_views'] = true
+      content_facet.content_view_environments = [rolling_cve, non_rolling_cve]
+      refute content_facet.content_view_environments_all_default_or_rolling?
+    end
+
+    def test_all_default_or_rolling_returns_true_when_all_rolling_or_library
+      rolling_cve = katello_content_view_environments(:rolling_view_library)
+      library_cve = katello_content_view_environments(:library_default_view_environment)
+      Setting['allow_multiple_content_views'] = true
+      content_facet.content_view_environments = [rolling_cve, library_cve]
+      assert content_facet.content_view_environments_all_default_or_rolling?
+    end
   end
 
   class ContentFacetErrataTest < ContentFacetBase

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -406,7 +406,8 @@ export const ErrataTab = () => {
   // Show the Applicable/Installable toggle when not all errata are installable.
   // contentViewEnvironmentsAllDefaultOrRolling is true when all CVEnvs are Library or rolling,
   // meaning all applicable errata are installable and the toggle is unnecessary.
-  const showApplicableInstallableToggle = contentFacet?.contentViewEnvironmentsAllDefaultOrRolling === false;
+  const showApplicableInstallableToggle =
+    contentFacet?.contentViewEnvironmentsAllDefaultOrRolling === false;
   const toggleGroup = (
     <Split hasGutter>
       <SplitItem>

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.js
@@ -403,11 +403,10 @@ export const ErrataTab = () => {
     </>
   ) : null;
 
-  const hostIsNonLibrary = (
-    (contentFacet?.contentViewDefault === false ||
-      contentFacet.lifecycleEnvironmentLibrary === false) &&
-    contentFacet.contentView.rolling === false
-  );
+  // Show the Applicable/Installable toggle when not all errata are installable.
+  // contentViewEnvironmentsAllDefaultOrRolling is true when all CVEnvs are Library or rolling,
+  // meaning all applicable errata are installable and the toggle is unnecessary.
+  const showApplicableInstallableToggle = contentFacet?.contentViewEnvironmentsAllDefaultOrRolling === false;
   const toggleGroup = (
     <Split hasGutter>
       <SplitItem>
@@ -432,7 +431,7 @@ export const ErrataTab = () => {
           isDisabled={!results?.length}
         />
       </SplitItem>
-      {hostIsNonLibrary &&
+      {showApplicableInstallableToggle &&
         <SplitItem>
           <ToggleGroup aria-label="Installable Errata">
             <ToggleGroupItem
@@ -510,7 +509,7 @@ export const ErrataTab = () => {
           displaySelectAllCheckbox={showActions}
           requestKey={HOST_ERRATA_KEY}
           alwaysShowActionButtons={false}
-          alwaysShowToggleGroup={hostIsNonLibrary && neededErrata}
+          alwaysShowToggleGroup={showApplicableInstallableToggle && neededErrata}
         >
           <Thead>
             <Tr ouiaId="row-header">

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/errataTab.test.js
@@ -19,11 +19,7 @@ jest.mock('../../hostDetailsHelpers', () => ({
 const contentFacetAttributes = {
   id: 11,
   uuid: 'e5761ea3-4117-4ecf-83d0-b694f99b389e',
-  content_view_default: false,
-  contentView: {
-    rolling: false,
-  },
-  lifecycle_environment_library: false,
+  content_view_environments_all_default_or_rolling: false,
   errata_counts: {
     total: 3,
   },
@@ -572,139 +568,45 @@ test('Select all is disabled if all rows are selected', async (done) => {
   done(); // Pass jest callback to confirm test is done
 });
 
-test('Toggle Group shows if it\'s not the default content view or library enviroment', async (done) => {
-  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
-  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
-  const mockErrata = makeMockErrata({});
-  // return errata data results when we look for errata
-  const scope = nockInstance
-    .get(hostErrata)
-    .query(defaultQuery)
-    .reply(200, mockErrata);
-
-  const {
-    queryByLabelText,
-    getAllByText,
-  } = renderWithRedux(<ErrataTab />, renderOptions(cfWithErrataTotal(mockErrata.total)));
-
-  // Assert that the errata are now showing on the screen, but wait for them to appear.
-  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
-  expect(queryByLabelText('Installable Errata')).toBeInTheDocument();
-  assertNockRequest(autocompleteScope);
-  assertNockRequest(scope);
-  done(); // Pass jest callback to confirm test is done
-});
-
-test('Toggle Group shows if it\'s the default content view but non-library environment', async (done) => {
-  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
+test('Toggle Group shows when content_view_environments_all_default_or_rolling is false', async (done) => {
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   const mockErrata = makeMockErrata({});
   const options = renderOptions({
     ...cfWithErrataTotal(mockErrata.total),
-    content_view_default: true,
+    content_view_environments_all_default_or_rolling: false,
   });
-  // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
     .query(defaultQuery)
     .reply(200, mockErrata);
 
-  const {
-    queryByLabelText,
-    getAllByText,
-  } = renderWithRedux(<ErrataTab />, options);
+  const { queryByLabelText, getAllByText } = renderWithRedux(<ErrataTab />, options);
 
-  // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
   expect(queryByLabelText('Installable Errata')).toBeInTheDocument();
   assertNockRequest(autocompleteScope);
   assertNockRequest(scope);
-  done(); // Pass jest callback to confirm test is done
+  done();
 });
 
-test('Toggle Group shows if it\'s the library environment but non-default content view', async (done) => {
-  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
+test('Toggle Group does not show when content_view_environments_all_default_or_rolling is true', async (done) => {
   const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
   const mockErrata = makeMockErrata({});
   const options = renderOptions({
     ...cfWithErrataTotal(mockErrata.total),
-    lifecycle_environment_library: true,
+    content_view_environments_all_default_or_rolling: true,
   });
-
-  // return errata data results when we look for errata
   const scope = nockInstance
     .get(hostErrata)
     .query(defaultQuery)
     .reply(200, mockErrata);
 
-  const {
-    queryByLabelText,
-    getAllByText,
-  } = renderWithRedux(<ErrataTab />, options);
+  const { queryByLabelText, getAllByText } = renderWithRedux(<ErrataTab />, options);
 
-  // Assert that the errata are now showing on the screen, but wait for them to appear.
-  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
-  expect(queryByLabelText('Installable Errata')).toBeInTheDocument();
-  assertNockRequest(autocompleteScope);
-  assertNockRequest(scope);
-  done(); // Pass jest callback to confirm test is done
-});
-
-test('Toggle Group does not show if it\'s the default content view and library environment', async (done) => {
-  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
-  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
-  const mockErrata = makeMockErrata({});
-  const options = renderOptions({
-    ...cfWithErrataTotal(mockErrata.total),
-    content_view_default: true,
-    lifecycle_environment_library: true,
-  });
-  // return errata data results when we look for errata
-  const scope = nockInstance
-    .get(hostErrata)
-    .query(defaultQuery)
-    .reply(200, mockErrata);
-
-  const {
-    queryByLabelText,
-    getAllByText,
-  } = renderWithRedux(<ErrataTab />, options);
-
-  // Assert that the errata are now showing on the screen, but wait for them to appear.
   await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
   expect(queryByLabelText('Installable Errata')).not.toBeInTheDocument();
   assertNockRequest(autocompleteScope);
-  assertNockRequest(scope);
-  done(); // Pass jest callback to confirm test is done
-});
-
-test('Toggle Group does not show if it\'s a rolling content view and library environment', async (done) => {
-  // Setup autocomplete with mockForemanAutoComplete since we aren't adding /katello
-  const autocompleteScope = mockForemanAutocomplete(nockInstance, autocompleteUrl);
-  const mockErrata = makeMockErrata({});
-  const options = renderOptions({
-    ...cfWithErrataTotal(mockErrata.total),
-    contentView: {
-      rolling: true,
-    },
-    lifecycle_environment_library: true,
-  });
-  // return errata data results when we look for errata
-  const scope = nockInstance
-    .get(hostErrata)
-    .query(defaultQuery)
-    .reply(200, mockErrata);
-
-  const {
-    queryByLabelText,
-    getAllByText,
-  } = renderWithRedux(<ErrataTab />, options);
-
-  // Assert that the errata are now showing on the screen, but wait for them to appear.
-  await patientlyWaitFor(() => expect(getAllByText('Important')[0]).toBeInTheDocument());
-  expect(queryByLabelText('Installable Errata')).not.toBeInTheDocument();
-  assertNockRequest(autocompleteScope);
-  assertNockRequest(scope, done); // Pass jest callback to confirm test is done
+  assertNockRequest(scope, done);
 });
 
 test('Selection is disabled for errata which are applicable but not installable', async (done) => {


### PR DESCRIPTION
The Applicable/Installable errata toggle was incorrectly hidden for
hosts assigned to multiple content view environments when the first
CVEnv contained a rolling content view, even if subsequent CVEnvs
were non-rolling.

Added new method content_view_environments_all_default_or_rolling?
to ContentFacet that returns true when:
- First CVEnv is Library (Default Org View + Library environment), OR
- All CVEnvs are rolling CVs or Library hosts

This is exposed via the API as content_view_environments_all_default_or_rolling
and consumed by the frontend to determine toggle visibility.

#### What are the changes introduced in this pull request?
This PR fixes a bug where the Applicable/Installable errata toggle was incorrectly hidden for hosts assigned to multiple content view environments (CVEnvs).

Previously, the toggle visibility logic only checked `contentFacet.contentView.rolling`, which represents only the first CVEnv. If the first CVEnv was rolling but subsequent CVEnvs were non-rolling, the toggle would be hidden even though applicable-but-not-installable errata could exist in the non-rolling CVEnvs.

The fix updates the logic to evaluate all assigned CVEnvs:
Hide toggle when first CVEnv is Library, OR all CVEnvs are rolling/Library
Show toggle when at least one non-rolling, non-Library CVEnv exists

#### Considerations taken when implementing this change?
1. Backwards compatibility: The new logic falls back to the original single-CVEnv behavior when contentViewEnvironments is not present, ensuring existing deployments continue to work.

2. Library-first hosts: Per the expected behavior, if the first CVEnv is Library (Default Org View + Library environment), the host is considered a "library host" and the toggle is hidden regardless of subsequent CVEnvs.

3. Rolling + Library combinations: A host with only rolling CVs and/or Library environments will have all applicable errata be installable, so the toggle is unnecessary and hidden.

#### What are the testing steps for this pull request?
1. Run the automated tests

2. Manual testing:
- Create a host assigned to multiple CVEnvs: [rolling CV, non-rolling CV]
- Navigate to the host's Errata tab
Expected: The Applicable/Installable toggle should be visible

- Create a host assigned to [rolling CV, rolling CV]
Expected: The toggle should be hidden

- Create a host with Library as the first CVEnv: [Library, non-rolling CV]
Expected: The toggle should be hidden

- Create a host with [non-rolling CV, Library]
Expected: The toggle should be visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Applicable/Installable errata toggle now consistently shows or hides across all environment configurations (default, rolling, library, mixed, and multi-content-view cases).

* **New Features**
  * Added a consolidated environment indicator so the UI can determine toggle visibility more reliably.

* **Tests**
  * Expanded tests and fixtures to cover the new environment shapes and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->