### PR TITLE
Fixes #39326 - Add severity to applied errata report

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -252,7 +252,7 @@ module Katello
           seen_host_ids &= only_host_ids if only_host_ids
 
           # preload errata in one query for this batch
-          preloaded_errata = Katello::Erratum.where(:errata_id => seen_errata_ids).pluck(:errata_id, :errata_type, :issued)
+          preloaded_errata = Katello::Erratum.where(:errata_id => seen_errata_ids).pluck(:errata_id, :errata_type, :issued, :severity)
           preloaded_hosts = ::Host.where(:id => seen_host_ids).includes(:reported_data)
 
           batch.each do |task|
@@ -262,7 +262,8 @@ module Katello
               current_erratum = preloaded_errata.find { |k, _| k == erratum_id }
               next if current_erratum.nil?
               current_erratum_errata_type = current_erratum[1]
-              current_erratum_issued = current_erratum.last
+              current_erratum_issued = current_erratum[2]
+              current_erratum_severity = current_erratum[3]
 
               if filter_errata_type != 'all' && !(filter_errata_type == current_erratum_errata_type)
                 next
@@ -274,6 +275,7 @@ module Katello
                 :erratum_id => erratum_id,
                 :erratum_type => current_erratum_errata_type,
                 :issued => current_erratum_issued,
+                :severity => current_erratum_severity,
                 :status => task.result,
               }
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
This PR is the Katello portion of the changes introduced in https://github.com/theforeman/foreman/pull/10985. Both PRs will need to be checked out at the same time for testing.

#### Considerations taken when implementing this change?
None I can think of. Should we let users filter by severity in the report options? I didn't think it was necessary, personally.

#### What are the testing steps for this pull request?

1. Register a host to your Foreman/Katello server.
2. Create and sync the "Needed Errata" product (https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/). Add this product to your host's content view and publish to the active lifecycle environment.
3. On the host, install walrus 0.71 using dnf install walrus-0.71. This is an outdated version of walrus which has one installable erratum.
4. Using the rails console, modify the erratum's severity to a severity you'd like to test with: Katello::Erratum.find_by(errata_id: 'RHEA-2012:0055').update!(severity: 'Important')
5. In Monitor -> Reports -> Report Templates, generate a "Host - Available Errata" report using the "Installable errata" option. The erratum should show up with the new severity.
6. Apply the erratum. Walrus will have updated to the newest version on the host.
7. Generate a "Host - Applied Errata" report. Make sure to modify the "Since" field to a date well before the erratum was created (I used 2000). The status will populate in the generated CSV.
8. Test with multiple hosts with multiple errata of different severity. Try the null case without severity. Try some of these:
    - "Critical"
    - "Low"
    - "None"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced errata data retrieval to now include severity information alongside other update details, providing complete visibility into update priorities and impact assessment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11744)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->