### PR TITLE
Fixes #39308 - Skip Candlepin update when subscription facet is destroyed

### DIFF
--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -38,7 +38,7 @@ module Katello
         content_facet.cvenvs_changed = false if content_facet
         content_facet&.save!
 
-        if subscription_facet
+        if subscription_facet && !subscription_facet.destroyed?
           consumer_params ||= subscription_facet.consumer_attributes
 
           host_uuid = consumer_params.dig(:facts, 'dmi.system.uuid')
@@ -48,7 +48,12 @@ module Katello
             override_value ||= subscription_facet.update_dmi_uuid_override&.value
             consumer_params[:facts]['dmi.system.uuid'] = override_value
           end
-          ::Katello::Resources::Candlepin::Consumer.update(subscription_facet.uuid, consumer_params)
+
+          begin
+            ::Katello::Resources::Candlepin::Consumer.update(subscription_facet.uuid, consumer_params)
+          rescue RestClient::Gone, RestClient::NotFound
+            raise "Unable to update missing or deleted candlepin consumer uuid=#{subscription_facet.uuid} host_id=#{self.id}"
+          end
 
           if consumer_params.try(:[], :facts)
             ::Katello::Host::SubscriptionFacet.update_facts(self, consumer_params[:facts])

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -250,6 +250,8 @@ module Katello
       end
 
       def backend_update_needed?
+        return false if self.destroyed?
+
         %w(release_version service_level purpose_role purpose_usage).each do |method|
           if self.send("#{method}_changed?")
             Rails.logger.debug("backend_update_needed: subscription facet #{method} changed")

--- a/test/factories/content_facet_factory.rb
+++ b/test/factories/content_facet_factory.rb
@@ -1,5 +1,25 @@
 FactoryBot.define do
-  factory :katello_content_facets, :aliases => [:content_facet], :class => ::Katello::Host::ContentFacet do
-    # UUID removed - it belongs to subscription_facet, not content_facet
+  factory :katello_content_facet, :aliases => [:content_facet], :class => ::Katello::Host::ContentFacet do
+    host { association(:host, content_facet: @instance) }
+
+    trait :with_content_view_environment do
+      content_view_environments { [association(:katello_content_view_environment)] }
+    end
+
+    trait :with_content_source do
+      content_source { association(:smart_proxy, :with_pulp3) }
+    end
+
+    trait :with_kickstart_repository do
+      kickstart_repository { association(:katello_repository, :with_product) }
+    end
+
+    trait :with_applicable_errata do
+      applicable_errata { [association(:katello_erratum)] }
+    end
+
+    trait :with_bound_repositories do
+      bound_repositories { [association(:katello_repository)] }
+    end
   end
 end

--- a/test/factories/content_view_environment_factory.rb
+++ b/test/factories/content_view_environment_factory.rb
@@ -5,21 +5,8 @@ FactoryBot.define do
     # - environment: the lifecycle environment
     # The content_view will be automatically set from the version
 
-    association :content_view_version, :factory => :katello_content_view_version
-
-    after(:build) do |cve, _evaluator|
-      # Set content_view from the version
-      if cve.content_view_version && !cve.content_view
-        cve.content_view = cve.content_view_version.content_view
-      end
-
-      # Set environment to library if not provided
-      unless cve.environment
-        org = cve.content_view&.organization || cve.content_view_version&.content_view&.organization
-        if org
-          cve.environment = org.library
-        end
-      end
-    end
+    content_view_version { association(:katello_content_view_version) }
+    content_view { content_view_version.content_view }
+    environment { association(:katello_environment, organization: content_view.organization) }
   end
 end

--- a/test/factories/host_factory.rb
+++ b/test/factories/host_factory.rb
@@ -11,7 +11,7 @@ FactoryBot.modify do
     end
 
     trait :with_content do
-      association :content_facet, :factory => :content_facet, :strategy => :build
+      association :content_facet, host: @instance, :factory => :content_facet, :strategy => :build
 
       after(:build) do |host, evaluator|
         if host.content_facet

--- a/test/factories/katello_erratum_factory.rb
+++ b/test/factories/katello_erratum_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :katello_erratum, class: Katello::Erratum do
+    sequence(:pulp_id) { |n| n }
+  end
+end

--- a/test/factories/repository_factory.rb
+++ b/test/factories/repository_factory.rb
@@ -65,7 +65,7 @@ FactoryBot.define do
     trait :with_product do
       with_content_view
 
-      product { FactoryBot.create(:katello_product, :with_provider, organization: organization) }
+      product { association(:katello_product, :with_provider, organization: organization) }
     end
 
     trait :deb do

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -250,6 +250,13 @@ module Katello
       assert subscription_facet.backend_update_needed?
     end
 
+    def test_backend_update_needed_facet_destroyed
+      host = FactoryBot.build_stubbed(:host, :with_subscription)
+      host.subscription_facet.expects(:destroyed?).returns(true)
+
+      refute host.subscription_facet.backend_update_needed?
+    end
+
     def test_host_update_with_overridden_dmi_uuid
       ::Setting[:host_dmi_uuid_duplicates] = ['duplicate-dmi-uuid']
       params = {facts: {'dmi.system.uuid' => 'duplicate-dmi-uuid'}}.with_indifferent_access

--- a/test/models/concerns/subscription_facet_host_extensions_test.rb
+++ b/test/models/concerns/subscription_facet_host_extensions_test.rb
@@ -1,0 +1,26 @@
+require 'katello_test_helper'
+
+module Katello
+  class SubscriptionFacetHostExtensionsTest
+    class UpdateCandlepinAssociationsTest < ActiveSupport::TestCase
+      test "doesn't update candlepin if subscription facet was destroyed" do
+        host = FactoryBot.build_stubbed(:host, :with_content, :with_subscription)
+        host.content_facet.stubs(:save!)
+        host.subscription_facet.expects(:destroyed?).once.returns(true)
+        ::Katello::Resources::Candlepin::Consumer.expects(:update).never
+
+        host.update_candlepin_associations
+      end
+
+      test "raises RuntimeError if consumer is gone" do
+        host = FactoryBot.build_stubbed(:host, :with_content, :with_subscription)
+        ::Katello::Resources::Candlepin::Consumer.expects(:update).raises(RestClient::Gone)
+        host.content_facet.stubs(:save!)
+
+        assert_raises(RuntimeError, /missing or deleted/) do
+          host.update_candlepin_associations
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION

#### What are the changes introduced in this pull request?

During a recent PR review around host registration I found two broken scenarios stemming from the same bug rooted in host artifact cleanup.

**Scenario 1: Candlepin goes down during registration.**

Attempts to cleanup certain host artifacts in the DB which issue another HTTP request to Candlepin. Since CP is down it fails and cleanup is left incomplete.

```
 b47ca512] Katello::Errors::ConnectionRefusedException: A backend service [ Candlepin ] is unreachable
 b47ca512 | /home/vagrant/katello/app/lib/katello/http_resource.rb:103:in `rescue in issue_request'
 b47ca512 | /home/vagrant/katello/app/lib/katello/http_resource.rb:86:in `issue_request'
 b47ca512 | /home/vagrant/katello/app/lib/katello/http_resource.rb:49:in `block (2 levels) in singleton class'
 b47ca512 | /home/vagrant/katello/app/lib/katello/resources/candlepin/consumer.rb:76:in `update'
 b47ca512 | /home/vagrant/katello/app/models/katello/concerns/subscription_facet_host_extensions.rb:51:in `update_candlepin_associations'
 b47ca512 | /home/vagrant/katello/app/models/katello/host/content_facet.rb:152:in `content_view_environments='
 b47ca512 | /home/vagrant/katello/app/services/katello/registration_manager.rb:327:in `remove_host_artifacts'
 b47ca512 | /home/vagrant/katello/app/services/katello/registration_manager.rb:194:in `rescue in block in register_host'
 b47ca512 | /home/vagrant/katello/app/services/katello/registration_manager.rb:185:in `block in register_host'
```
The exception is raised from within `clean_host_artifacts`.

**Scenario 2: Host unregister**

Host artifacts are again cleaned up when a host is unregistered.
```
e73444c5] Started DELETE "/rhsm/consumers/7580a190-e70f-4c71-ba58-4c52e2faa786" for 192.168.124.4 at 2026-05-09 14:32:20 +0000
e73444c5] Processing by Katello::Api::Rhsm::CandlepinProxiesController#consumer_destroy as JSON
e73444c5]   Parameters: {"id"=>"7580a190-e70f-4c71-ba58-4c52e2faa786"}
e73444c5] RestClient::Gone: Katello::Resources::Candlepin::Consumer: 410 Gone {"deletedId":"7580a190-e70f-4c71-ba58-4c52e2faa786","displayMessage":"Unit 7580a190-e70f-4c71-ba58-4c52e2faa786 has been deleted","requestUuid":"7b799f35-1751-4339-8c9d-cbc355759fee"} (PUT /candlepin/consumers/7580a190-e70f-4c71-ba58-4c52e2faa786)
 e73444c5 | Body: {"deletedId":"7580a190-e70f-4c71-ba58-4c52e2faa786","displayMessage":"Unit 7580a190-e70f-4c71-ba58-4c52e2faa786 has been deleted","requestUuid":"7b799f35-1751-4339-8c9d-cbc355759fee"}
 e73444c5 |
```
The DELETE request is emitting logs about a PUT to the candlepin consumer which returns a `410 Gone`. When cleanup happens the consumer has already been deleted from Candlepin. Artifact cleanup is again incomplete. The CandlepinProxiesController rescues all RestClient exceptions which hides the fact that something actually went wrong - it just passes the return code on without a stack trace.

#### Considerations taken when implementing this change?
I don't think CandlepinProxiesController rescuing all rest client exceptions is a good idea but I decided to leave it alone and just fix the actual bug.

#### What are the testing steps for this pull request?

Scenario 1:
- Register a host (subman) and immediately unregister it.
- Stop tomcat
- Attempt to register again immediately (registration proceeds because Katello thinks Candlepin is still running)
- An error is raised about Candlepin being down but `remove_host_artifacts` should not be in the stack trace.

Scenario 2:
- Register a host
- Unregister the host
- The HTTP response should be 204 and not 410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented backend updates for destroyed subscription records.
  * Improved handling when a host’s Candlepin consumer is missing or deleted, with a clearer error message.
  * Ensured content facet state is reset and saved during association updates.

* **Tests**
  * Added coverage for destroyed subscription records and missing Candlepin consumers.
  * Expanded test factories and traits to support content, repositories, environments, errata, and related scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->