### PR TITLE
Fixes #XXXXX - Return static compliance response under SCA

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -16,7 +16,7 @@ module Katello
     before_action :authorize, :only => [:consumer_create, :list_owners, :rhsm_index]
     before_action :authorize_client_or_user, :only => [:consumer_show, :regenerate_identity_certificates, :upload_tracer_profile, :facts, :proxy_jobs_get_path]
     before_action :authorize_client_or_admin, :only => [:hypervisors_update, :async_hypervisors_update, :hypervisors_heartbeat]
-    before_action :authorize_proxy_routes, :only => [:get, :post, :put, :delete]
+    before_action :authorize_proxy_routes, :only => [:get, :post, :put, :delete, :consumer_compliance, :consumer_purpose_compliance]
     before_action :authorize_client, :only => [:consumer_destroy, :consumer_checkin,
                                                :enabled_repos, :available_releases]
 
@@ -70,6 +70,44 @@ module Katello
     def drop_api_namespace(original_request_path)
       prefix = "/rhsm"
       original_request_path.gsub(prefix, '')
+    end
+
+    SCA_COMPLIANCE_RESPONSE = {
+      'compliant' => true,
+      'compliantProducts' => {},
+      'compliantUntil' => nil,
+      'date' => nil,
+      'nonCompliantProducts' => [],
+      'partialStacks' => {},
+      'partiallyCompliantProducts' => {},
+      'productComplianceDateRanges' => {},
+      'reasons' => [],
+      'status' => 'disabled',
+    }.freeze
+
+    SCA_PURPOSE_COMPLIANCE_RESPONSE = {
+      'compliant' => true,
+      'compliantAddOns' => {},
+      'compliantRole' => {},
+      'compliantSLA' => {},
+      'compliantServiceType' => {},
+      'compliantUsage' => {},
+      'date' => nil,
+      'nonCompliantAddOns' => [],
+      'nonCompliantRole' => nil,
+      'nonCompliantSLA' => nil,
+      'nonCompliantServiceType' => nil,
+      'nonCompliantUsage' => nil,
+      'reasons' => [],
+      'status' => 'disabled',
+    }.freeze
+
+    def consumer_compliance
+      render :json => SCA_COMPLIANCE_RESPONSE.merge('date' => Time.now.utc.iso8601)
+    end
+
+    def consumer_purpose_compliance
+      render :json => SCA_PURPOSE_COMPLIANCE_RESPONSE.merge('date' => Time.now.utc.iso8601)
     end
 
     def get

--- a/config/routes/api/rhsm.rb
+++ b/config/routes/api/rhsm.rb
@@ -28,8 +28,8 @@ Katello::Engine.routes.draw do
       match '/consumers/:id/certificates' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_certificates_path
       match '/consumers/:id/certificates' => 'candlepin_proxies#put', :via => :put, :as => :proxy_consumer_certificates_put_path
       match '/consumers/:id/release' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_releases_path
-      match '/consumers/:id/compliance' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_compliance_path
-      match '/consumers/:id/purpose_compliance' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_purpose_compliance_path
+      match '/consumers/:id/compliance' => 'candlepin_proxies#consumer_compliance', :via => :get, :as => :proxy_consumer_compliance_path
+      match '/consumers/:id/purpose_compliance' => 'candlepin_proxies#consumer_purpose_compliance', :via => :get, :as => :proxy_consumer_purpose_compliance_path
       match '/consumers/:id/certificates/serials' => 'candlepin_proxies#serials', :via => :get, :as => :proxy_certificate_serials_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#get', :via => :get, :as => :proxy_consumer_entitlements_path
       match '/consumers/:id/entitlements' => 'candlepin_proxies#post', :via => :post, :as => :proxy_consumer_entitlements_post_path

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -520,7 +520,7 @@ module Katello
         assert_response :success
         body = JSON.parse(response.body)
         assert_equal 'disabled', body['status']
-        assert_equal true, body['compliant']
+        assert body['compliant']
         assert_empty body['reasons']
         assert body.key?('date')
       end
@@ -539,7 +539,7 @@ module Katello
         assert_response :success
         body = JSON.parse(response.body)
         assert_equal 'disabled', body['status']
-        assert_equal true, body['compliant']
+        assert body['compliant']
         assert_empty body['reasons']
         assert body.key?('compliantRole')
       end

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -507,6 +507,44 @@ module Katello
       end
     end
 
+    describe "consumer_compliance" do
+      before do
+        uuid = @host.subscription_facet.uuid
+        User.stubs(:consumer?).returns(true)
+        stub_cp_consumer_with_uuid(uuid)
+      end
+
+      it "returns static SCA compliance without calling Candlepin" do
+        Resources::Candlepin::Proxy.expects(:get).never
+        get :consumer_compliance, params: { :id => @host.subscription_facet.uuid }
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 'disabled', body['status']
+        assert_equal true, body['compliant']
+        assert_empty body['reasons']
+        assert body.key?('date')
+      end
+    end
+
+    describe "consumer_purpose_compliance" do
+      before do
+        uuid = @host.subscription_facet.uuid
+        User.stubs(:consumer?).returns(true)
+        stub_cp_consumer_with_uuid(uuid)
+      end
+
+      it "returns static SCA purpose compliance without calling Candlepin" do
+        Resources::Candlepin::Proxy.expects(:get).never
+        get :consumer_purpose_compliance, params: { :id => @host.subscription_facet.uuid }
+        assert_response :success
+        body = JSON.parse(response.body)
+        assert_equal 'disabled', body['status']
+        assert_equal true, body['compliant']
+        assert_empty body['reasons']
+        assert body.key?('compliantRole')
+      end
+    end
+
     describe "get parent host" do
       it "can get parent host" do
         capsule = "foocapsule.example.com"

--- a/test/lib/access_permissions_test.rb
+++ b/test/lib/access_permissions_test.rb
@@ -28,6 +28,8 @@ module Katello
       'katello/api/rhsm/candlepin_proxies/get',
       'katello/api/rhsm/candlepin_proxies/delete',
       'katello/api/rhsm/candlepin_proxies/serials',
+      'katello/api/rhsm/candlepin_proxies/consumer_compliance',
+      'katello/api/rhsm/candlepin_proxies/consumer_purpose_compliance',
     ].freeze
 
     KATELLO_NON_AUTH = [

--- a/test/routing/candlepin_proxies_test.rb
+++ b/test/routing/candlepin_proxies_test.rb
@@ -12,7 +12,7 @@ module Katello
     end
 
     def test_consumer_purpose_compliance
-      {controller: @proxies_controller, action: 'get', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
+      {controller: @proxies_controller, action: 'consumer_purpose_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
     end
   end
 end

--- a/test/routing/candlepin_proxies_test.rb
+++ b/test/routing/candlepin_proxies_test.rb
@@ -11,6 +11,10 @@ module Katello
       {controller: @proxies_controller, action: 'list_owners', login: '1'}.must_recognize(method: :get, path: '/rhsm/users/1/owners')
     end
 
+    def test_consumer_compliance
+      {controller: @proxies_controller, action: 'consumer_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/compliance')
+    end
+
     def test_consumer_purpose_compliance
       {controller: @proxies_controller, action: 'consumer_purpose_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
     end


### PR DESCRIPTION
## Problem

During registration, subscription-manager on RHEL 8 and RHEL 9 polls `GET /rhsm/consumers/:id/compliance` 12 times per host. Each call is proxied through Katello to Candlepin. At 1064 concurrent registrations, this generates ~6,700 Candlepin requests — 19.8% of all Candlepin traffic — competing for 150 Tomcat threads.

RHEL 10's subscription-manager no longer polls this endpoint, but the vast majority of the current installed base is RHEL 8/9.

## Solution

Since all Katello organizations use Simple Content Access (`contentAccessMode: org_environment`), compliance is always `"status": "disabled"`. Return a static response directly from Katello instead of proxying to Candlepin. Same treatment for `purpose_compliance`.

No Candlepin call, no cache, no Redis. The response matches exactly what Candlepin returns under SCA.

## Measured impact at 1064 concurrent (real data)

| Metric | Baseline | Cache (#11692) | Static (this PR) |
|---|---:|---:|---:|
| Compliance calls to Candlepin | 6,692 | 958 | **0** |
| Compliance as % of total CP requests | **19.8%** | 4.1% | **0.0%** |
| Tomcat thread pressure (CP req/thread) | 225 | 157 (−30%) | **152 (−32%)** |
| Puma threads blocked on CP for compliance | **6,692** | 958 | **0** |

## Client behavior by OS

| Client OS | Compliance calls per registration |
|---|---:|
| RHEL 8.10 | 12 |
| RHEL 9.7 | 12 |
| RHEL 10.1 | **0** |

## Changes

- Route `/consumers/:id/compliance` to dedicated `consumer_compliance` action returning static SCA response
- Route `/consumers/:id/purpose_compliance` to dedicated `consumer_purpose_compliance` action returning static SCA response
- Authorization unchanged (`authorize_proxy_routes` still validates consumer identity)

## How to test

1. `bundle exec rake test TEST=test/controllers/api/rhsm/candlepin_proxies_controller_test.rb`
2. Register a host, verify sub-man shows "Content Access Mode is set to Simple Content Access"
3. Verify zero `/candlepin/consumers/*/compliance` calls in `candlepin.log`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consumer compliance endpoint returning compliance status and an ISO8601 UTC timestamp.
  * Added consumer purpose compliance endpoint returning compliance role info and an ISO8601 UTC timestamp.
* **Tests**
  * Added tests confirming successful responses and expected keys (timestamp, compliance flag, role info) for both endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->