### PR TITLE
Fixes #39322 - Extend valid controller list

### DIFF
--- a/app/lib/katello/concerns/bookmark_controller_validator_extensions.rb
+++ b/app/lib/katello/concerns/bookmark_controller_validator_extensions.rb
@@ -1,12 +1,14 @@
 module Katello
   module Concerns
     module BookmarkControllerValidatorExtensions
-      extend ActiveSupport::Concern
+      KATELLO_CONTROLLERS = %w[
+        /katello/api/v2/host_bootc_images
+        /katello/api/v2/flatpak_remotes
+        /katello/api/v2/flatpak_remote_repositories
+      ].freeze
 
       def valid_controllers_list
-        @valid_controllers_list ||= (["dashboard", "common_parameters", "/katello/api/v2/host_bootc_images", "/katello/api/v2/flatpak_remotes", "/katello/api/v2/flatpak_remote_repositories"] +
-          ActiveRecord::Base.connection.tables.map(&:to_s) +
-          Permission.resources.map(&:tableize)).uniq
+        super + KATELLO_CONTROLLERS
       end
     end
   end

--- a/test/lib/validators/bookmark_controller_validator_extensions_test.rb
+++ b/test/lib/validators/bookmark_controller_validator_extensions_test.rb
@@ -1,0 +1,15 @@
+require 'katello_test_helper'
+
+module Katello
+  class BookmarkControllerValidatorExtensionsTest < ActiveSupport::TestCase
+    Katello::Concerns::BookmarkControllerValidatorExtensions::KATELLO_CONTROLLERS.each do |controller|
+      test "#{controller} should be a valid bookmark controller" do
+        bookmark = FactoryBot.build_stubbed(:bookmark, :name => "#{controller} bookmark",
+                                                       :controller => controller,
+                                                       :query => 'search query',
+                                                       :public => true)
+        assert bookmark.valid?, "#{controller} should be a valid bookmark controller, errors: #{bookmark.errors.full_messages}"
+      end
+    end
+  end
+end


### PR DESCRIPTION

#### What are the changes introduced in this pull request?

Previously, the extension overrode whatever Foreman was shipping, which prevented other plugins from applying their own modifications.

#### Considerations taken when implementing this change?

Following the general pattern where plugins can extend core but shouldn't hard-override it.

#### What are the testing steps for this pull request?

- Try saving bookmarks for host bootc images, flatpak remotes and flatpak remote repositories
- The tests here and PRT in https://github.com/SatelliteQE/robottelo/pull/21539 should pass

Also see https://github.com/theforeman/foreman_openscap/pull/610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured bookmark validation logic to improve code organization, clarity, and long-term maintainability of the validation system.

* **Tests**
  * Added comprehensive automated test coverage for bookmark validation across all supported controller types and configurations, ensuring proper validation behavior and error handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11743)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->