### PR TITLE
fixes #39306 - sanitize order input in bootc_images

### DIFF
--- a/app/controllers/katello/api/v2/host_bootc_images_controller.rb
+++ b/app/controllers/katello/api/v2/host_bootc_images_controller.rb
@@ -10,13 +10,15 @@ module Katello
     api :GET, "/hosts/bootc_images", N_("List booted bootc container images for hosts")
     param_group :search, Api::V2::ApiController
     def bootc_images
-      params[:sort_by] = sanitize_sort_column(params[:sort_by])
-      params[:sort_order] ||= 'asc'
       if params[:order]
-        params[:order] = "#{params[:order].split(' ')[0]} #{sanitize_sort_order(params[:order].split(' ')[1])}"
+        parts = params[:order].split(' ')
+        params[:sort_by] = sanitize_sort_column(parts[0])
+        params[:sort_order] = sanitize_sort_order(parts[1])
       else
-        params[:order] = "#{params[:sort_by]} #{sanitize_sort_order(params[:sort_order])}"
+        params[:sort_by] = sanitize_sort_column(params[:sort_by])
+        params[:sort_order] = sanitize_sort_order(params[:sort_order])
       end
+      params[:order] = "#{params[:sort_by]} #{params[:sort_order]}"
       per_page = params[:per_page].present? ? params[:per_page].to_i : Setting[:entries_per_page]
       page = params[:page].present? ? params[:page].to_i : 1
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Further sanitize `bootc_images`. This change strengths the initial sanitization when `params[:order]` is used. 

Note this PR is a replacement for https://github.com/Katello/katello/pull/11712

#### Considerations taken when implementing this change?
- Keep API behavior the same but make params safer




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bootc images API endpoint to improve sorting parameter handling with enhanced flexibility and modified sort order fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->