### PR TITLE
Fixes #39312 - Add DEB tracer support to Host Details Traces tab

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -410,6 +410,10 @@ module Katello
         ::Katello::Rpm.yum_installable_for_host(self.host).where(name: ALL_TRACER_PACKAGE_NAMES).any?
       end
 
+      def tracer_deb_available?
+        ::Katello::Deb.deb_installable_for_host(self.host).where(name: HOST_TOOLS_TRACER_PACKAGE_NAME).any?
+      end
+
       def host_tools_installed?(force_update_cache: false)
         Rails.cache.fetch("#{self.host.id}/host_tools_installed", expires_in: 7.days, force: force_update_cache) do
           self.host.installed_packages.where("#{Katello::InstalledPackage.table_name}.name" => ALL_HOST_TOOLS_PACKAGE_NAMES).any? ||

--- a/app/views/katello/api/v2/content_facet/show.json.rabl
+++ b/app/views/katello/api/v2/content_facet/show.json.rabl
@@ -29,6 +29,10 @@ child :content_facet => :content_facet_attributes do
     content_facet.tracer_rpm_available?
   end
 
+  node :katello_tracer_deb_available do |content_facet|
+    content_facet.tracer_deb_available?
+  end
+
   user = User.current # current_user is not available here
   child :permissions do
     node(:view_lifecycle_environments) { user.can?("view_lifecycle_environments") }

--- a/test/fixtures/models/katello_debs.yml
+++ b/test/fixtures/models/katello_debs.yml
@@ -25,3 +25,10 @@ three:
   version:      1.0
   architecture: amd64
   filename:     tre_1.0_amd64.deb
+
+katello_host_tools_tracer:
+  name:         katello-host-tools-tracer
+  pulp_id:      katello-host-tools-tracer-uuid
+  version:      1.0
+  architecture: amd64
+  filename:     katello-host-tools-tracer_1.0_amd64.deb

--- a/test/fixtures/models/katello_repository_debs.yml
+++ b/test/fixtures/models/katello_repository_debs.yml
@@ -22,3 +22,7 @@ debian_devlib_one:
   deb_id: <%= ActiveRecord::FixtureSet.identify(:one) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:debian_10_dev_library_view) %>
 
+debian_katello_host_tools_tracer:
+  deb_id: <%= ActiveRecord::FixtureSet.identify(:katello_host_tools_tracer) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:debian_10_amd64) %>
+

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -308,6 +308,14 @@ module Katello
       assert_equal 1, host_one.content_facet.upgradable_deb_count
     end
 
+    def test_tracer_deb_available?
+      refute host_one.content_facet.tracer_deb_available?
+
+      host_one.content_facet.bound_repositories << repo
+
+      assert host_one.reload.content_facet.tracer_deb_available?
+    end
+
     def test_installable_debs
       lib_applicable = host_one.applicable_debs
       cf_one = host_one.content_facet

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.js
@@ -8,25 +8,23 @@ import {
   ModalVariant,
   Text,
   TextContent,
-  TextList,
-  TextListItem,
-  Alert,
 } from '@patternfly/react-core';
 import {
   Dropdown,
   DropdownItem,
   DropdownToggle,
 } from '@patternfly/react-core/deprecated';
-import { CaretDownIcon, ArrowRightIcon } from '@patternfly/react-icons';
+import { CaretDownIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { useSelector } from 'react-redux';
 import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
 import { katelloPackageInstallUrl } from '../customizedRexUrlHelpers';
 import { KATELLO_TRACER_PACKAGE } from './HostTracesConstants';
+import TracerPrerequisites from './TracerPrerequisites';
 import './EnableTracerModal.scss';
 
 const EnableTracerModal = ({
-  isOpen, setIsOpen, triggerJobStart, tracerRpmAvailable,
+  isOpen, setIsOpen, triggerJobStart, tracerAvailable, isDebHost,
 }) => {
   const title = __('Enable Tracer');
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -51,53 +49,68 @@ const EnableTracerModal = ({
     handleClose();
   };
 
+  const debPrereqItems = [
+    {
+      text: __('The Foreman Client DEB repository is enabled and synced. '),
+      href: '/products',
+      linkText: __('View products'),
+      id: 'enable-tracer-deb-products-link',
+    },
+    {
+      text: __("The Foreman Client DEB repository is available in the host's content view environment(s). "),
+      href: '/content_views',
+      linkText: __('View content views'),
+      id: 'enable-tracer-deb-cv-link',
+    },
+    {
+      text: __('The Foreman Client DEB repository set is enabled for the host. '),
+      href: '#/Content/Repository%20sets',
+      linkText: __('Enable repository sets'),
+      id: 'enable-tracer-deb-reposets-link',
+      itemId: 'enable-repo-deb-sets-p',
+    },
+    { text: __('Remote execution is enabled.') },
+  ];
+
+  const rpmPrereqItems = [
+    {
+      text: __('The Foreman Client repository is enabled. '),
+      href: '/redhat_repositories',
+      linkText: __('Enable Red Hat repositories'),
+      id: 'enable-tracer-enable-red-hat-repos-link',
+    },
+    {
+      text: __('The Foreman Client repository is synced. '),
+      href: '/katello/sync_management',
+      linkText: __('View sync status'),
+      id: 'enable-tracer-sync-status-link',
+    },
+    {
+      text: __("The Foreman Client repository is available in the host's content view environment(s). "),
+      href: '/content_views',
+      linkText: __('View content views'),
+      id: 'enable-tracer-cv-link',
+    },
+    {
+      text: __('The Foreman Client repository set is enabled for the host. '),
+      href: '#/Content/Repository%20sets',
+      linkText: __('Enable repository sets'),
+      id: 'enable-tracer-reposets-link',
+      itemId: 'enable-repo-sets-p',
+    },
+    { text: __('Remote execution is enabled.') },
+  ];
+
   const body = (
     <TextContent>
       <Text ouiaId="enable-tracer-modal-text" id="enable-tracer-modal-p">
         {__('Enabling Tracer requires installing the katello-host-tools-tracer package on the host.')}
       </Text>
-      {!tracerRpmAvailable && (
-        <>
-          <Alert
-            ouiaId="enable-tracer-modal-prereq-text"
-            variant="warning"
-            isInline
-            title={__('Before continuing, ensure that all of the following prerequisites are met:')}
-          />
-          <TextList className="enable-tracer-modal-prereq-list">
-            <TextListItem>
-              {__('The Foreman Client repository is enabled. ')}
-              <a onClick={() => setButtonLoading(true)} href="/redhat_repositories" id="enable-tracer-enable-red-hat-repos-link">
-                {__('Enable Red Hat repositories')}
-              </a>
-              <ArrowRightIcon />
-            </TextListItem>
-            <TextListItem>
-              {__('The Foreman Client repository is synced. ')}
-              <a onClick={() => setButtonLoading(true)} href="/katello/sync_management" id="enable-tracer-sync-status-link">
-                {__('View sync status')}
-              </a>
-              <ArrowRightIcon />
-            </TextListItem>
-            <TextListItem>
-              {__('The Foreman Client repository is available in the host\'s content view environment(s). ')}
-              <a onClick={() => setButtonLoading(true)} href="/content_views" id="enable-tracer-cv-link">
-                {__('View content views')}
-              </a>
-              <ArrowRightIcon />
-            </TextListItem>
-            <TextListItem id="enable-repo-sets-p">
-              {__('The Foreman Client repository set is enabled for the host. ')}
-              <a onClick={() => setButtonLoading(true)} href="#/Content/Repository%20sets" id="enable-tracer-reposets-link">
-                {__('Enable repository sets')}
-              </a>
-              <ArrowRightIcon />
-            </TextListItem>
-            <TextListItem>
-              {__('Remote execution is enabled.')}
-            </TextListItem>
-          </TextList>
-        </>
+      {!tracerAvailable && (
+        <TracerPrerequisites
+          items={isDebHost ? debPrereqItems : rpmPrereqItems}
+          onLinkClick={() => setButtonLoading(true)}
+        />
       )}
     </TextContent>
   );
@@ -159,8 +172,9 @@ const EnableTracerModal = ({
         <FlexItem>
           <TextContent>
             <Text ouiaId="enable-tracer-modal-provider-text">
-              {tracerRpmAvailable ? __('Select a provider to install katello-host-tools-tracer') :
-                __('Once the prerequisites are met, select a provider to install katello-host-tools-tracer')}
+              {tracerAvailable
+                ? __('Select a provider to install katello-host-tools-tracer')
+                : __('Once the prerequisites are met, select a provider to install katello-host-tools-tracer')}
             </Text>
           </TextContent>
         </FlexItem>
@@ -193,7 +207,13 @@ EnableTracerModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   setIsOpen: PropTypes.func.isRequired,
   triggerJobStart: PropTypes.func.isRequired,
-  tracerRpmAvailable: PropTypes.bool.isRequired,
+  tracerAvailable: PropTypes.bool,
+  isDebHost: PropTypes.bool,
+};
+
+EnableTracerModal.defaultProps = {
+  tracerAvailable: false,
+  isDebHost: false,
 };
 
 export default EnableTracerModal;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracerPrerequisites.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracerPrerequisites.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert,
+  TextList,
+  TextListItem,
+} from '@patternfly/react-core';
+import { ArrowRightIcon } from '@patternfly/react-icons';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+const TracerPrerequisites = ({ items, onLinkClick }) => (
+  <>
+    <Alert
+      ouiaId="enable-tracer-modal-prereq-text"
+      variant="warning"
+      isInline
+      title={__('Before continuing, ensure that all of the following prerequisites are met:')}
+    />
+    <TextList className="enable-tracer-modal-prereq-list">
+      {items.map(({
+        text, href, linkText, id, itemId,
+      }) => (
+        <TextListItem key={id || text} id={itemId}>
+          {text}
+          {href && (
+            <>
+              <a onClick={onLinkClick} href={href} id={id}>{linkText}</a>
+              <ArrowRightIcon />
+            </>
+          )}
+        </TextListItem>
+      ))}
+    </TextList>
+  </>
+);
+
+TracerPrerequisites.propTypes = {
+  items: PropTypes.arrayOf(PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    href: PropTypes.string,
+    linkText: PropTypes.string,
+    id: PropTypes.string,
+    itemId: PropTypes.string,
+  })).isRequired,
+  onLinkClick: PropTypes.func.isRequired,
+};
+
+export default TracerPrerequisites;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesEnabler.js
@@ -52,7 +52,7 @@ EnableTracerButton.propTypes = {
   pollingStarted: PropTypes.bool.isRequired,
 };
 
-const TracesEnabler = ({ hostname, tracerRpmAvailable }) => {
+const TracesEnabler = ({ hostname, tracerAvailable, isDebHost }) => {
   const title = __('Traces are not enabled');
   const enablingTitle = __('Traces are being enabled');
   const body = __('Traces help administrators identify applications that need to be restarted after a system is patched.');
@@ -93,7 +93,8 @@ const TracesEnabler = ({ hostname, tracerRpmAvailable }) => {
           isOpen={enableTracerModalOpen}
           setIsOpen={setEnableTracerModalOpen}
           triggerJobStart={triggerJobStart}
-          tracerRpmAvailable={tracerRpmAvailable}
+          tracerAvailable={tracerAvailable}
+          isDebHost={isDebHost}
         />
       </EmptyStateFooter>
     </EmptyState>
@@ -102,7 +103,13 @@ const TracesEnabler = ({ hostname, tracerRpmAvailable }) => {
 
 TracesEnabler.propTypes = {
   hostname: PropTypes.string.isRequired,
-  tracerRpmAvailable: PropTypes.bool.isRequired,
+  tracerAvailable: PropTypes.bool,
+  isDebHost: PropTypes.bool,
+};
+
+TracesEnabler.defaultProps = {
+  tracerAvailable: false,
+  isDebHost: false,
 };
 
 export default TracesEnabler;

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/TracesTab.js
@@ -46,10 +46,14 @@ const TracesTab = () => {
     id: hostId,
     name: hostname,
     content_facet_attributes: contentFacetAttributes,
+    operatingsystem_family: osFamily,
   } = hostDetails;
   const showActions = can(invokeRexJobs, userPermissionsFromHostDetails({ hostDetails }));
   const showEnableTracer = (contentFacetAttributes?.katello_tracer_installed === false);
-  const tracerRpmAvailable = contentFacetAttributes?.katello_tracer_rpm_available;
+  const isDebHost = osFamily === 'Debian';
+  const tracerAvailable = isDebHost
+    ? contentFacetAttributes?.katello_tracer_deb_available
+    : contentFacetAttributes?.katello_tracer_rpm_available;
   const emptyContentTitle = showActions ? __('No applications to restart') : __('Traces not available');
   const tracesNotAvailBody = showEnableTracer ? __('Traces may be enabled by a user with the appropriate permissions.') :
     __('Traces will be shown here to a user with the appropriate permissions.');
@@ -198,7 +202,9 @@ const TracesTab = () => {
   ) : null;
   const status = useSelector(state => selectHostTracesStatus(state));
   if (showEnableTracer && showActions) {
-    return <TracesEnabler hostname={hostname} tracerRpmAvailable={tracerRpmAvailable} />;
+    return (
+      <TracesEnabler hostname={hostname} tracerAvailable={tracerAvailable} isDebHost={isDebHost} />
+    );
   }
 
   if (!hostId) return <Skeleton />;

--- a/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
+++ b/webpack/components/extensions/HostDetails/Tabs/__tests__/tracesTab.test.js
@@ -35,19 +35,31 @@ const tracerNotInstalledResponse = {
   },
 };
 
-const renderOptions = isTracerInstalled => ({ // sets initial Redux state
+const tracerNotInstalledDebResponse = {
+  ...tracerInstalledResponse,
+  operatingsystem_family: 'Debian',
+  content_facet_attributes: {
+    katello_tracer_installed: false,
+    katello_tracer_deb_available: false,
+  },
+};
+
+const buildRenderOptions = response => ({
   apiNamespace: HOST_TRACES_KEY,
   initialState: {
     API: {
       HOST_DETAILS: {
         name: hostName,
         id: 1,
-        response: isTracerInstalled ? tracerInstalledResponse : tracerNotInstalledResponse,
+        response,
         status: 'RESOLVED',
       },
     },
   },
 });
+
+const renderOptions = isTracerInstalled =>
+  buildRenderOptions(isTracerInstalled ? tracerInstalledResponse : tracerNotInstalledResponse);
 
 const actionMenuToTheRightOf = node => node.nextElementSibling.firstElementChild;
 
@@ -493,10 +505,16 @@ describe('Without tracer installed', () => {
   });
 
   test('Detects when tracer package is available to install', async () => {
-    tracerNotInstalledResponse.content_facet_attributes.katello_tracer_rpm_available = true;
+    const rpmAvailableResponse = {
+      ...tracerNotInstalledResponse,
+      content_facet_attributes: {
+        ...tracerNotInstalledResponse.content_facet_attributes,
+        katello_tracer_rpm_available: true,
+      },
+    };
 
     const { getByText, queryByText }
-      = renderWithRedux(<TracesTab />, renderOptions(false));
+      = renderWithRedux(<TracesTab />, buildRenderOptions(rpmAvailableResponse));
 
     await patientlyWaitFor(() => expect(queryByText('Traces are not enabled')).toBeInTheDocument());
     const enableTracesButton = getByText('Enable Traces');
@@ -530,5 +548,44 @@ describe('Without tracer installed', () => {
       );
     enableTracesModalLink.click();
     expect(enableTracesModalLink).toHaveClass('pf-m-in-progress');
+  });
+});
+
+describe('Without tracer installed on a DEB host', () => {
+  test('Shows Enable Tracer empty state on deb host', async () => {
+    const { queryByText } =
+      renderWithRedux(<TracesTab />, buildRenderOptions(tracerNotInstalledDebResponse));
+
+    await patientlyWaitFor(() => expect(queryByText('Traces are not enabled')).toBeInTheDocument());
+  });
+
+  test('Shows DEB-specific prerequisites when deb tracer package is not available', async () => {
+    const { getByText, queryByText }
+      = renderWithRedux(<TracesTab />, buildRenderOptions(tracerNotInstalledDebResponse));
+
+    await patientlyWaitFor(() => expect(queryByText('Traces are not enabled')).toBeInTheDocument());
+    getByText('Enable Traces').click();
+
+    expect(getByText('Before continuing, ensure that all of the following prerequisites are met:')).toBeInTheDocument();
+    expect(queryByText('The Foreman Client DEB repository is enabled and synced.')).toBeInTheDocument();
+    expect(queryByText('Enable Red Hat repositories')).not.toBeInTheDocument();
+  });
+
+  test('Does not show prerequisites when deb tracer package is available', async () => {
+    const debAvailableResponse = {
+      ...tracerNotInstalledDebResponse,
+      content_facet_attributes: {
+        ...tracerNotInstalledDebResponse.content_facet_attributes,
+        katello_tracer_deb_available: true,
+      },
+    };
+
+    const { getByText, queryByText }
+      = renderWithRedux(<TracesTab />, buildRenderOptions(debAvailableResponse));
+
+    await patientlyWaitFor(() => expect(queryByText('Traces are not enabled')).toBeInTheDocument());
+    getByText('Enable Traces').click();
+
+    expect(queryByText('Before continuing, ensure that all of the following prerequisites are met:')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
 The Enable Tracer modal and the Traces tab previously only handled
 RPM-based hosts. This adds equivalent support for Debian-family hosts.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracer support added for Debian-based hosts and API now exposes tracer DEB availability.
  * Host traces UI detects host OS and shows DEB- or RPM-specific tracer prerequisites.

* **Tests**
  * Added tests and fixtures covering tracer DEB availability and DEB host UI behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11738)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->