### PR TITLE
Fixes #39319 - Generic content pages are not scoped by organization

### DIFF
--- a/webpack/scenes/Content/ContentActions.js
+++ b/webpack/scenes/Content/ContentActions.js
@@ -1,11 +1,14 @@
 import { API_OPERATIONS, get } from 'foremanReact/redux/API';
-import api from '../../services/api';
+import api, { orgId } from '../../services/api';
 import { CONTENT_KEY, CONTENT_TYPES_KEY, CONTENT_ID_KEY, REPOSITORY_CONTENT_ID_KEY } from './ContentConstants';
 
 export const getContent = (contentType, params) => get({
   type: API_OPERATIONS.GET,
   key: CONTENT_KEY,
-  params,
+  params: {
+    ...params,
+    organization_id: orgId(),
+  },
   url: api.getApiUrl(`/${contentType}`),
 });
 
@@ -18,13 +21,19 @@ export const getContentTypes = () => get({
 export const getContentDetails = (contentType, id) => get({
   type: API_OPERATIONS.GET,
   key: CONTENT_ID_KEY,
+  params: {
+    organization_id: orgId(),
+  },
   url: api.getApiUrl(`/${contentType}/${id}`),
 });
 
 export const getRepositoryContentDetails = (contentType, id, params) => get({
   type: API_OPERATIONS.GET,
   key: REPOSITORY_CONTENT_ID_KEY,
-  params,
+  params: {
+    ...params,
+    organization_id: orgId(),
+  },
   url: api.getApiUrl(`/repositories?${contentType}_id=${id}`),
 });
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pass org_id as params on Generic content pages.
#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?
1. Create a new organization
2. Create some ansible collection, python repos and sync in Default and the new org
3. Go to Content Types > Other content types
4. Verify that you only see content belonging to organization selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Content fetches are now properly scoped to the user's organization, preventing cross-organization results.
  * Repository content and content-details requests now respect organization scoping so users see only relevant data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11742?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->