### PR TITLE
Bump master to 5.0.0-develop

### DIFF
--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.21.0-master".freeze
+  VERSION = "5.0.0-master".freeze
 end


### PR DESCRIPTION
Version bump after KATELLO-4.21 branching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Version number updated to 4.22.0-master

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11747)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->