### PR TITLE
Fixes #39292 - Add cache HIT/MISS logging for Candlepin proxy caches

### DIFF
--- a/app/lib/katello/resources/candlepin/candlepin_ping.rb
+++ b/app/lib/katello/resources/candlepin/candlepin_ping.rb
@@ -8,10 +8,15 @@ module Katello
 
         class << self
           def ping(try_cache: false)
-            Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL, race_condition_ttl: RACE_TTL, force: !try_cache) do
+            cache_miss = false
+            result = Rails.cache.fetch(CACHE_KEY, expires_in: CACHE_TTL, race_condition_ttl: RACE_TTL, force: !try_cache) do
+              cache_miss = true
+              ::Foreman::Logging.logger('registration').debug "rhsm_status cache=MISS"
               response = get('/candlepin/status').body
               JSON.parse(response).with_indifferent_access
             end
+            ::Foreman::Logging.logger('registration').debug "rhsm_status cache=HIT" unless cache_miss || !try_cache
+            result
           end
 
           def ok?


### PR DESCRIPTION
## Summary

Emit debug-level log lines via the `:registration` named logger for each cached Candlepin endpoint, enabling operators to verify cache effectiveness in production.

### Log output (at debug level)

```
[registration] compliance cache=MISS uuid=abc123
[registration] compliance cache=HIT uuid=abc123
[registration] rhsm_status cache=MISS
[registration] rhsm_status cache=HIT
```

At the default info level, no additional log lines appear.

## Dependencies

This is a **draft PR** that requires these PRs to merge first:

- **Foreman** [#10946](https://github.com/theforeman/foreman/pull/10946) — `:registration` named logger (Redmine #39290)
- **Katello** [#11696](https://github.com/Katello/katello/pull/11696) — Cache Candlepin status (Redmine #39204)

Will rebase onto master once dependencies are merged.

## How to test

1. Enable debug logging in settings.yaml: `:logging: :loggers: :registration: :level: debug`
2. Register a host
3. Check production.log for `cache=HIT` and `cache=MISS` lines
