### PR TITLE
fixes #39314 - ensure load balanced capsules have same data

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -141,6 +141,19 @@ module Katello
           .distinct
       end
 
+      def subscription_facets_for_sync
+        if load_balanced?
+          sibling_ids = self.class.behind_load_balancer(registration_host).pluck(:id)
+          ::Katello::Host::SubscriptionFacet.joins(:host => :content_facet)
+            .includes(:host)
+            .where('katello_content_facets.content_source_id IN (?)', sibling_ids) # matches host assigned to capsule behind load balancer.
+            .where.not('katello_subscription_facets.uuid' => nil)
+            .distinct
+        else
+          subscription_facets
+        end
+      end
+
       def registration_url
         url = self.setting('Registration', 'registration_url').presence || self.url
         URI(url)
@@ -257,7 +270,7 @@ module Katello
         end
 
         begin
-          facets = subscription_facets
+          facets = subscription_facets_for_sync
           if facets.exists?
             update_container_gateway_hosts(facets)
             update_host_container_repo_mapping(facets)

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -129,6 +129,22 @@ module Katello
       python_repo
     end
 
+    def setup_load_balanced_capsules
+      lb_url = 'loadbalancer.example.com'
+      @capsule1 = FactoryBot.create(:smart_proxy, :pulp_mirror, :url => 'http://capsule1.example.com:9090')
+      @capsule2 = FactoryBot.create(:smart_proxy, :pulp_mirror, :url => 'http://capsule2.example.com:9090')
+      @capsule1.lifecycle_environments << @library
+      @capsule2.lifecycle_environments << @library
+
+      cg_feature = Feature.find_or_create_by(:name => SmartProxy::CONTAINER_GATEWAY_FEATURE)
+      [@capsule1, @capsule2].each do |capsule|
+        capsule.features << cg_feature unless capsule.features.include?(cg_feature)
+        capsule.stubs(:load_balanced?).returns(true)
+        capsule.stubs(:registration_host).returns(lb_url)
+      end
+      SmartProxy.stubs(:behind_load_balancer).with(lb_url).returns(SmartProxy.where(id: [@capsule1.id, @capsule2.id]))
+    end
+
     # rubocop:disable Metrics/AbcSize
     def test_update_global_content_counts
       @proxy_mirror.features << ::Feature.find_by(name: ::SmartProxy::PULP3_FEATURE)
@@ -514,6 +530,32 @@ module Katello
       capsule_content.smart_proxy.sync_container_gateway
     end
 
+    def test_sync_container_gateway_with_load_balanced_hosts
+      setup_load_balanced_capsules
+      with_pulp3_features(@capsule2)
+
+      ::Katello::Resources::Candlepin::Consumer.stubs(:update)
+      host = FactoryBot.build(:host, :with_content, :with_subscription,
+                              :content_view => @view,
+                              :lifecycle_environment => @library)
+      host.content_facet.content_source = @capsule1
+      host.subscription_facet.uuid = 'test-uuid-123'
+      host.save!
+
+      ProxyAPI::ContainerGateway.any_instance.expects(:repository_list).returns(true)
+      update_hosts_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:update_hosts).with do |arg|
+        arg[:hosts].length == 1 && arg[:hosts].first[:uuid] == 'test-uuid-123'
+      end
+      update_hosts_expectation.returns(true)
+      host_mapping_expectation = ProxyAPI::ContainerGateway.any_instance.expects(:host_repository_mapping).with do |arg|
+        arg[:hosts].length == 1 && arg[:hosts].first.key?('test-uuid-123')
+      end
+      host_mapping_expectation.returns(true)
+
+      @capsule2.expects(:container_gateway_users).returns([])
+      @capsule2.sync_container_gateway
+    end
+
     def test_sync_container_gateway_skips_nil_uuid
       environment = katello_environments(:library)
       with_pulp3_features(capsule_content.smart_proxy)
@@ -563,6 +605,21 @@ module Katello
       update_repo_expectation.returns(true)
 
       @proxy.update_host_repositories(host)
+    end
+
+    def test_subscription_facets_for_sync_includes_sibling_hosts
+      setup_load_balanced_capsules
+
+      ::Katello::Resources::Candlepin::Consumer.stubs(:update)
+      host = FactoryBot.build(:host, :with_content, :with_subscription,
+                              :content_view => @view,
+                              :lifecycle_environment => @library)
+      host.content_facet.content_source = @capsule1
+      host.subscription_facet.uuid = '123'
+      host.save!
+
+      assert_equal 1, @capsule2.subscription_facets_for_sync.count
+      assert_equal '123', @capsule2.subscription_facets_for_sync.first.uuid
     end
 
     def test_update_host_repositories_with_nil_uuid


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
When we sync capsules, we do not sync authentication related data behind load balancer. This change fixes that by first checking if capsule is load balanced then gets all the siblings behind this load balancer. Then uses a different SQL query to match hosts assigned to capsule behind that load balancer. If capsule is not load balanced we fall back to the original check.

#### What are the testing steps for this pull request?
- Two new tests, that test behavior behind load balance setups
- load balance setup function in test file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved container gateway synchronization for smart proxies operating behind load balancers. The system now correctly determines subscription facets when smart proxies are load-balanced, ensuring proper facet scope across load-balanced instances.

* **Tests**
  * Added tests to verify container gateway synchronization behavior for load-balanced smart proxies and subscription facet scoping.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11740)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->