### PR TITLE
Fixes #39309 - Add CC delete validation

### DIFF
--- a/app/models/katello/content_credential.rb
+++ b/app/models/katello/content_credential.rb
@@ -29,11 +29,11 @@ module Katello
     has_many :ssl_key_root_repos, :class_name => "Katello::RootRepository", :foreign_key => "ssl_client_key_id",
                              :inverse_of => :ssl_client_key, :dependent => :restrict_with_exception
     has_many :ssl_ca_alternate_content_sources, :class_name => "Katello::AlternateContentSource", :foreign_key => "ssl_ca_cert_id",
-                                :inverse_of => :ssl_ca_cert, :dependent => :nullify
+                                :inverse_of => :ssl_ca_cert, :dependent => :restrict_with_exception
     has_many :ssl_client_alternate_content_sources, :class_name => "Katello::AlternateContentSource", :foreign_key => "ssl_client_cert_id",
-                                :inverse_of => :ssl_client_cert, :dependent => :nullify
+                                :inverse_of => :ssl_client_cert, :dependent => :restrict_with_exception
     has_many :ssl_key_alternate_content_sources, :class_name => "Katello::AlternateContentSource", :foreign_key => "ssl_client_key_id",
-                                :inverse_of => :ssl_client_key, :dependent => :nullify
+                                :inverse_of => :ssl_client_key, :dependent => :restrict_with_exception
     belongs_to :organization, :inverse_of => :gpg_keys
 
     validates_lengths_from_database

--- a/test/models/content_credential_test.rb
+++ b/test/models/content_credential_test.rb
@@ -49,6 +49,27 @@ module Katello
         assert_nothing_raised { content_credential.destroy }
       end
 
+      it 'should not be destroyable when used as ssl_ca_cert in an alternate content source' do
+        content_credential = katello_gpg_keys(:real_ca)
+        assert_raises(ActiveRecord::DeleteRestrictionError) { content_credential.destroy }
+        content_credential.ssl_ca_alternate_content_sources.update_all(:ssl_ca_cert_id => nil)
+        assert_nothing_raised { content_credential.destroy }
+      end
+
+      it 'should not be destroyable when used as ssl_client_cert in an alternate content source' do
+        content_credential = katello_gpg_keys(:real_cert)
+        assert_raises(ActiveRecord::DeleteRestrictionError) { content_credential.destroy }
+        content_credential.ssl_client_alternate_content_sources.update_all(:ssl_client_cert_id => nil)
+        assert_nothing_raised { content_credential.destroy }
+      end
+
+      it 'should not be destroyable when used as ssl_client_key in an alternate content source' do
+        content_credential = katello_gpg_keys(:real_key)
+        assert_raises(ActiveRecord::DeleteRestrictionError) { content_credential.destroy }
+        content_credential.ssl_key_alternate_content_sources.update_all(:ssl_client_key_id => nil)
+        assert_nothing_raised { content_credential.destroy }
+      end
+
       it "should be unsuccessful without content" do
         content_credential = ContentCredential.new(:name => "Gpg Key 1", :organization => @organization)
         refute content_credential.valid?


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR just adds validation to prevent deletion of a Content Credential when used by some ACS as CA cert, client cert, or client key.

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a ContentCredential of Cert type.
2. Create an ACS using the credential from 1 as CA cert, client cert, or client key.
3. Try to delete the Content Credential -> you should be prevented from the deletion as long as the CC is used by an ACS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental deletion of SSL certificates and keys that are currently in use by alternate content sources, enhancing data integrity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->