### PR TITLE
Fixes #39328 - Add macro for fetching activation_key_names

### DIFF
--- a/app/lib/katello/concerns/base_template_scope_extensions.rb
+++ b/app/lib/katello/concerns/base_template_scope_extensions.rb
@@ -118,6 +118,14 @@ module Katello
         host_subscription_facet(host)&.registered_at
       end
 
+      apipie :method, 'Returns activation key names associated with the host' do
+        required :host, 'Host::Managed', desc: 'Host object to get activation key names for'
+        returns array_of: String, desc: 'Activation key names used to register the host'
+      end
+      def activation_key_names(host)
+        host_subscription_facet(host)&.activation_key_names || []
+      end
+
       apipie :method, 'Returns IDs of the applicable errata on the host' do
         required :host, 'Host::Managed', desc: 'Host object to get the applicable errata for'
         returns array_of: Integer, desc: 'Array with applicable errata IDs of the host'


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Added a new macro called activation_key_names that, if used correctly, would help to extract the names of activation keys used to register a content host. 

If more than one key was used, then the key names are printed in comma-separated values. 

#### Considerations taken when implementing this change?

While we expose subscription_facet and allow rendering registered_at\through and last_checkin, we don't have any macro that exposes the activation key names, used to register a system, and users are demanding the same.

We already have host_subscription_facet macro present in https://github.com/Katello/katello/blob/master/app/lib/katello/concerns/base_template_scope_extensions.rb#L316-L318 i.e.

```
      def host_subscription_facet(host)
        host.subscription_facet
      end
```

We needed to simply do `host_subscription_facet(host)&.activation_keys&.map(&:name)` to get the activation key names associated with a registered content host.


#### What are the testing steps for this pull request?

* Apply the changes from this PR on a centos9-katello-devel env. 
* Register a system with that katello server , using an activation key.
* Clone the last_checking report template in UI, to a new name, and make it look something like this:

~~~
<%- include_unknown_search = input('Include unknown') == 'true' ? ' or null? last_checkin' : '' %>
<%- search += "and #{input('Host filter')}" if input('Host filter').present? -%>
<%- report_headers('Name', 'IP', 'IPv6', 'Last Checkin', 'Registered through', 'AK') -%>
<%- load_hosts(search: search, preload: [ :subscription_facet, :interfaces ]).each_record do |host| -%>
<%-   report_row(
        'Name': host.name,
        'IP': host.ip,
        'IPv6': host.ip6,
        'Last Checkin': last_checkin(host).to_s,
        'Registered through': registered_through(host),
        'AK': activation_key_names(host),
      ) -%>
<%- end -%>
<%= report_render order: 'Last Checkin' -%>
~~~

( make sure that you don't have this line there `<%- search = "(last_checkin < \"#{input('Interval')} ago\"#{include_unknown_search})" -%>` )

* Now try doing either a preview of this template or else simply generate a csv\html\json report to see how it behaves. 

I would expect the AK fields to get populated with right activation key names. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can now access activation key names for hosts, allowing template authors to reference host activation keys during configuration and deployment.
  * Safely handles hosts without activation keys by returning an empty result, avoiding errors when keys are absent.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11745?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->