### PR TITLE
Fixes #39284 - Fix an activation key's loading issue in hostgroup create/edit

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -47,7 +47,9 @@ KT.hosts.refreshContentViewEnvironments = function() {
   }
   var orgId = Array.isArray(orgIds) ? orgIds[0] : orgIds;
 
-  var previousInheritText = select.find('option:first-child').text();
+  var inheritOption = select.find('option:first-child');
+  var previousInheritText = inheritOption.text();
+  var previousInheritDataId = inheritOption.attr('data-id');
   var previousValue = select.val();
   select.find('option').remove();
 
@@ -63,7 +65,9 @@ KT.hosts.refreshContentViewEnvironments = function() {
 
     // Add inherit option back if it was there
     if (previousInheritText && (previousInheritText.includes('Inherit') || previousInheritText === '')) {
-      select.append($("<option />").text(previousInheritText).val(''));
+      var inheritOpt = $("<option />").text(previousInheritText).val('');
+      if (previousInheritDataId) inheritOpt.attr('data-id', previousInheritDataId);
+      select.append(inheritOpt);
     }
 
     $.each(data.results, function(index, cve) {

--- a/app/controllers/katello/concerns/api/api_controller.rb
+++ b/app/controllers/katello/concerns/api/api_controller.rb
@@ -65,8 +65,8 @@ module Katello
         controller_name
       end
 
-      def resource_name
-        controller_name.singularize
+      def resource_name(resource = controller_name)
+        resource.singularize
       end
 
       def respond(options = {})

--- a/app/helpers/katello/content_options_helper.rb
+++ b/app/helpers/katello/content_options_helper.rb
@@ -158,9 +158,9 @@ module Katello
       %(<option data-id="#{inherited_value}" value="">#{blank_or_inherit_f(f, attr)}</option>)
     end
 
-    def blank_or_inherit_cve(f) # f is Rails convention for form objects
+    def blank_or_inherit_cvenv(f) # f is Rails convention for form objects
       return true unless f.object.respond_to?(:parent_id) && f.object.parent_id
-      parent_cve = f.object.parent&.content_facet&.content_view_environment
+      parent_cve = f.object.parent&.content_view_environment
       inherited_value = parent_cve.try(:id) || ''
 
       if parent_cve
@@ -169,7 +169,7 @@ module Katello
                    else
                      "#{parent_cve.environment.name} / #{parent_cve.content_view.name}"
                    end
-        %(<option data-id="#{inherited_value}" value="">#{_('Inherit parent (%s)') % cve_name}</option>)
+        %(<option data-id="#{inherited_value}" value="">#{h(_('Inherit parent (%s)') % cve_name)}</option>)
       else
         %(<option value="">#{_('Inherit parent')}</option>)
       end

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -55,6 +55,12 @@ module Katello
         end
       end
 
+      def content_view_environment
+        return super if ancestry.nil? || self.content_view_environment_id.present?
+        cve_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
+        Katello::ContentViewEnvironment.find_by(:id => cve_id)
+      end
+
       def content_view
         return content_facet&.content_view if ancestry.nil? || self.content_view_id.present?
         Katello::ContentView.find_by(:id => inherited_content_view_id)

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -35,7 +35,7 @@
   <% cve_inherited = content_view_inherited?(@hostgroup) || lifecycle_environment_inherited?(@hostgroup) %>
 
   <%= field(f, cve_select_attr, {:label => _("Content View Environment"), :help_inline => cve_inherited ? 'Inherited from host group' : nil}) do %>
-    <%= select_tag cve_select_id, content_view_environment_options(@hostgroup, :include_blank => blank_or_inherit_cve(f)), :class => 'form-control', :name => cve_select_name %>
+    <%= select_tag cve_select_id, content_view_environment_options(@hostgroup, :include_blank => blank_or_inherit_cvenv(f)), :class => 'form-control', :name => cve_select_name %>
   <% end %>
 <% else %>
   <%# Hosts use separate Lifecycle Environment and Content View fields %>

--- a/webpack/components/ActivationKeysSearch/ActivationKeysSearch.test.js
+++ b/webpack/components/ActivationKeysSearch/ActivationKeysSearch.test.js
@@ -3,23 +3,20 @@ import { renderWithRedux } from 'react-testing-lib-wrapper';
 import ActivationKeysSearch from './index';
 
 describe('ActivationKeysSearch', () => {
-  const mockQuerySelector = jest.spyOn(document, 'querySelector');
-  mockQuerySelector.mockImplementation((selector) => {
-    if (selector === '#hostgroup_lifecycle_environment_id') {
-      return {
-        options: [{}],
-        selectedIndex: 0,
-        value: '1',
-      };
-    }
-    if (selector === '#hostgroup_content_view_id') {
-      return {
-        options: [{}],
-        selectedIndex: 0,
-        value: '2 ',
-      };
-    }
-    return null;
+  let orgSelect;
+
+  beforeEach(() => {
+    orgSelect = document.createElement('select');
+    orgSelect.id = 'hostgroup_organization_ids';
+    const option = document.createElement('option');
+    option.value = '1';
+    option.selected = true;
+    orgSelect.appendChild(option);
+    document.body.appendChild(orgSelect);
+  });
+
+  afterEach(() => {
+    orgSelect.remove();
   });
   it('renders without crashing', () => {
     const { getByText } = renderWithRedux(<ActivationKeysSearch />, {});

--- a/webpack/components/ActivationKeysSearch/index.js
+++ b/webpack/components/ActivationKeysSearch/index.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import {
   Form,
   FormGroup,
@@ -14,57 +14,72 @@ import {
   SelectVariant,
 } from '@patternfly/react-core/deprecated';
 import { FormattedMessage } from 'react-intl';
-import $ from 'jquery';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { get } from 'foremanReact/redux/API';
 import { foremanUrl } from 'foremanReact/common/helpers';
-import { STATUS } from 'foremanReact/constants';
-import { selectAPIStatus } from 'foremanReact/redux/API/APISelectors';
 
-const getSelectedEnvId = () => {
-  const selectElement = document.querySelector('#hostgroup_lifecycle_environment_id');
-  const selectedOption = selectElement.options[selectElement.selectedIndex];
-  let dataId = selectedOption?.getAttribute?.('data-id');
-  if (!dataId) {
-    dataId = selectElement.value;
+const getOrganizationIds = () => {
+  const orgIdsElem = document.querySelector('#hostgroup_organization_ids');
+  if (!orgIdsElem) return [];
+  const ids = new Set();
+  Array.from(orgIdsElem.selectedOptions || []).forEach((opt) => {
+    if (opt.value) ids.add(opt.value);
+  });
+  const useds = orgIdsElem.getAttribute('data-useds');
+  if (useds) {
+    try {
+      const parsed = JSON.parse(useds);
+      if (Array.isArray(parsed)) parsed.forEach(id => ids.add(String(id)));
+    } catch (e) {
+      useds.toString().split(',').filter(Boolean).forEach(id => ids.add(id));
+    }
   }
-  return dataId;
+  return Array.from(ids);
 };
-const getSelectedContentViewId = () => {
-  const selectElement = document.querySelector('#hostgroup_content_view_id');
-  const selectedOption = selectElement.options[selectElement.selectedIndex];
-  let dataId = selectedOption?.getAttribute?.('data-id');
-  if (!dataId) {
-    dataId = selectElement.value;
-  }
-  return dataId;
-};
+
+const ACTIVATION_KEYS = 'ACTIVATION_KEYS';
+
 const ActivationKeysSearch = () => {
-  const ACTIVATION_KEYS = 'ACTIVATION_KEYS';
   const KT_AK_LABEL = 'kt_activation_keys';
-  const [selectedEnvId, setSelectedEnvId] = useState(getSelectedEnvId());
-  const [selectedContentViewId, setSelectedContentViewId] = useState(getSelectedContentViewId());
-  const isLoading =
-    useSelector(state => selectAPIStatus(state, ACTIVATION_KEYS)) === STATUS.PENDING;
+  const [organizationIds, setOrganizationIds] = useState(getOrganizationIds());
+  const [isLoading, setIsLoading] = useState(false);
   const [activationKeys, setActivationKeys] = useState([]);
   const [selectedKeys, setSelectedKeys] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const dispatch = useDispatch();
 
   const ktLoadActivationKeys = useCallback(() => {
-    if (selectedEnvId && selectedContentViewId) {
+    if (organizationIds.length === 0) return;
+    setIsLoading(true);
+    setActivationKeys([]);
+    let completed = 0;
+    organizationIds.forEach((orgId) => {
       dispatch(get({
-        key: ACTIVATION_KEYS,
-        url: foremanUrl(`/katello/api/v2/environments/${selectedEnvId}/activation_keys`),
-        params: { content_view_id: selectedContentViewId },
+        key: `${ACTIVATION_KEYS}_${orgId}`,
+        url: foremanUrl('/katello/api/v2/activation_keys'),
+        params: {
+          organization_id: orgId,
+          full_result: true,
+        },
         handleSuccess: ({ data }) => {
-          setActivationKeys(data.results);
+          setActivationKeys((prev) => {
+            const existingIds = new Set(prev.map(ak => ak.id));
+            const newKeys = data.results.filter(ak => !existingIds.has(ak.id));
+            return [...prev, ...newKeys];
+          });
+          completed += 1;
+          if (completed >= organizationIds.length) setIsLoading(false);
+        },
+        handleError: () => {
+          completed += 1;
+          if (completed >= organizationIds.length) setIsLoading(false);
         },
         errorToast: () =>
           __('There was a problem retrieving Activation Key data from the server.'),
       }));
-    }
-  }, [dispatch, selectedEnvId, selectedContentViewId, setActivationKeys]);
+    });
+  }, [dispatch, organizationIds]);
+
   const getParamContainer = useCallback(() => {
     let ret;
     const inputs = document.querySelectorAll("div#parameters .fields input[type='text']");
@@ -76,14 +91,25 @@ const ActivationKeysSearch = () => {
     return ret;
   }, [KT_AK_LABEL]);
 
+  // Update organization IDs when they change
   useEffect(() => {
-    $('#hostgroup_lifecycle_environment_id').on('change', () => setSelectedEnvId(getSelectedEnvId)); // cant use eventlistener on select2
-    $('#hostgroup_content_view_id').on('change', () =>
-      setSelectedContentViewId(getSelectedContentViewId())); // cant use eventlistener on select2
-    if (selectedEnvId && selectedContentViewId) {
-      ktLoadActivationKeys();
-    }
+    const orgElem = document.querySelector('#hostgroup_organization_ids');
+    if (!orgElem) return undefined;
 
+    const handleChange = () => setOrganizationIds(getOrganizationIds());
+
+    const observer = new MutationObserver(handleChange);
+    observer.observe(orgElem, { childList: true, attributes: true, subtree: true });
+    orgElem.addEventListener('change', handleChange);
+
+    return () => {
+      observer.disconnect();
+      orgElem.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  // Initialize from hidden parameter on mount
+  useEffect(() => {
     const ktHideParams = () => {
       const container = getParamContainer();
       if (container) {
@@ -104,15 +130,21 @@ const ActivationKeysSearch = () => {
     };
     ktHideParams();
     setSelectedKeys(ktAkGetKeysFromParam());
-  }, [getParamContainer, ktLoadActivationKeys, selectedContentViewId, selectedEnvId]);
+  }, [getParamContainer]);
+
+  // Load activation keys when organizations change
+  useEffect(() => {
+    if (organizationIds.length > 0) {
+      ktLoadActivationKeys();
+    }
+  }, [ktLoadActivationKeys, organizationIds]);
 
   useEffect(() => {
     function ktSetParam() {
       let paramContainerCopy = getParamContainer();
       if (selectedKeys.length > 0) {
-        const value = selectedKeys.map(key => key.trim()).join(',');
+        const value = selectedKeys.map(key => key.split(' — ')[0].trim()).join(',');
         if (!paramContainerCopy) {
-          // we create the param for kt_activation_keys
           const addParameterButton = document.querySelector('#parameters .btn-primary');
           addParameterButton.click();
           const directionOfAddedItems = addParameterButton.getAttribute('direction');
@@ -128,7 +160,6 @@ const ActivationKeysSearch = () => {
         const destroyInput = paramContainerCopy.querySelector("input[name*='[_destroy]']");
         if (destroyInput) destroyInput.value = 0;
       } else if (paramContainerCopy) {
-        // we remove the param by setting destroy to 1
         const destroyInput = paramContainerCopy.querySelector("input[name*='[_destroy]']");
         if (destroyInput) destroyInput.value = 1;
       }
@@ -136,15 +167,22 @@ const ActivationKeysSearch = () => {
     ktSetParam();
   }, [getParamContainer, selectedKeys]);
 
-  if (!(selectedEnvId && selectedContentViewId)) {
+  if (organizationIds.length === 0) {
     return (
       <EmptyState>
-        <EmptyStateHeader titleText={<>{__('Please select a lifecycle environment and content view to view activation keys.')}</>} headingLevel="h4" />
+        <EmptyStateHeader
+          titleText={
+            <>{__('Please select an organization to view activation keys.')}</>
+          }
+          headingLevel="h4"
+        />
       </EmptyState>
     );
   }
 
-  const onSelect = (event, selection) => {
+  const multiOrg = organizationIds.length > 1;
+
+  const onSelect = (_event, selection) => {
     setIsOpen(false);
     if (selectedKeys.includes(selection)) {
       setSelectedKeys(prevState => prevState.filter(item => item !== selection));
@@ -152,6 +190,7 @@ const ActivationKeysSearch = () => {
       setSelectedKeys(prevState => [...prevState, selection]);
     }
   };
+
   const isEmptyResults = activationKeys.length === 0;
   return (
     <div>
@@ -169,13 +208,16 @@ const ActivationKeysSearch = () => {
             isDisabled={isLoading || isEmptyResults}
             placeholderText={
               isEmptyResults
-                ? __('The selected lifecycle environment contains no activation keys')
+                ? __('No activation keys available')
                 : null
             }
           >
-            {activationKeys.map(({ id, name }) => (
-              <SelectOption key={id} value={name} />
-            ))}
+            {activationKeys.map(({ id, name, organization }) => {
+              const label = multiOrg ? `${name} — ${organization?.name}` : name;
+              return (
+                <SelectOption key={id} value={label} />
+              );
+            })}
           </Select>
         </FormGroup>
         <Alert title={__('Activation Key information')} variant="info" ouiaId="ak-info">


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The `ActivationKeysSearch` component on the hostgroup create/edit page was broken because it was trying to read from separate lifecycle environment and content view dropdowns (`#hostgroup_lifecycle_environment_id` and `#hostgroup_content_view_id`) that don't exist on the hostgroup form. Hostgroups use a combined content view environment (CVEnv) dropdown instead.


#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Navigate to hostgroup create/edit page
2. Select a content view environment from the dropdown
3. Verify activation keys load correctly in the search component
4. Verify selected activation keys are saved properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata loss when refreshing content view environment options.

* **New Features**
  * Activation key search now filters by organization for more accurate results.
  * Enhanced content view environment inheritance support for hostgroups with parent inheritance.

* **Refactor**
  * Updated helper methods for improved content view environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->