### PR TITLE
Fixes #39313 - Fix RHSM proxy authorization for non-admin users

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -536,10 +536,10 @@ module Katello
         if params[:consumer]
           User.consumer? && current_user.uuid == params[:consumer]
         else
-          User.consumer? || ::User.current.can?(:view_organizations, self)
+          User.consumer? || ::User.current.can?(:view_organizations)
         end
       when "rhsm_proxy_owner_servicelevels_path", "rhsm_proxy_owner_system_purpose_path"
-        (User.consumer? || ::User.current.can?(:view_organizations, self))
+        (User.consumer? || ::User.current.can?(:view_organizations))
       when "rhsm_proxy_consumer_accessible_content_path", "rhsm_proxy_consumer_certificates_path",
            "rhsm_proxy_consumer_releases_path", "rhsm_proxy_certificate_serials_path",
            "rhsm_proxy_consumer_entitlements_path", "rhsm_proxy_consumer_entitlements_post_path",

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -522,6 +522,50 @@ module Katello
       end
     end
 
+    describe "authorize_proxy_routes owner endpoints" do
+      # Tests for fix: can?(:view_organizations) was incorrectly called with self (controller),
+      # causing NoMethodError on allows_taxonomy_filtering? for non-admin users.
+
+      def stub_route_recognition(route_name, route_params = {})
+        mock_route = OpenStruct.new(name: route_name)
+        Katello::Engine.routes.router.stubs(:recognize).returns([mock_route, route_params])
+      end
+
+      before do
+        @controller.stubs(:authenticate).returns(true)
+        User.stubs(:consumer?).returns(false)
+      end
+
+      it "does not raise NoMethodError for user with view_organizations permission" do
+        user = User.find(users(:restricted).id)
+        user.organizations = [@organization]
+        user.save!
+        setup_user_with_permissions(:view_organizations, user)
+        User.current = user
+
+        stub_route_recognition("rhsm_proxy_owner_system_purpose_path")
+
+        result = nil
+        assert_nothing_raised do
+          result = @controller.send(:authorize_proxy_routes)
+        end
+        assert result, "User with view_organizations should be authorized"
+      end
+
+      it "returns false for user without view_organizations permission" do
+        user = User.find(users(:restricted).id)
+        user.organizations = [@organization]
+        user.save!
+        setup_user_with_permissions(:view_hosts, user)
+        User.current = user
+
+        stub_route_recognition("rhsm_proxy_owner_system_purpose_path")
+
+        result = @controller.send(:authorize_proxy_routes)
+        refute result, "User without view_organizations should not be authorized"
+      end
+    end
+
     describe "get content source id" do
       let(:hostname) { "content-source-test-#{SecureRandom.hex(8)}.example.com" }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Remove `self` parameter from `can?(:view_organizations, self)` calls in `authorize_proxy_routes`. Passing the controller instance caused `NoMethodError: undefined method 'allows_taxonomy_filtering?'` for non-admin users accessing RHSM owner endpoints.

#### Considerations taken when implementing this change?

The `can?` call without a resource argument performs a global permission check filtered by the user's taxonomy scope. This is appropriate for route-level authorization—organization-specific checks already happen in `find_organization`.

#### What are the testing steps for this pull request?

1. Create a non-admin user with `view_organizations` permission
2. Curl the endpoint:
   ```bash
   curl -sku "testuser:password" "https://$(hostname)/rhsm/owners/ORG_LABEL/system_purpose"
   ```
3. **Before fix:** 500 error with `allows_taxonomy_filtering?` NoMethodError
4. **After fix:** 200 OK response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened authorization for RHSM proxy owner endpoints to ensure correct access decisions when consumer parameters are not provided.

* **Tests**
  * Added controller tests for owner-scoped RHSM proxy authorization, confirming allowed and denied access scenarios behave as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->