### PR TITLE
Fix duplicate interval registration on Subscriptions page

### DIFF
--- a/webpack/scenes/Subscriptions/SubscriptionActions.js
+++ b/webpack/scenes/Subscriptions/SubscriptionActions.js
@@ -88,11 +88,16 @@ export const cancelPollTasks = () => (dispatch, getState) => {
   }
 };
 
-export const pollTasks = () => dispatch => dispatch(startPollingTasks(SUBSCRIPTIONS, {
-  organization_id: orgId(),
-  result: 'pending',
-  label: BLOCKING_FOREMAN_TASK_TYPES.join(' or '),
-}));
+export const pollTasks = () => (dispatch, getState) => {
+  if (selectIsPollingTasks(getState(), SUBSCRIPTIONS)) {
+    dispatch(stopPollingTasks(SUBSCRIPTIONS));
+  }
+  return dispatch(startPollingTasks(SUBSCRIPTIONS, {
+    organization_id: orgId(),
+    result: 'pending',
+    label: BLOCKING_FOREMAN_TASK_TYPES.join(' or '),
+  }));
+};
 
 export const resetTasks = () => (dispatch) => {
   dispatch({


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The SubscriptionsPage component has two useEffect hooks that both call pollTasks() on initial mount when an organization is present, causing IntervalMiddleware to throw "There is already an interval running and registered for: SUBSCRIPTIONS_TASK_SEARCH."

Make pollTasks() idempotent by stopping any existing polling interval before registering a new one, matching the pattern already used by cancelPollTasks().

Addresses this browser error, that has also been seen failing intermittently on `foremanctl` UI tests:

```
IntervalHelpers.js:4 Uncaught (in promise) Error: There is already an interval running and registered for: SUBSCRIPTIONS_TASK_SEARCH.
    at t.registeredIntervalException (IntervalHelpers.js:4:3)
    at IntervalMiddleware.js:17:13
    at SubscriptionActions.js:91:44
    at SubscriptionsPage.js:65:5
    at SubscriptionsPage.js:21:35
    at Generator.<anonymous> (SubscriptionsPage.js:2:1)
```

#### Considerations taken when implementing this change?

N/A

#### What are the testing steps for this pull request?

- Open developer console in browser
- Navigate to subscription page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription polling reliability: polling now checks for and stops any active poll before starting a new one, preventing concurrent operations.
  * Polling includes better context handling for task results and labels, reducing sync conflicts and making subscription status updates more stable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->