### PR TITLE
Fixes #39289 - Fix n-1/2 publication-less capsule python syncs

### DIFF
--- a/app/services/katello/pulp3/repository/generic.rb
+++ b/app/services/katello/pulp3/repository/generic.rb
@@ -31,7 +31,8 @@ module Katello
         end
 
         def partial_repo_path
-          "/pulp/content/#{repo.relative_path}/".sub('//', '/')
+          prefix = repo.repository_type.generic_content_path_prefix || '/pulp/content'
+          "#{prefix}/#{repo.relative_path}/".sub('//', '/')
         end
       end
     end

--- a/app/services/katello/pulp3/repository_mirror.rb
+++ b/app/services/katello/pulp3/repository_mirror.rb
@@ -222,14 +222,14 @@ module Katello
       end
 
       def adjust_distribution_options_for_pulp_version(distro, dist_options)
+        # REMOVE when N-2 capsules use Pulp >= 3.105 (enables publication-free distribution for old capsules)
         if distro.respond_to?(:repository_version)
           # New Pulp supports repository_version - use it and clear publication
           dist_options[:publication] = nil if distro.publication.present?
         else
           # Old Pulp doesn't support repository_version - fall back to publication
           dist_options.delete(:repository_version)
-          dist_options[:publication] = publication_href
-          fail "Could not lookup a publication_href for repo #{repo_service.repo.id}" if publication_href.nil?
+          dist_options[:publication] = publication_href_or_create
         end
       end
 
@@ -241,13 +241,13 @@ module Katello
       end
 
       def retry_distribution_update_with_publication(error, distro, dist_options)
+        # REMOVE when N-2 capsules use Pulp >= 3.105
         # If repository_version is not supported (old Pulp), retry with publication
         if repo_service.repo.repository_type.pulp3_transitioning_from_publication &&
            error.code == 400 &&
            (error.message.include?("repository_version") || error.message.include?("publication"))
           dist_options.delete(:repository_version)
-          dist_options[:publication] = publication_href
-          fail "Could not lookup a publication_href for repo #{repo_service.repo.id}" if publication_href.nil?
+          dist_options[:publication] = publication_href_or_create
           response = api.distributions_api.partial_update(distro.pulp_href, dist_options)
           # Pulp 3.90+ returns polymorphic responses (PULP-734): task when changes occur, nil when no-op
           (response.respond_to?(:task) && response.task.present?) ? [response] : []
@@ -257,18 +257,44 @@ module Katello
       end
 
       def retry_distribution_create_with_publication(error, dist_options)
+        # REMOVE when N-2 capsules use Pulp >= 3.105
         # If repository_version is not supported (old Pulp), retry with publication
         if repo_service.repo.repository_type.pulp3_transitioning_from_publication &&
            error.code == 400 &&
            (error.message.include?("repository_version") || error.message.include?("publication"))
           dist_options.delete(:repository_version)
-          dist_options[:publication] = publication_href
-          fail "Could not lookup a publication_href for repo #{repo_service.repo.id}" if publication_href.nil?
+          dist_options[:publication] = publication_href_or_create
           distribution_data = api.distribution_class.new(dist_options)
           [api.distributions_api.create(distribution_data)]
         else
           fail error
         end
+      end
+
+      def publication_href_or_create
+        # Get existing publication href, or create one on-demand if needed (for N-1 capsule compatibility)
+        pub_href = publication_href
+        if pub_href.nil?
+          Rails.logger.info("No publication found for capsule #{smart_proxy.name}, creating one for repo #{repo_service.repo.id}")
+          task_response = create_publication
+          fail "Failed to create publication task for repo #{repo_service.repo.id}" if task_response.nil?
+
+          task = Katello::Pulp3::Task.new(smart_proxy, { 'task' => task_response.task })
+
+          # Poll with timeout to prevent indefinite blocking
+          timeout = Setting[:sync_total_timeout] || 3600
+          start_time = Time.now
+          until task.done?
+            elapsed = Time.now - start_time
+            fail "Publication creation timed out after #{elapsed.to_i} seconds for repo #{repo_service.repo.id}" if elapsed > timeout
+            sleep 1
+            task.poll
+          end
+
+          pub_href = Katello::Pulp3::Task.publication_href([task.task_data])
+          fail "Failed to create publication for repo #{repo_service.repo.id}" if pub_href.nil?
+        end
+        pub_href
       end
 
       def count_by_pulpcore_type(service_class)

--- a/app/services/katello/repository_type.rb
+++ b/app/services/katello/repository_type.rb
@@ -17,7 +17,7 @@ module Katello
               :repositories_api_class, :api_class, :remotes_api_class, :repository_versions_api_class,
               :distributions_api_class, :remote_class, :repo_sync_url_class, :client_module_class,
               :distribution_class, :publication_class, :publications_api_class, :url_description,
-              :test_url, :test_url_root_options, :repo_discovery_class
+              :test_url, :test_url_root_options, :repo_discovery_class, :generic_content_path_prefix
 
     attr_accessor :metadata_publish_matching_check, :index_additional_data_proc
     attr_reader :id, :unique_content_per_repo

--- a/lib/katello/repository_types/python.rb
+++ b/lib/katello/repository_types/python.rb
@@ -7,6 +7,7 @@ Katello::RepositoryTypeManager.register('python') do
   pulp3_plugin 'python'
   pulp3_skip_publication true
   pulp3_transitioning_from_publication true
+  generic_content_path_prefix '/pypi'
 
   client_module_class PulpPythonClient
   api_class PulpPythonClient::ApiClient

--- a/lib/katello/tasks/upgrades/4.21/cleanup_python_publications.rake
+++ b/lib/katello/tasks/upgrades/4.21/cleanup_python_publications.rake
@@ -18,6 +18,7 @@ namespace :katello do
         end
 
         migrate_distributions(python_repos, smart_proxy)
+        repair_python_metadata(python_repos, smart_proxy)
         delete_python_publications(smart_proxy)
         clear_publication_hrefs(python_repos)
       end
@@ -72,6 +73,46 @@ namespace :katello do
         if migration_failed
           puts "ERROR: One or more distribution migrations failed."
           exit 1
+        end
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # rubocop:disable Metrics/MethodLength
+      def self.repair_python_metadata(python_repos, smart_proxy)
+        puts "Repairing Python package metadata..."
+        tasks = []
+        python_repos.select { |repo| repo.environment.present? }.each do |repo|
+          begin
+            service = Katello::Pulp3::Repository.instance_for_type(repo, smart_proxy)
+            repository_href = service.repository_reference.repository_href
+            api = service.api
+            response = api.repositories_api.repair_metadata(repository_href)
+            tasks << { task: Katello::Pulp3::Task.new(smart_proxy, { 'task' => response.task }), repo: repo }
+            puts "Queued metadata repair for: #{repo.name}"
+          rescue StandardError => e
+            puts "WARNING: Could not queue metadata repair for #{repo.name}: #{e.message}"
+          end
+        end
+
+        # Wait for repair tasks and log results
+        tasks.each do |task_info|
+          max_wait = 300
+          elapsed = 0
+          until task_info[:task].done?
+            if elapsed >= max_wait
+              puts "WARNING: Metadata repair timed out for #{task_info[:repo].name} after #{max_wait} seconds (Pulp will continue processing in background)"
+              break
+            end
+            sleep 5
+            elapsed += 5
+            task_info[:task].poll
+          end
+
+          if task_info[:task].error
+            puts "WARNING: Metadata repair failed for #{task_info[:repo].name}: #{task_info[:task].error}"
+          elsif task_info[:task].done?
+            puts "Metadata repair completed for #{task_info[:repo].name}"
+          end
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/test/lib/tasks/upgrades/4.21/cleanup_python_publications_test.rb
+++ b/test/lib/tasks/upgrades/4.21/cleanup_python_publications_test.rb
@@ -94,11 +94,25 @@ module Katello
       task_response = OpenStruct.new(task: '/pulp/api/v3/tasks/12345/')
       service_mock = mock('repository_service')
       service_mock.expects(:update_distribution).returns([task_response])
+
+      # Mock repository_reference for repair_python_metadata
+      repository_reference_mock = mock('repository_reference')
+      repository_reference_mock.stubs(:repository_href).returns('/pulp/api/v3/repositories/python/pypi/repo123/')
+      service_mock.stubs(:repository_reference).returns(repository_reference_mock)
+
+      # Mock api for repair_python_metadata
+      repositories_api_mock = mock('repositories_api')
+      repair_task_response = OpenStruct.new(task: '/pulp/api/v3/tasks/repair123/')
+      repositories_api_mock.stubs(:repair_metadata).returns(repair_task_response)
+      api_mock = mock('api')
+      api_mock.stubs(:repositories_api).returns(repositories_api_mock)
+      service_mock.stubs(:api).returns(api_mock)
+
       Katello::Pulp3::Repository.stubs(:instance_for_type).returns(service_mock)
       task_mock = mock('task')
       task_mock.stubs(:done?).returns(true)
       task_mock.stubs(:error).returns(nil)
-      Katello::Pulp3::Task.expects(:new).returns(task_mock)
+      Katello::Pulp3::Task.stubs(:new).returns(task_mock)
 
       Katello::Pulp3::Api::Core.any_instance.stubs(:publications_list_all).returns([])
 
@@ -116,12 +130,26 @@ module Katello
       task_response = OpenStruct.new(task: '/pulp/api/v3/tasks/12345/')
       service_mock = mock('repository_service')
       service_mock.stubs(:update_distribution).returns([task_response])
+
+      # Mock repository_reference for repair_python_metadata
+      repository_reference_mock = mock('repository_reference')
+      repository_reference_mock.stubs(:repository_href).returns('/pulp/api/v3/repositories/python/pypi/repo123/')
+      service_mock.stubs(:repository_reference).returns(repository_reference_mock)
+
+      # Mock api for repair_python_metadata
+      repositories_api_mock = mock('repositories_api')
+      repair_task_response = OpenStruct.new(task: '/pulp/api/v3/tasks/repair123/')
+      repositories_api_mock.stubs(:repair_metadata).returns(repair_task_response)
+      api_mock = mock('api')
+      api_mock.stubs(:repositories_api).returns(repositories_api_mock)
+      service_mock.stubs(:api).returns(api_mock)
+
       Katello::Pulp3::Repository.stubs(:instance_for_type).returns(service_mock)
       task_mock = mock('task')
       task_mock.stubs(:done?).returns(false).then.returns(true)
       task_mock.stubs(:poll).returns(task_mock)
       task_mock.stubs(:error).returns(nil)
-      Katello::Pulp3::Task.expects(:new).returns(task_mock)
+      Katello::Pulp3::Task.stubs(:new).returns(task_mock)
 
       Katello::Pulp3::Api::Core.any_instance.stubs(:publications_list_all).returns([])
 
@@ -178,6 +206,20 @@ module Katello
 
       service_mock = mock('repository_service')
       service_mock.expects(:update_distribution).times(3).returns([task1_response], [task2_response], [task3_response])
+
+      # Mock repository_reference for repair_python_metadata
+      repository_reference_mock = mock('repository_reference')
+      repository_reference_mock.stubs(:repository_href).returns('/pulp/api/v3/repositories/python/pypi/repo123/')
+      service_mock.stubs(:repository_reference).returns(repository_reference_mock)
+
+      # Mock api for repair_python_metadata
+      repositories_api_mock = mock('repositories_api')
+      repair_task_response = OpenStruct.new(task: '/pulp/api/v3/tasks/repair123/')
+      repositories_api_mock.stubs(:repair_metadata).returns(repair_task_response)
+      api_mock = mock('api')
+      api_mock.stubs(:repositories_api).returns(repositories_api_mock)
+      service_mock.stubs(:api).returns(api_mock)
+
       Katello::Pulp3::Repository.stubs(:instance_for_type).returns(service_mock)
 
       task_mock1 = mock('task1')
@@ -189,7 +231,8 @@ module Katello
       task_mock3 = mock('task3')
       task_mock3.stubs(:done?).returns(true)
       task_mock3.stubs(:error).returns(nil)
-      Katello::Pulp3::Task.expects(:new).times(3).returns(task_mock1, task_mock2, task_mock3)
+      # Task.new called 3 times for distribution tasks + 3 times for repair tasks = 6 total
+      Katello::Pulp3::Task.expects(:new).times(6).returns(task_mock1, task_mock2, task_mock3, task_mock1, task_mock2, task_mock3)
 
       pub1 = OpenStruct.new(pulp_href: '/pulp/api/v3/publications/python/pypi/pub1/')
       pub2 = OpenStruct.new(pulp_href: '/pulp/api/v3/publications/python/pypi/pub2/')


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Update remote path for python repos to pypi since that's where publication-less python repos are distributed at /pypi endpoint
#### Considerations taken when implementing this change?
We assume the apcahe config is present on katello. The PR for it is still out so make this change locally.
Ensure /etc/httpd/conf.d/05-foreman-ssl.conf has:                                                                           
                                                                                                                                                  
  ```
<Location "/pypi">                                                                                                                              
    RequestHeader unset X-CLIENT-CERT                                                                                                             
    RequestHeader set X-CLIENT-CERT "%{SSL_CLIENT_CERT}s" env=SSL_CLIENT_CERT                                                                     
    RequestHeader set X-FORWARDED-PROTO expr=%{REQUEST_SCHEME}                                                                                    
    ProxyPass unix:///run/pulpcore-api.sock|http://pulpcore-api/pypi timeout=600                                                                  
    ProxyPassReverse unix:///run/pulpcore-api.sock|http://pulpcore-api/pypi                                                                       
  </Location>
```
#### What are the testing steps for this pull request?
1. Sync some python repos on primary pulp
2. Sync a n-1 capsule.
3. Sync should succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable content-path prefix per repository type (defaults preserved).
  * On-demand publication provisioning during repository transitions to reduce failures.

* **Bug Fixes**
  * Improved Python/PyPI repository path handling for correct content routing.
  * Python metadata repair added to upgrade flow to ensure publications and distributions migrate cleanly.

* **Tests**
  * Expanded tests and stubs to cover repair and multi-repo publication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->