### PR TITLE
Fixes #39303 - Use redhat-uep.pem as CA fallback for custom CDN syncs

### DIFF
--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -40,6 +40,9 @@ module Katello
           elsif options[:ssl_ca_file]
             @cert_store = OpenSSL::X509::Store.new
             @cert_store.add_file(options[:ssl_ca_file])
+          else
+            @cert_store = OpenSSL::X509::Store.new
+            @cert_store.set_default_paths
           end
 
           if @cert_store && proxy&.cacert&.present?

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -65,7 +65,7 @@ module Katello
             elsif cdn_configuration.redhat_cdn_host?
               options[:ssl_ca_file] = self.ca_file
             end
-            if cdn_configuration.custom_cdn_auth_enabled?
+            if cdn_configuration.custom_cdn_auth_enabled? || cdn_configuration.redhat_cdn_host?
               options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(product.certificate)
               options[:ssl_client_key] = OpenSSL::PKey::RSA.new(product.key)
             end

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -43,7 +43,7 @@ module Katello
             @cert_store.set_default_paths
           end
 
-          if @cert_store && proxy&.cacert&.present?
+          if proxy&.cacert&.present?
             Foreman::Util.add_ca_bundle_to_store(proxy.cacert, @cert_store)
           end
 

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -60,7 +60,11 @@ module Katello
             options[:ssl_ca_file] = self.ca_file
             self.new(cdn_configuration.url, options)
           elsif cdn_configuration.custom_cdn?
-            options[:ssl_ca_cert] = cdn_configuration.ssl_ca
+            if cdn_configuration.ssl_ca.present?
+              options[:ssl_ca_cert] = cdn_configuration.ssl_ca
+            elsif cdn_configuration.redhat_cdn_host?
+              options[:ssl_ca_file] = self.ca_file
+            end
             if cdn_configuration.custom_cdn_auth_enabled?
               options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(product.certificate)
               options[:ssl_client_key] = OpenSSL::PKey::RSA.new(product.key)

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -34,14 +34,12 @@ module Katello
                                     :ssl_ca_cert,
                                     :custom_cdn)
 
+          @cert_store = OpenSSL::X509::Store.new
           if options[:ssl_ca_cert].present?
-            @cert_store = OpenSSL::X509::Store.new
             Foreman::Util.add_ca_bundle_to_store(options[:ssl_ca_cert], @cert_store)
           elsif options[:ssl_ca_file]
-            @cert_store = OpenSSL::X509::Store.new
             @cert_store.add_file(options[:ssl_ca_file])
           else
-            @cert_store = OpenSSL::X509::Store.new
             @cert_store.set_default_paths
           end
 

--- a/app/models/katello/cdn_configuration.rb
+++ b/app/models/katello/cdn_configuration.rb
@@ -41,8 +41,8 @@ module Katello
       custom_cdn_auth_enabled
     end
 
-    def redhat_cdn_url?
-      Katello::Resources::CDN::CdnResource.redhat_cdn?(url)
+    def redhat_cdn_host?
+      URI.parse(url).host&.end_with?('.redhat.com')
     end
 
     def export_sync?

--- a/app/models/katello/cdn_configuration.rb
+++ b/app/models/katello/cdn_configuration.rb
@@ -43,6 +43,8 @@ module Katello
 
     def redhat_cdn_host?
       URI.parse(url).host&.end_with?('.redhat.com')
+    rescue URI::InvalidURIError
+      false
     end
 
     def export_sync?

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -523,7 +523,7 @@ module Katello
           }
         elsif root.redhat? && root.cdn_configuration.custom_cdn?
           options = {
-            ca_cert: root.cdn_configuration.ssl_ca || ::File.read(::Katello::Resources::CDN::CdnResource.ca_file),
+            ca_cert: custom_cdn_ca_cert,
           }
         elsif root.redhat? && root.cdn_configuration.network_sync?
           options = {
@@ -540,6 +540,11 @@ module Katello
         end
         append_proxy_cacert(options) if options.key?(:cacert)
         options
+      end
+
+      def custom_cdn_ca_cert
+        return root.cdn_configuration.ssl_ca if root.cdn_configuration.ssl_ca.present?
+        ::File.read(::Katello::Resources::CDN::CdnResource.ca_file) if URI.parse(root.url).host&.end_with?('.redhat.com')
       end
 
       def append_proxy_cacert(options)

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -523,7 +523,7 @@ module Katello
           }
         elsif root.redhat? && root.cdn_configuration.custom_cdn?
           options = {
-            ca_cert: root.cdn_configuration.ssl_ca,
+            ca_cert: root.cdn_configuration.ssl_ca || ::File.read(::Katello::Resources::CDN::CdnResource.ca_file),
           }
         elsif root.redhat? && root.cdn_configuration.network_sync?
           options = {

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -538,18 +538,18 @@ module Katello
             ca_cert: root.ssl_ca_cert&.content,
           }
         end
-        append_proxy_cacert(options) if options.key?(:cacert)
+        append_proxy_cacert(options) if options.key?(:ca_cert)
         options
       end
 
       def custom_cdn_ca_cert
         return root.cdn_configuration.ssl_ca if root.cdn_configuration.ssl_ca.present?
-        ::File.read(::Katello::Resources::CDN::CdnResource.ca_file) if URI.parse(root.url).host&.end_with?('.redhat.com')
+        ::File.read(::Katello::Resources::CDN::CdnResource.ca_file) if root.cdn_configuration.redhat_cdn_host?
       end
 
       def append_proxy_cacert(options)
-        if root.http_proxy&.cacert&.present? && options.key?(:cacert)
-          options[:cacert] += "\n#{root.http_proxy&.cacert}"
+        if root.http_proxy&.cacert&.present? && options.key?(:ca_cert)
+          options[:ca_cert] += "\n#{root.http_proxy.cacert}"
         end
         options
       end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -525,6 +525,10 @@ module Katello
           options = {
             ca_cert: custom_cdn_ca_cert,
           }
+          if root.cdn_configuration.redhat_cdn_host?
+            options[:client_cert] = root.product.certificate
+            options[:client_key] = root.product.key
+          end
         elsif root.redhat? && root.cdn_configuration.network_sync?
           options = {
             client_cert: root.cdn_configuration.ssl_cert,

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -553,7 +553,7 @@ module Katello
 
       def append_proxy_cacert(options)
         if root.http_proxy&.cacert&.present? && options.key?(:ca_cert)
-          options[:ca_cert] += "\n#{root.http_proxy.cacert}"
+          options[:ca_cert] = [options[:ca_cert], root.http_proxy.cacert].compact.join("\n")
         end
         options
       end

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -11,6 +11,32 @@ class CdnResourceTest < ActiveSupport::TestCase
     Katello::Resources::CDN::CdnResource.new('http://foo.com', ssl_ca_file: "lol")
   end
 
+  def test_custom_cdn_no_ssl_ca_redhat_url
+    organization = taxonomies(:empty_organization)
+    organization.cdn_configuration.update(
+      type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE,
+      url: 'https://cdn-eu.redhat.com',
+      ssl_ca_credential_id: nil
+    )
+    cdn_resource = Katello::Resources::CDN::CdnResource.create(product: nil, cdn_configuration: organization.cdn_configuration)
+    cdn_resource_options = cdn_resource.instance_variable_get(:@options)
+    assert_equal Katello::Resources::CDN::CdnResource.ca_file, cdn_resource_options[:ssl_ca_file]
+    assert_nil cdn_resource_options[:ssl_ca_cert]
+  end
+
+  def test_custom_cdn_no_ssl_ca_non_redhat_url
+    organization = taxonomies(:empty_organization)
+    organization.cdn_configuration.update(
+      type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE,
+      url: 'https://cdn.example.com',
+      ssl_ca_credential_id: nil
+    )
+    cdn_resource = Katello::Resources::CDN::CdnResource.create(product: nil, cdn_configuration: organization.cdn_configuration)
+    cdn_resource_options = cdn_resource.instance_variable_get(:@options)
+    assert_nil cdn_resource_options[:ssl_ca_file]
+    assert_nil cdn_resource_options[:ssl_ca_cert]
+  end
+
   def test_custom_cdn_auth
     organization = taxonomies(:empty_organization)
     credential = FactoryBot.create(:katello_content_credential, organization: organization)

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -13,15 +13,22 @@ class CdnResourceTest < ActiveSupport::TestCase
 
   def test_custom_cdn_no_ssl_ca_redhat_url
     organization = taxonomies(:empty_organization)
+    product = ::Katello::Product.find_by(cp_id: 'redhat_empty')
     organization.cdn_configuration.update(
       type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE,
       url: 'https://cdn-eu.redhat.com',
       ssl_ca_credential_id: nil
     )
-    cdn_resource = Katello::Resources::CDN::CdnResource.create(product: nil, cdn_configuration: organization.cdn_configuration)
+    product.expects(:certificate).once.returns('')
+    product.expects(:key).once.returns('')
+    OpenSSL::X509::Certificate.expects(:new).once.returns('mock cert')
+    OpenSSL::PKey::RSA.expects(:new).once.returns('mock key')
+    cdn_resource = Katello::Resources::CDN::CdnResource.create(product: product, cdn_configuration: organization.cdn_configuration)
     cdn_resource_options = cdn_resource.instance_variable_get(:@options)
     assert_equal Katello::Resources::CDN::CdnResource.ca_file, cdn_resource_options[:ssl_ca_file]
     assert_nil cdn_resource_options[:ssl_ca_cert]
+    assert_equal 'mock cert', cdn_resource_options[:ssl_client_cert]
+    assert_equal 'mock key', cdn_resource_options[:ssl_client_key]
   end
 
   def test_custom_cdn_no_ssl_ca_non_redhat_url

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -26,6 +26,21 @@ module Katello
             assert_match(/Please run `foreman-rake katello:delete_orphaned_content` to fix the following repository: Fedora 17 x86_64./, error.message)
           end
 
+          def test_ssl_remote_options_custom_cdn_redhat_host
+            repo = katello_repositories(:rhel_7_x86_64)
+            service = Katello::Pulp3::Repository::Yum.new(repo, @proxy)
+            repo.root.organization.cdn_configuration.update(
+              type: ::Katello::CdnConfiguration::CUSTOM_CDN_TYPE,
+              url: 'https://cdn-eu.redhat.com'
+            )
+            ::Katello::RootRepository.any_instance.stubs(:http_proxy).returns(nil)
+            ::Katello::Product.any_instance.stubs(:certificate).returns('my cert')
+            ::Katello::Product.any_instance.stubs(:key).returns('my key')
+            options = service.ssl_remote_options
+            assert_equal 'my cert', options[:client_cert]
+            assert_equal 'my key', options[:client_key]
+          end
+
           def test_append_proxy_cacert
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             http_proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -41,6 +41,17 @@ module Katello
             assert_equal 'my key', options[:client_key]
           end
 
+          def test_append_proxy_cacert_with_nil_ca_cert
+            service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            http_proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',
+                              :username => 'admin',
+                              :password => 'password',
+                              :cacert => "proxy cert")
+            ::Katello::RootRepository.any_instance.stubs(:http_proxy).returns(http_proxy)
+            options = service.append_proxy_cacert(ca_cert: nil)
+            assert_equal "proxy cert", options[:ca_cert]
+          end
+
           def test_append_proxy_cacert
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
             http_proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',

--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -34,8 +34,8 @@ module Katello
                               :cacert => "")
             ::Katello::RootRepository.any_instance.expects(:http_proxy).returns(http_proxy)
             cert = "MY cert"
-            options = service.append_proxy_cacert(cacert: cert)
-            assert_equal(options[:cacert], cert)
+            options = service.append_proxy_cacert(ca_cert: cert)
+            assert_equal(options[:ca_cert], cert)
           end
 
           def test_additional_content_hrefs_properly_includes_errata


### PR DESCRIPTION
## Summary

- When syncing Red Hat repos via Custom CDN with no SSL CA credential configured, Pulp remotes now fall back to `redhat-uep.pem` instead of passing `nil` (which left Pulp with no trusted CA for Red Hat CDN hosts)
- `CdnResource` SSL connections also now fall back to the system CA bundle when no explicit CA cert or file is provided
- Allows alternate Red Hat CDN URLs (e.g. `cdn-eu.redhat.com`, `cdn-us.redhat.com`) to be used without requiring a manually uploaded CA credential

## Test plan

- [ ] Set CDN configuration to Custom CDN with a regional Red Hat CDN URL (e.g. `cdn-eu.redhat.com` or `cdn-us.redhat.com`) and no SSL CA credential selected
- [ ] Sync a Red Hat repository and confirm it succeeds without SSL errors
- [ ] Confirm that a custom CA credential, when explicitly selected, still takes precedence over the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDN SSL/TLS behavior: system CA paths are used when no custom CA is provided; Red Hat CDN hosts now correctly use the Red Hat CA and appropriate client certificates, and proxy CA certificates are appended consistently to the CA bundle.

* **Tests**
  * Added tests for custom CDN CA behavior for Red Hat vs non‑Red Hat hosts and for proxy CA handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11732)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->