### PR TITLE
Fixes #39325 - Migrate RedHatRepositories from pf3 to pf5

### DIFF
--- a/webpack/components/MultiSelect/MultiSelect.scss
+++ b/webpack/components/MultiSelect/MultiSelect.scss
@@ -1,0 +1,4 @@
+.pf-multiselect-scrollable-menu {
+  max-height: 75vh;
+  overflow-y: auto;
+}

--- a/webpack/components/MultiSelect/index.js
+++ b/webpack/components/MultiSelect/index.js
@@ -1,47 +1,203 @@
-import React from 'react';
+import React, { useState, useRef, useMemo, useCallback, memo } from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { FormGroup, ControlLabel } from 'react-bootstrap';
-import BootstrapSelect from '../../components/react-bootstrap-select';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Popper,
+  Badge,
+  MenuSearch,
+  SearchInput,
+  Divider,
+  Spinner,
+} from '@patternfly/react-core';
+import './MultiSelect.scss';
+
+// Memoized menu item to prevent re-renders when other items change
+const MemoizedMenuItem = memo(({
+  itemId, isSelected, label,
+}) => (
+  <MenuItem
+    itemId={itemId}
+    hasCheckbox
+    isSelected={isSelected}
+  >
+    {label}
+  </MenuItem>
+));
+
+MemoizedMenuItem.propTypes = {
+  itemId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  isSelected: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+};
 
 function MultiSelect(props) {
   const {
     options,
     onChange,
     defaultValues,
-    ...otherProps
+    noneSelectedText,
+    maxItemsCountForFullLabel,
+    className,
+    ouiaId,
+    isLoading,
+    searchable,
   } = props;
 
-  const optionComponents = options.map(option => (
-    <option key={`option-${option.value}`} value={option.value}>
-      {option.label}
-    </option>
-  ));
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState(defaultValues || []);
+  const [searchValue, setSearchValue] = useState('');
+  const toggleRef = useRef(null);
+  const menuRef = useRef(null);
+  const searchInputRef = useRef(null);
+
+  const handleSelect = useCallback((_event, value) => {
+    let newSelected;
+    setSelected((prevSelected) => {
+      newSelected = prevSelected.includes(value)
+        ? prevSelected.filter(item => item !== value)
+        : [...prevSelected, value];
+      return newSelected;
+    });
+    setTimeout(() => onChange(newSelected), 0);
+  }, [onChange]);
+
+  const handleSearchChange = useCallback((_event, value) => {
+    setSearchValue(value);
+  }, []);
+
+  // Memoize filtered options to prevent recalculation on every render
+  const filteredOptions = useMemo(() => {
+    if (!searchable || !searchValue) return options;
+    const lowerSearch = searchValue.toLowerCase();
+    return options.filter(option =>
+      option.label.toLowerCase().includes(lowerSearch));
+  }, [options, searchValue, searchable]);
+
+  // Memoize toggle display text calculation
+  const toggleText = useMemo(() => {
+    if (selected.length === 0 || selected.length > maxItemsCountForFullLabel) {
+      return noneSelectedText;
+    }
+    // Show individual labels when count is low
+    const labels = selected.map((val) => {
+      const option = options.find(opt => opt.value === val);
+      return option ? option.label : val;
+    });
+    return labels.join(', ');
+  }, [selected, options, maxItemsCountForFullLabel, noneSelectedText]);
+
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+      isFullWidth
+      isDisabled={isLoading}
+      {...(selected.length > 0 && {
+        badge: selected.length > maxItemsCountForFullLabel ? (
+          <Badge isRead>{selected.length}</Badge>
+        ) : null,
+      })}
+      ouiaId={ouiaId}
+      icon={isLoading ? <Spinner size="md" /> : null}
+    >
+      {isLoading ? __('Loading...') : toggleText}
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu
+      ref={menuRef}
+      onSelect={handleSelect}
+      selected={selected}
+      ouiaId={`${ouiaId}-menu`}
+      className="pf-multiselect-scrollable-menu"
+    >
+      {searchable && (
+        <>
+          <MenuSearch>
+            <SearchInput
+              ref={searchInputRef}
+              value={searchValue}
+              onChange={handleSearchChange}
+              placeholder={__('Search')}
+              aria-label={__('Search')}
+            />
+          </MenuSearch>
+          <Divider />
+        </>
+      )}
+      <MenuContent>
+        <MenuList>
+          {filteredOptions.length === 0 ? (
+            <MenuItem isDisabled>{__('No results found')}</MenuItem>
+          ) : (
+            filteredOptions.map(option => (
+              <MemoizedMenuItem
+                key={`option-${option.value}`}
+                itemId={option.value}
+                isSelected={selected.includes(option.value)}
+                label={option.label}
+              />
+            ))
+          )}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
 
   return (
-    <FormGroup controlId="formControlsSelectMultiple">
-      <ControlLabel srOnly>{__('Select Value')}</ControlLabel>
-      <BootstrapSelect
-        defaultValues={defaultValues}
-        {...otherProps}
-        multiple
-        onChange={evt => onChange(evt)}
-      >
-        {optionComponents}
-      </BootstrapSelect>
-    </FormGroup>
+    <div className={className}>
+      <Popper
+        trigger={toggle}
+        popper={menu}
+        isVisible={isOpen}
+        appendTo={() => document.body}
+        popperMatchesTriggerWidth={false}
+        onDocumentClick={(event) => {
+          if (
+            toggleRef.current &&
+            !toggleRef.current.contains(event.target) &&
+            menuRef.current &&
+            !menuRef.current.contains(event.target)
+          ) {
+            setIsOpen(false);
+          }
+        }}
+      />
+    </div>
   );
 }
 
 MultiSelect.defaultProps = {
   onChange: () => { },
   defaultValues: null,
+  noneSelectedText: __('Nothing selected'),
+  maxItemsCountForFullLabel: 3,
+  className: '',
+  ouiaId: undefined,
+  isLoading: false,
+  searchable: false,
 };
 
 MultiSelect.propTypes = {
-  options: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    label: PropTypes.string.isRequired,
+  })).isRequired,
   onChange: PropTypes.func,
-  defaultValues: PropTypes.arrayOf(PropTypes.string),
+  defaultValues: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  noneSelectedText: PropTypes.string,
+  maxItemsCountForFullLabel: PropTypes.number,
+  className: PropTypes.string,
+  ouiaId: PropTypes.string,
+  isLoading: PropTypes.bool,
+  searchable: PropTypes.bool,
 };
 
 export default MultiSelect;

--- a/webpack/redux/OrganizationProducts/OrganizationProductsSelectors.js
+++ b/webpack/redux/OrganizationProducts/OrganizationProductsSelectors.js
@@ -5,3 +5,6 @@ export const selectOrganizationProductsState = state =>
 
 export const selectOrganizationProducts = state =>
   selectOrganizationProductsState(state).results;
+
+export const selectOrganizationProductsLoading = state =>
+  selectOrganizationProductsState(state).loading;

--- a/webpack/scenes/RedHatRepositories/RedHatRepositoriesPage.js
+++ b/webpack/scenes/RedHatRepositories/RedHatRepositoriesPage.js
@@ -5,9 +5,8 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
-import { Grid, Row, Col } from 'react-bootstrap';
-import { Skeleton, Alert } from '@patternfly/react-core';
-import { Button, FieldLevelHelp } from 'patternfly-react';
+import { Grid, GridItem, Skeleton, Alert, Button, Popover } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import PermissionDenied from 'foremanReact/components/PermissionDenied';
 import { LoadingState } from '../../components/LoadingState';
@@ -46,10 +45,10 @@ const RedHatRepositoriesPage = ({
   }
   if (organization.cdn_configuration.type === EXPORT_SYNC) {
     return (
-      <Grid id="redhatRepositoriesPage" bsClass="container-fluid">
+      <div id="redhatRepositoriesPage">
         <h1>{__('Red Hat Repositories')}</h1>
-        <Row className="toolbar-pf">
-          <Col>
+        <Grid hasGutter>
+          <GridItem span={12}>
             <Alert
               ouiaId="repo-sets-alert"
               variant="info"
@@ -57,23 +56,23 @@ const RedHatRepositoriesPage = ({
               isInline
               title={__('CDN configuration is set to Export Sync (disconnected). Repository enablement/disablement is not permitted on this page.')}
             />
-          </Col>
-        </Row>
-      </Grid>
+          </GridItem>
+        </Grid>
+      </div>
     );
   }
 
   return (
-    <Grid id="redhatRepositoriesPage" bsClass="container-fluid">
+    <div id="redhatRepositoriesPage">
       <h1>{__('Red Hat Repositories')}</h1>
-      <Row className="toolbar-pf">
-        <Col sm={12}>
+      <Grid hasGutter>
+        <GridItem md={6}>
           <SearchBar />
-        </Col>
-      </Row>
+        </GridItem>
+      </Grid>
 
-      <Row className="row-eq-height">
-        <Col sm={6} className="available-repositories-container">
+      <Grid>
+        <GridItem md={6} className="available-repositories-container">
           <div className="available-repositories-header">
             <h2>{__('Available Repositories')}</h2>
             <RecommendedRepositorySetsToggler
@@ -93,20 +92,33 @@ const RedHatRepositoriesPage = ({
               },
             )}
           </LoadingState>
-        </Col>
+        </GridItem>
 
-        <Col sm={6} className="enabled-repositories-container">
-          <h2>
-            {__('Enabled Repositories')}
-            <FieldLevelHelp content={__('Only repositories not published in a content view can be disabled. Published repositories must be deleted from the repository details page.')} />
-            <Button
-              ouiaid="export-csv-button"
-              className="pull-right"
-              onClick={() => { api.open('/repositories.csv', repoParams); }}
-            >
-              {__('Export as CSV')}
-            </Button>
-          </h2>
+        <GridItem md={6} className="enabled-repositories-container">
+          <div className="enabled-repositories-header">
+            <h2>
+              {__('Enabled Repositories')}
+              <Popover bodyContent={__('Only repositories not published in a content view can be disabled. Published repositories must be deleted from the repository details page.')}>
+                <Button
+                  variant="plain"
+                  aria-label={__('Help')}
+                  ouiaId="enabled-repos-help-button"
+                  className="help-button-plain"
+                >
+                  <InfoCircleIcon />
+                </Button>
+              </Popover>
+              <Button
+                ouiaId="export-csv-button"
+                variant="tertiary"
+                size="sm"
+                onClick={() => { api.open('/repositories.csv', repoParams); }}
+                className="export-csv-button"
+              >
+                {__('Export as CSV')}
+              </Button>
+            </h2>
+          </div>
 
           <LoadingState loading={enabledRepositories.loading} loadingText={__('Loading')}>
             {getEnabledComponent(
@@ -119,9 +131,9 @@ const RedHatRepositoriesPage = ({
               },
             )}
           </LoadingState>
-        </Col>
-      </Row>
-    </Grid>
+        </GridItem>
+      </Grid>
+    </div>
   );
 };
 

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepository.js
@@ -1,89 +1,103 @@
-import React, { Component } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { ListView } from 'patternfly-react';
+import {
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  DataListAction,
+} from '@patternfly/react-core';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
 import RepositoryTypeIcon from '../RepositoryTypeIcon';
-
 import EnabledRepositoryContent from './EnabledRepositoryContent';
 
-class EnabledRepository extends Component {
-  constructor(props) {
-    super(props);
-    this.disableTooltipId = `disable-${props.id}`;
-  }
+const EnabledRepository = ({
+  id,
+  contentId,
+  productId,
+  label,
+  name,
+  type,
+  arch,
+  releasever,
+  orphaned,
+  canDisable,
+  loading,
+  search,
+  pagination,
+  setRepositoryDisabled,
+  loadEnabledRepos,
+  disableRepository,
+}) => {
+  const repoForAction = useCallback(() => ({
+    id,
+    contentId,
+    productId,
+    name,
+    type,
+    arch,
+    releasever,
+  }), [id, contentId, productId, name, type, arch, releasever]);
 
-  setDisabled = () => {
-    this.props.setRepositoryDisabled(this.repoForAction());
-  };
-
-  repoForAction = () => {
-    const {
-      id, productId, contentId, arch, releasever, name, type,
-    } = this.props;
-
-    return {
-      id,
-      contentId,
-      productId,
-      name,
-      type,
-      arch,
-      releasever,
-    };
-  };
-
-  reload = () => (
-    this.props.loadEnabledRepos({
-      ...this.props.pagination,
-      search: this.props.search,
+  const reload = useCallback(() => (
+    loadEnabledRepos({
+      ...pagination,
+      search,
     }, true)
-  );
+  ), [loadEnabledRepos, pagination, search]);
 
-  notifyDisabled = () => {
+  const notifyDisabled = useCallback(() => {
     window.tfm.toastNotifications.notify({
-      message: sprintf(__("Repository '%(repoName)s' has been disabled."), { repoName: this.props.name }),
+      message: sprintf(__("Repository '%(repoName)s' has been disabled."), { repoName: name }),
       type: 'success',
     });
-  };
+  }, [name]);
 
-  reloadAndNotify = async (result) => {
+  const reloadAndNotify = useCallback(async (result) => {
     if (result && result.success) {
-      await this.reload();
-      await this.setDisabled();
-      await this.notifyDisabled();
+      await reload();
+      await setRepositoryDisabled(repoForAction());
+      await notifyDisabled();
     }
-  };
+  }, [reload, setRepositoryDisabled, repoForAction, notifyDisabled]);
 
-  disableRepository = async () => {
-    const result = await this.props.disableRepository(this.repoForAction());
-    this.reloadAndNotify(result);
-  };
+  const handleDisableRepository = useCallback(async () => {
+    const result = await disableRepository(repoForAction());
+    await reloadAndNotify(result);
+  }, [disableRepository, repoForAction, reloadAndNotify]);
 
-  render() {
-    const {
-      name, id, type, orphaned, label, canDisable,
-    } = this.props;
+  const heading = `${name} ${orphaned ? __('(Orphaned)') : ''}`;
 
-    return (
-      <ListView.Item
-        key={id}
-        actions={
+  return (
+    <DataListItem key={id} aria-labelledby={`enabled-repo-${id}`}>
+      <DataListItemRow className="repository-item-row">
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="icon" className="repository-cell-icon">
+              <div className="repository-icon-badge repository-icon-badge-green">
+                <RepositoryTypeIcon type={type} />
+              </div>
+            </DataListCell>,
+            <DataListCell key="content" className="repository-cell-content">
+              <div id={`enabled-repo-${id}`} className="repository-name">
+                {heading}
+              </div>
+              <div className="repository-label">{label}</div>
+            </DataListCell>,
+          ]}
+        />
+        <DataListAction>
           <EnabledRepositoryContent
-            loading={this.props.loading}
-            disableTooltipId={this.disableTooltipId}
-            disableRepository={this.disableRepository}
+            loading={loading}
+            disableRepository={handleDisableRepository}
             canDisable={canDisable}
           />
-        }
-        leftContent={<RepositoryTypeIcon id={id} type={type} />}
-        heading={`${name} ${orphaned ? __('(Orphaned)') : ''}`}
-        description={label}
-        stacked
-      />
-    );
-  }
-}
+        </DataListAction>
+      </DataListItemRow>
+    </DataListItem>
+  );
+};
 
 EnabledRepository.propTypes = {
   id: PropTypes.number.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepositoryContent.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/EnabledRepositoryContent.js
@@ -1,42 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
-import { Spinner, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Spinner, Tooltip, Button } from '@patternfly/react-core';
+import { MinusCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 
 const EnabledRepositoryContent = ({
-  loading, disableTooltipId, disableRepository, canDisable,
-}) => (
-  <Spinner loading={loading} inline>
-    <OverlayTrigger
-      overlay={<Tooltip id={disableTooltipId}>{canDisable ? __('Disable') : __('Cannot be disabled because it is part of a content view')}</Tooltip>}
-      placement="bottom"
-      trigger={['hover', 'focus']}
-      rootClose={false}
-    >
-      <button
-        onClick={disableRepository}
-        style={canDisable ? {
-          backgroundColor: 'initial',
-          border: 'none',
-          color: '#0388ce',
-        } : {
-          backgroundColor: 'initial',
-          border: 'none',
-          color: '#d2d2d2',
-        }
-      }
-        disabled={!canDisable}
+  loading, disableRepository, canDisable,
+}) => {
+  if (loading) {
+    return <Spinner size="md" />;
+  }
+
+  const tooltipContent = canDisable
+    ? __('Disable')
+    : __('Cannot be disabled because it is part of a content view');
+
+  return (
+    <Tooltip content={tooltipContent} position="bottom">
+      <Button
+        variant="plain"
+        onClick={canDisable ? disableRepository : undefined}
+        isAriaDisabled={!canDisable}
+        aria-label={canDisable ? __('Disable') : __('Cannot be disabled')}
+        ouiaId="disable-repository-button"
+        className="disable-repository-button"
       >
-        <i className={cx('fa-2x', 'fa fa-minus-circle')} />
-      </button>
-    </OverlayTrigger>
-  </Spinner>
-);
+        <MinusCircleIcon />
+      </Button>
+    </Tooltip>
+  );
+};
 
 EnabledRepositoryContent.propTypes = {
   loading: PropTypes.bool.isRequired,
-  disableTooltipId: PropTypes.string.isRequired,
   disableRepository: PropTypes.func.isRequired,
   canDisable: PropTypes.bool.isRequired,
 };

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepository.test.js
@@ -126,20 +126,20 @@ describe('EnabledRepository Component', () => {
     const props = getBaseProps(enabledRepoFixtures[0]); // deletable: true
     const { container } = renderWithRedux(<EnabledRepository {...props} />, getInitialState());
 
-    // For legacy PatternFly v3 button with icon
+    // For PatternFly v5 button with aria-disabled
     const disableButton = container.querySelector('button');
     expect(disableButton).toBeInTheDocument();
-    expect(disableButton).not.toBeDisabled();
+    expect(disableButton).toHaveAttribute('aria-disabled', 'false');
   });
 
   test('renders disabled button when repository cannot be disabled', () => {
     const props = getBaseProps(enabledRepoFixtures[1]); // deletable: false (in content view)
     const { container } = renderWithRedux(<EnabledRepository {...props} />, getInitialState());
 
-    // For legacy PatternFly v3 button with icon
+    // For PatternFly v5 button with aria-disabled
     const disableButton = container.querySelector('button');
     expect(disableButton).toBeInTheDocument();
-    expect(disableButton).toBeDisabled();
+    expect(disableButton).toHaveAttribute('aria-disabled', 'true');
   });
 
   test('disables repository via API when disable button is clicked', async () => {

--- a/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepositoryContent.test.js
+++ b/webpack/scenes/RedHatRepositories/components/EnabledRepository/__tests__/EnabledRepositoryContent.test.js
@@ -13,13 +13,12 @@ describe('Enabled Repositories Content Component', () => {
 
   describe('rendering', () => {
     test('renders without errors when enabled', () => {
-      const { container } = render(<EnabledRepositoryContent {...getBaseProps()} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<EnabledRepositoryContent {...getBaseProps()} />);
 
-      // For legacy PatternFly v3 button
-      const button = container.querySelector('button');
+      // Verify button is rendered and enabled (aria-disabled="false")
+      const button = getByLabelText('Disable');
       expect(button).toBeInTheDocument();
-      expect(button).not.toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'false');
     });
 
     test('renders disabled state when canDisable is false', () => {
@@ -27,12 +26,12 @@ describe('Enabled Repositories Content Component', () => {
         ...getBaseProps(),
         canDisable: false,
       };
-      const { container } = render(<EnabledRepositoryContent {...props} />);
+      const { getByLabelText } = render(<EnabledRepositoryContent {...props} />);
 
-      // For legacy PatternFly v3 button
-      const button = container.querySelector('button');
+      // Verify button is rendered and aria-disabled
+      const button = getByLabelText('Cannot be disabled');
       expect(button).toBeInTheDocument();
-      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-disabled', 'true');
     });
 
     test('renders loading spinner when loading', () => {
@@ -40,16 +39,26 @@ describe('Enabled Repositories Content Component', () => {
         ...getBaseProps(),
         loading: true,
       };
-      const { container } = render(<EnabledRepositoryContent {...props} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { container, queryByLabelText } = render(<EnabledRepositoryContent {...props} />);
+
+      // Verify spinner is shown (check for pf-v5-c-spinner class)
+      const spinner = container.querySelector('.pf-v5-c-spinner');
+      expect(spinner).toBeInTheDocument();
+
+      // Verify button is not shown
+      expect(queryByLabelText('Disable')).not.toBeInTheDocument();
     });
 
     test('renders minus circle icon', () => {
-      const { container } = render(<EnabledRepositoryContent {...getBaseProps()} />);
+      const { getByLabelText } = render(<EnabledRepositoryContent {...getBaseProps()} />);
 
-      // For legacy PatternFly v3 icon with aria-hidden
-      const icon = container.querySelector('.fa-minus-circle');
-      expect(icon).toBeInTheDocument();
+      // Verify button with icon is rendered
+      const button = getByLabelText('Disable');
+      expect(button).toBeInTheDocument();
+
+      // Verify the button contains an SVG icon
+      const svg = button.querySelector('svg');
+      expect(svg).toBeInTheDocument();
     });
   });
 
@@ -61,12 +70,11 @@ describe('Enabled Repositories Content Component', () => {
         disableRepository: mockCallback,
         canDisable: true,
       };
-      const { container } = render(<EnabledRepositoryContent {...props} />);
+      const { getByLabelText } = render(<EnabledRepositoryContent {...props} />);
 
       expect(mockCallback).not.toHaveBeenCalled();
 
-      // For legacy PatternFly v3 button
-      const button = container.querySelector('button');
+      const button = getByLabelText('Disable');
       fireEvent.click(button);
 
       expect(mockCallback).toHaveBeenCalled();
@@ -79,32 +87,26 @@ describe('Enabled Repositories Content Component', () => {
         disableRepository: mockCallback,
         canDisable: false,
       };
-      const { container } = render(<EnabledRepositoryContent {...props} />);
+      const { getByLabelText } = render(<EnabledRepositoryContent {...props} />);
 
-      // For legacy PatternFly v3 button
-      const button = container.querySelector('button');
+      const button = getByLabelText('Cannot be disabled');
       fireEvent.click(button);
 
       // Button is disabled, so onClick shouldn't fire
       expect(mockCallback).not.toHaveBeenCalled();
     });
 
-    test('does not call disableRepository when loading', () => {
+    test('does not render button when loading', () => {
       const mockCallback = jest.fn();
       const props = {
         ...getBaseProps(),
         disableRepository: mockCallback,
         loading: true,
       };
-      const { container } = render(<EnabledRepositoryContent {...props} />);
+      const { queryByLabelText } = render(<EnabledRepositoryContent {...props} />);
 
-      // For legacy PatternFly v3 - button still exists but Spinner may affect behavior
-      const button = container.querySelector('button');
-      if (button) {
-        fireEvent.click(button);
-      }
-
-      // Component is loading, callback shouldn't be triggered
+      // Button doesn't exist when loading
+      expect(queryByLabelText('Disable')).not.toBeInTheDocument();
       expect(mockCallback).not.toHaveBeenCalled();
     });
   });

--- a/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.js
+++ b/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { translate as __ } from 'foremanReact/common/I18n';
-import { Switch, Icon, FieldLevelHelp } from 'patternfly-react';
+import { Switch, Popover, Button } from '@patternfly/react-core';
+import { StarIcon, InfoCircleIcon } from '@patternfly/react-icons';
 
 import './RecommendedRepositorySetsToggler.scss';
 
@@ -19,13 +20,24 @@ const RecommendedRepositorySetsToggler = ({
   return (
     <div className={classes} {...props}>
       <Switch
-        bsSize="mini"
-        value={enabled}
-        onChange={() => onChange(!enabled)}
+        id="recommended-repos-switch"
+        aria-label={__('Recommended repositories toggle')}
+        ouiaId="recommended-repos-switch"
+        isChecked={enabled}
+        onChange={(_event, checked) => onChange(checked)}
       />
-      <Icon type="fa" name="star" />
+      <StarIcon />
       {children}
-      <FieldLevelHelp content={help} />
+      <Popover bodyContent={help}>
+        <Button
+          variant="plain"
+          aria-label={__('Help')}
+          ouiaId="recommended-repos-help-button"
+          className="recommended-repos-help-button"
+        >
+          <InfoCircleIcon />
+        </Button>
+      </Popover>
     </div>
   );
 };

--- a/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.scss
+++ b/webpack/scenes/RedHatRepositories/components/RecommendedRepositorySetsToggler.scss
@@ -1,16 +1,16 @@
 @import "foremanReact/common/variables";
 
 .recommended-repositories-toggler-container {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 
-  > * {
-    margin: 0 3px;
+  // Style only the StarIcon (not the question icon)
+  > svg {
+    color: var(--pf-v5-global--warning-color--100);
+  }
 
-    &.fa.fa-star {
-      color: $color-pf-gold-300;
-    }
-
-    &:last-child {
-      margin: 0;
-    }
+  .recommended-repos-help-button {
+    padding: 0.25rem 0 0 0;
   }
 }

--- a/webpack/scenes/RedHatRepositories/components/RepositorySet.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySet.js
@@ -1,6 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { ListView, Icon } from 'patternfly-react';
+import {
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  DataListToggle,
+  DataListContent,
+  DataListAction,
+} from '@patternfly/react-core';
+import { StarIcon } from '@patternfly/react-icons';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
 import RepositoryTypeIcon from './RepositoryTypeIcon';
 // eslint-disable-next-line import/no-named-as-default
@@ -8,20 +18,65 @@ import RepositorySetRepositories from './RepositorySetRepositories';
 
 const RepositorySet = ({
   type, id, name, label, product, recommended,
-}) => (
-  <ListView.Item
-    id={id}
-    className="listViewItem--listItemVariants"
-    description={label}
-    heading={name}
-    leftContent={<RepositoryTypeIcon id={id} type={type} />}
-    stacked
-    actions={recommended ? <Icon type="fa" name="star" className="recommended-repository-set-icon" /> : ''}
-    hideCloseIcon
-  >
-    <RepositorySetRepositories contentId={id} productId={product.id} type={type} label={label} />
-  </ListView.Item>
-);
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <DataListItem
+      aria-labelledby={`repository-set-${id}`}
+      isExpanded={isExpanded}
+      className={isExpanded ? 'repository-set-expanded' : ''}
+    >
+      <DataListItemRow
+        className="repository-item-row"
+        onClick={() => setIsExpanded(!isExpanded)}
+        style={{ cursor: 'pointer' }}
+      >
+        <DataListToggle
+          isExpanded={isExpanded}
+          id={`toggle-${id}`}
+          aria-controls={`expand-${id}`}
+          className="repository-toggle-control"
+        />
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="icon" className="repository-cell-icon">
+              <div className="repository-icon-badge repository-icon-badge-blue">
+                <RepositoryTypeIcon type={type} />
+              </div>
+            </DataListCell>,
+            <DataListCell key="content" className="repository-cell-content">
+              <div id={`repository-set-${id}`} className="repository-name">
+                {name}
+              </div>
+              <div className="repository-label">{label}</div>
+            </DataListCell>,
+          ]}
+        />
+        {recommended && (
+          <DataListAction>
+            <StarIcon className="recommended-repository-set-icon" aria-hidden="true" />
+          </DataListAction>
+        )}
+      </DataListItemRow>
+      {isExpanded && (
+        <DataListContent
+          aria-label={sprintf(__('Details for %s'), name)}
+          id={`expand-${id}`}
+          isHidden={false}
+          className="repository-expandable-content"
+        >
+          <RepositorySetRepositories
+            contentId={id}
+            productId={product.id}
+            type={type}
+            label={label}
+          />
+        </DataListContent>
+      )}
+    </DataListItem>
+  );
+};
 
 RepositorySet.propTypes = {
   id: PropTypes.number.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -1,78 +1,88 @@
-import React, { Component } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Alert, Spinner } from 'patternfly-react';
+import { Alert, Spinner } from '@patternfly/react-core';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-import loadRepositorySetRepos from '../../../redux/actions/RedHatRepositories/repositorySetRepositories';
+import loadRepositorySetReposAction from '../../../redux/actions/RedHatRepositories/repositorySetRepositories';
 import RepositorySetRepository from './RepositorySetRepository/';
 import { yStream } from './RepositorySetRepositoriesHelpers';
 
-export class RepositorySetRepositories extends Component {
-  componentDidMount() {
-    const { contentId, productId } = this.props;
-
-    if (this.props.data.loading) {
-      this.props.loadRepositorySetRepos(contentId, productId);
+export const RepositorySetRepositories = ({
+  loadRepositorySetRepos,
+  contentId,
+  productId,
+  type,
+  data,
+}) => {
+  useEffect(() => {
+    if (data.loading) {
+      loadRepositorySetRepos(contentId, productId);
     }
-  }
+  }, [contentId, productId, data.loading, loadRepositorySetRepos]);
 
-  sortedRepos = repos => [...repos.filter(({ enabled }) => !enabled)]
-    .sort((repo1, repo2) => {
-      const repo1YStream = yStream(repo1.releasever || '');
-      const repo2YStream = yStream(repo2.releasever || '');
+  const sortedRepos = useMemo(() => {
+    const repos = data.repositories || [];
+    return [...repos.filter(({ enabled }) => !enabled)]
+      .sort((repo1, repo2) => {
+        const repo1YStream = yStream(repo1.releasever || '');
+        const repo2YStream = yStream(repo2.releasever || '');
 
-      if (repo1YStream < repo2YStream) {
-        return -1;
-      }
+        if (repo1YStream < repo2YStream) {
+          return -1;
+        }
 
-      if (repo2YStream < repo1YStream) {
-        return 1;
-      }
+        if (repo2YStream < repo1YStream) {
+          return 1;
+        }
 
-      if (repo1.arch === repo2.arch) {
-        const repo1MajorMinor = repo1.releasever.split('.');
-        const repo2MajorMinor = repo2.releasever.split('.');
+        if (repo1.arch === repo2.arch) {
+          const repo1MajorMinor = (repo1.releasever || '0.0').split('.');
+          const repo2MajorMinor = (repo2.releasever || '0.0').split('.');
 
-        const repo1Major = parseInt(repo1MajorMinor[0], 10);
-        const repo2Major = parseInt(repo2MajorMinor[0], 10);
+          const repo1Major = parseInt(repo1MajorMinor[0], 10) || 0;
+          const repo2Major = parseInt(repo2MajorMinor[0], 10) || 0;
 
-        if (repo1Major === repo2Major) {
-          const repo1Minor = parseInt(repo1MajorMinor[1], 10);
-          const repo2Minor = parseInt(repo2MajorMinor[1], 10);
+          if (repo1Major === repo2Major) {
+            const repo1Minor = parseInt(repo1MajorMinor[1], 10) || 0;
+            const repo2Minor = parseInt(repo2MajorMinor[1], 10) || 0;
 
-          if (repo1Minor === repo2Minor) {
-            return 0;
-          } return (repo1Minor > repo2Minor) ? -1 : 1;
-        } return (repo1Major > repo2Major) ? -1 : 1;
-      } return (repo1.arch > repo2.arch) ? -1 : 1;
-    });
+            if (repo1Minor === repo2Minor) {
+              return 0;
+            } return (repo1Minor > repo2Minor) ? -1 : 1;
+          } return (repo1Major > repo2Major) ? -1 : 1;
+        } return (repo1.arch > repo2.arch) ? -1 : 1;
+      });
+  }, [data.repositories]);
 
-  render() {
-    const { data, type } = this.props;
-
-    if (data.error) {
-      return (
-        <Alert type="danger">
-          <span>{data.error.displayMessage}</span>
-        </Alert>
-      );
-    }
-
-    const availableRepos = this.sortedRepos(data.repositories).map(repo => (
-      <RepositorySetRepository key={repo.arch + repo.releasever} type={type} {...repo} />
-    ));
-
-    const repoMessage = (data.repositories.length > 0 && availableRepos.length === 0 ?
-      __('All available architectures for this repo are enabled.') : __('No repositories available.'));
-
+  if (data.error) {
     return (
-      <Spinner loading={data.loading}>
-        {availableRepos.length ? availableRepos : <div>{repoMessage}</div>}
-      </Spinner>
+      <Alert
+        variant="danger"
+        title={data.error.displayMessage}
+        ouiaId="repository-set-error-alert"
+        isInline
+      />
     );
   }
-}
+
+  if (data.loading) {
+    return <Spinner size="md" />;
+  }
+
+  const availableRepos = sortedRepos.map(repo => (
+    <RepositorySetRepository
+      key={`${repo.arch || 'noarch'}-${repo.releasever || 'none'}`}
+      type={type}
+      {...repo}
+    />
+  ));
+
+  const repoMessage = ((data.repositories || []).length > 0 && availableRepos.length === 0 ?
+    __('All available architectures for this repo are enabled.') : __('No repositories available.'));
+
+  return availableRepos.length ? <>{availableRepos}</> : <div>{repoMessage}</div>;
+};
 
 RepositorySetRepositories.propTypes = {
   loadRepositorySetRepos: PropTypes.func.isRequired,
@@ -104,5 +114,5 @@ const mapStateToProps = (
 });
 
 export default connect(mapStateToProps, {
-  loadRepositorySetRepos,
+  loadRepositorySetRepos: loadRepositorySetReposAction,
 })(RepositorySetRepositories);

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/RepositorySetRepository.js
@@ -1,134 +1,160 @@
-import React, { Component } from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import cx from 'classnames';
-import { ListView, Spinner, OverlayTrigger, Tooltip, Icon, FieldLevelHelp } from 'patternfly-react';
+import {
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  DataListAction,
+  Spinner,
+  Tooltip,
+  Popover,
+  Button,
+} from '@patternfly/react-core';
+import { TimesCircleIcon, PlusCircleIcon, InfoCircleIcon } from '@patternfly/react-icons';
 
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import { yStream } from '../RepositorySetRepositoriesHelpers';
 import '../../index.scss';
 
-class RepositorySetRepository extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {};
-  }
+const RepositorySetRepository = ({
+  contentId,
+  productId,
+  displayArch,
+  arch,
+  releasever,
+  type,
+  label,
+  enabledSearch,
+  enabledPagination,
+  loading,
+  error,
+  setRepositoryEnabled,
+  loadEnabledRepos,
+  enableRepository,
+}) => {
+  const repoForAction = useCallback(() => ({
+    arch,
+    productId,
+    contentId,
+    releasever,
+    label,
+  }), [arch, productId, contentId, releasever, label]);
 
-  setEnabled = () => {
-    this.props.setRepositoryEnabled(this.repoForAction());
-  };
-
-  repoForAction = () => {
-    const {
-      productId, contentId, arch, releasever, label,
-    } = this.props;
-
-    return {
-      arch,
-      productId,
-      contentId,
-      releasever,
-      label,
-    };
-  };
-
-  reloadEnabledRepos = () => (
-    this.props.loadEnabledRepos({
-      ...this.props.enabledPagination,
-      search: this.props.enabledSearch,
+  const reloadEnabledRepos = useCallback(() => (
+    loadEnabledRepos({
+      ...enabledPagination,
+      search: enabledSearch,
     }, true)
-  );
+  ), [loadEnabledRepos, enabledPagination, enabledSearch]);
 
-  notifyEnabled = (data) => {
+  const notifyEnabled = useCallback((data) => {
     const repoName = data.output.repository.name;
     window.tfm.toastNotifications.notify({
       message: sprintf(__("Repository '%(repoName)s' has been enabled."), { repoName }),
       type: 'success',
     });
-  };
+  }, []);
 
-  reloadAndNotify = async (result) => {
+  const reloadAndNotify = useCallback(async (result) => {
     if (result && result.success) {
-      await this.reloadEnabledRepos();
-      await this.setEnabled();
-      await this.notifyEnabled(result.data);
+      await reloadEnabledRepos();
+      await setRepositoryEnabled(repoForAction());
+      await notifyEnabled(result.data);
     }
-  };
+  }, [reloadEnabledRepos, setRepositoryEnabled, repoForAction, notifyEnabled]);
 
-  enableRepository = async () => {
-    const result = await this.props.enableRepository(this.repoForAction());
-    this.reloadAndNotify(result);
-  };
+  const handleEnableRepository = useCallback(async () => {
+    const result = await enableRepository(repoForAction());
+    await reloadAndNotify(result);
+  }, [enableRepository, repoForAction, reloadAndNotify]);
 
-  render() {
-    const { displayArch, releasever, type } = this.props;
+  const archLabel = displayArch || __('Unspecified');
+  const releaseverLabel = releasever || '';
 
-    const archLabel = displayArch || __('Unspecified');
-    const releaseverLabel = releasever || '';
-
-    const yStreamHelpText =
-      sprintf(
-        __('This repository is not suggested. Please see additional %(anchorBegin)sdocumentation%(anchorEnd)s prior to use.'),
-        {
-          anchorBegin: '<a href="https://access.redhat.com/articles/1586183">',
-          anchorEnd: '</a>',
-        },
-      );
-    // eslint-disable-next-line react/no-danger
-    const yStreamHelp = <span dangerouslySetInnerHTML={{ __html: yStreamHelpText }} />;
-    const shouldDeemphasize = () => type !== 'kickstart' && yStream(releaseverLabel);
-    const repositoryHeading = () => (
-      <span>
-        {archLabel} {releaseverLabel}
-        {shouldDeemphasize() ? (<FieldLevelHelp content={yStreamHelp} />) : null}
-      </span>
+  const yStreamHelpText =
+    sprintf(
+      __('This repository is not suggested. Please see additional %(anchorBegin)sdocumentation%(anchorEnd)s prior to use.'),
+      {
+        anchorBegin: '<a href="https://access.redhat.com/articles/1586183">',
+        anchorEnd: '</a>',
+      },
     );
+  // eslint-disable-next-line react/no-danger
+  const yStreamHelp = <span dangerouslySetInnerHTML={{ __html: yStreamHelpText }} />;
+  const shouldDeemphasize = type !== 'kickstart' && yStream(releaseverLabel);
+  const headingId = `repo-${arch || 'unspecified'}-${releasever || 'unspecified'}`;
 
-    return (
-      <ListView.Item
-        heading={repositoryHeading()}
-        className={`list-item-with-divider ${shouldDeemphasize() ? 'deemphasize' : ''}`}
-        leftContent={
-          this.props.error ? (
-            <div className="list-error-danger">
-              <Icon name="times-circle-o" />
-            </div>
-          ) : null
-        }
-        additionalInfo={
-          this.state.error
-            ? [
-              <ListView.InfoItem key="error" stacked className="list-error-danger">
-                {this.state.error.displayMessage}
-              </ListView.InfoItem>,
-            ]
-            : null
-        }
-        actions={
-          <Spinner loading={this.props.loading} inline>
-            <OverlayTrigger
-              overlay={<Tooltip id="enable">{__('Enable')}</Tooltip>}
-              placement="bottom"
-              trigger={['hover', 'focus']}
-              rootClose={false}
-            >
-              <button
-                onClick={this.enableRepository}
-                style={{
-                  backgroundColor: 'initial',
-                  border: 'none',
-                  color: '#0388ce',
-                }}
-              >
-                <i className={cx('fa-2x', 'fa fa-plus-circle')} />
-              </button>
-            </OverlayTrigger>
-          </Spinner>
-        }
-        stacked
-      />
+  const repositoryHeading = (
+    <span>
+      {archLabel} {releaseverLabel}
+      {shouldDeemphasize ? (
+        <Popover bodyContent={yStreamHelp}>
+          <Button
+            variant="plain"
+            aria-label={__('Help')}
+            ouiaId="ystream-help-button"
+            className="ystream-help-button"
+          >
+            <InfoCircleIcon />
+          </Button>
+        </Popover>
+      ) : null}
+    </span>
+  );
+
+  const dataListCells = [];
+
+  // Error icon cell (if error exists)
+  if (error) {
+    const errorCell = (
+      <DataListCell key="error-icon" className="repository-cell-icon">
+        <div className="list-error-danger">
+          <TimesCircleIcon />
+        </div>
+      </DataListCell>
     );
+    dataListCells.push(errorCell);
   }
-}
+
+  // Main content cell
+  const contentCell = (
+    <DataListCell key="content" className="repository-cell-content">
+      <div
+        id={headingId}
+        className={shouldDeemphasize ? 'deemphasize repository-text-md' : 'repository-name repository-text-md'}
+      >
+        {repositoryHeading}
+      </div>
+    </DataListCell>
+  );
+  dataListCells.push(contentCell);
+
+  return (
+    <DataListItem aria-labelledby={headingId} className="list-item-with-divider">
+      <DataListItemRow className="repository-item-row">
+        <DataListItemCells dataListCells={dataListCells} />
+        <DataListAction>
+          {loading ? (
+            <Spinner size="md" />
+          ) : (
+            <Tooltip content={__('Enable')} position="bottom">
+              <Button
+                variant="plain"
+                onClick={handleEnableRepository}
+                aria-label={__('Enable')}
+                ouiaId="enable-repository-button"
+                className="enable-repository-button"
+              >
+                <PlusCircleIcon />
+              </Button>
+            </Tooltip>
+          )}
+        </DataListAction>
+      </DataListItemRow>
+    </DataListItem>
+  );
+};
 
 RepositorySetRepository.propTypes = {
   contentId: PropTypes.number.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/__test__/RepositorySetRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/__test__/RepositorySetRepository.test.js
@@ -106,11 +106,11 @@ describe('RepositorySetRepository Component', () => {
     // Verify the Y-stream version number appears
     expect(getByText('x86_64 8.5')).toBeInTheDocument();
 
-    // For legacy PatternFly v3 FieldLevelHelp - verify info icon appears
-    // The FieldLevelHelp component renders an info icon button with popover help content
+    // For PatternFly v5 Popover with help button - verify help button appears
+    // The Popover component renders a help button with popover help content
     // The popover contains a link to https://access.redhat.com/articles/1586183
-    const helpIcon = container.querySelector('.pficon-info');
-    expect(helpIcon).toBeInTheDocument();
+    const helpButton = container.querySelector('.ystream-help-button');
+    expect(helpButton).toBeInTheDocument();
   });
 
   test('does not show help icon for non-Y-stream repository', () => {
@@ -124,9 +124,9 @@ describe('RepositorySetRepository Component', () => {
     const listItem = container.querySelector('.deemphasize');
     expect(listItem).not.toBeInTheDocument();
 
-    // Should NOT have FieldLevelHelp info icon
-    const helpIcon = container.querySelector('.pficon-info');
-    expect(helpIcon).not.toBeInTheDocument();
+    // Should NOT have help button
+    const helpButton = container.querySelector('.ystream-help-button');
+    expect(helpButton).not.toBeInTheDocument();
   });
 
   test('does not deemphasize kickstart repositories even if Y-stream', () => {
@@ -199,12 +199,13 @@ describe('RepositorySetRepository Component', () => {
       getInitialState(),
     );
 
-    // For legacy PatternFly v3 icon - error icon should be visible
-    const errorIcon = container.querySelector('.fa-times-circle-o');
-    expect(errorIcon).toBeInTheDocument();
-
+    // For PatternFly v5 icon - error icon should be visible
     const errorContainer = container.querySelector('.list-error-danger');
     expect(errorContainer).toBeInTheDocument();
+
+    // Verify TimesCircleIcon is rendered inside error container
+    const errorIcon = errorContainer.querySelector('svg');
+    expect(errorIcon).toBeInTheDocument();
   });
 
   test('enables repository via API when enable button is clicked', async () => {

--- a/webpack/scenes/RedHatRepositories/components/RepositoryTypeIcon.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositoryTypeIcon.js
@@ -1,33 +1,40 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ListView, OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Tooltip } from '@patternfly/react-core';
+import {
+  BundleIcon,
+  CodeIcon,
+  FileIcon,
+  BugIcon,
+  FileImageIcon,
+  FutbolIcon,
+  MiddlewareIcon,
+  QuestionIcon,
+} from '@patternfly/react-icons';
+import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 
-import { getTypeIcon } from '../../../services/index';
+const RepositoryTypeIcon = ({ type }) => {
+  const iconMap = {
+    yum: BundleIcon,
+    source_rpm: CodeIcon,
+    file: FileIcon,
+    debug: BugIcon,
+    iso: FileImageIcon,
+    kickstart: FutbolIcon,
+    containerimage: MiddlewareIcon,
+  };
 
-export default class RepositoryTypeIcon extends React.Component {
-  constructor(props) {
-    super(props);
+  const Icon = iconMap[type] || QuestionIcon;
 
-    this.tooltipId = `type-tooltip-${props.id}`;
-  }
-
-  render() {
-    const typeIcon = getTypeIcon(this.props.type);
-
-    return (
-      <OverlayTrigger
-        overlay={<Tooltip id={this.tooltipId}>{this.props.type}</Tooltip>}
-        placement="bottom"
-        trigger={['hover', 'focus']}
-        rootClose={false}
-      >
-        <ListView.Icon name={typeIcon.name} size="sm" type={typeIcon.type} />
-      </OverlayTrigger>
-    );
-  }
-}
+  return (
+    <Tooltip content={type} position="bottom">
+      <Icon aria-label={sprintf(__('%s repository type icon'), type)} size="lg" />
+    </Tooltip>
+  );
+};
 
 RepositoryTypeIcon.propTypes = {
-  id: PropTypes.number.isRequired,
   type: PropTypes.string.isRequired,
 };
+
+export default RepositoryTypeIcon;

--- a/webpack/scenes/RedHatRepositories/components/Search.js
+++ b/webpack/scenes/RedHatRepositories/components/Search.js
@@ -1,96 +1,141 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import React, { Component } from 'react';
-import { DropdownButton, MenuItem } from 'patternfly-react';
+import React, { useState, useCallback, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
+import {
+  Menu,
+  MenuContent,
+  MenuList,
+  MenuItem,
+  MenuToggle,
+  Popper,
+} from '@patternfly/react-core';
 import SearchBar from 'foremanReact/components/SearchBar';
 import { translate as __ } from 'foremanReact/common/I18n';
-import '../index.scss';
 import { orgId } from '../../../services/api';
 
-class RepositorySearch extends Component {
-  constructor(props) {
-    super(props);
-    this.dropDownItems = [
-      {
-        key: 'available',
-        endpoint: 'repository_sets',
-        title: __('Available'),
-      },
-      {
-        key: 'enabled',
-        endpoint: 'enabled_repositories',
-        title: __('Enabled'),
-      },
-      {
-        key: 'both',
-        endpoint: false,
-        title: __('Both'),
-      },
-    ];
-    this.state = { searchList: this.dropDownItems[0] };
-    this.onSearch = this.onSearch.bind(this);
-  }
+const RepositorySearch = ({ onSearch, onSelectSearchList }) => {
+  const dropDownItems = useMemo(() => [
+    {
+      key: 'available',
+      endpoint: 'repository_sets',
+      title: __('Available'),
+    },
+    {
+      key: 'enabled',
+      endpoint: 'enabled_repositories',
+      title: __('Enabled'),
+    },
+    {
+      key: 'both',
+      endpoint: false,
+      title: __('Both'),
+    },
+  ], []);
 
-  onSearch(search) {
-    this.props.onSearch(search);
-  }
+  const [searchList, setSearchList] = useState(dropDownItems[0]);
+  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const toggleRef = useRef(null);
+  const menuRef = useRef(null);
 
-  onSelectSearchList(searchList) {
-    this.setState({ searchList });
-    this.props.onSelectSearchList(searchList.key);
-  }
+  const handleSearch = useCallback((search) => {
+    onSearch(search);
+  }, [onSearch]);
 
-  getAutoCompleteEndpoint() {
-    let endpoint = '';
-    if (this.state.searchList.key === 'enabled') {
-      endpoint = '/katello/api/v2/repositories/auto_complete_search';
-    } else if (this.state.searchList.key === 'available') {
-      endpoint = '/katello/api/v2/repository_sets/auto_complete_search';
+  const handleSelectSearchList = useCallback((_event, selectedKey) => {
+    const selected = dropDownItems.find(item => item.key === selectedKey);
+    if (selected) {
+      setSearchList(selected);
+      onSelectSearchList(selected.key);
+      setIsSelectOpen(false);
     }
+  }, [dropDownItems, onSelectSearchList]);
 
-    return endpoint;
-  }
+  const getAutoCompleteEndpoint = useCallback(() => {
+    if (searchList.key === 'enabled') {
+      return '/katello/api/v2/repositories/auto_complete_search';
+    } else if (searchList.key === 'available') {
+      return '/katello/api/v2/repository_sets/auto_complete_search';
+    }
+    return '';
+  }, [searchList.key]);
 
-  autocompleteQueryParams() {
+  const autocompleteQueryParams = useCallback(() => {
     const params = { organization_id: orgId() };
-    if (this.state.searchList.key === 'enabled') {
+    if (searchList.key === 'enabled') {
       params.enabled = true;
     }
-
     return params;
-  }
+  }, [searchList.key]);
 
-  render() {
-    return (
-      <div style={{ display: 'flex' }}>
-        <DropdownButton title={this.state.searchList.title} id="search-list-select">
-          {this.dropDownItems
-            .filter(({ key }) => key !== this.state.searchList.key)
-            .map(({ key, title, ...rest }) => (
-              <MenuItem
-                key={key}
-                onClick={() =>
-                  this.onSelectSearchList({ key, title, ...rest })
-                }
-              >
-                {title}
-              </MenuItem>
-            ))}
-        </DropdownButton>
+  const toggle = (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setIsSelectOpen(!isSelectOpen)}
+      isExpanded={isSelectOpen}
+      ouiaId="search-list-select"
+    >
+      {searchList.title}
+    </MenuToggle>
+  );
+
+  const menu = (
+    <Menu
+      ref={menuRef}
+      onSelect={handleSelectSearchList}
+      selected={searchList.key}
+      ouiaId="search-list-menu"
+    >
+      <MenuContent>
+        <MenuList>
+          {dropDownItems.map(({ key, title }) => (
+            <MenuItem
+              key={key}
+              itemId={key}
+              isSelected={searchList.key === key}
+            >
+              {title}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  );
+
+  return (
+    <>
+      <div className="search-list-select-container">
+        <Popper
+          trigger={toggle}
+          popper={menu}
+          isVisible={isSelectOpen}
+          appendTo={() => document.body}
+          onDocumentClick={(event) => {
+            if (
+              toggleRef.current &&
+              !toggleRef.current.contains(event.target) &&
+              menuRef.current &&
+              !menuRef.current.contains(event.target)
+            ) {
+              setIsSelectOpen(false);
+            }
+          }}
+        />
+      </div>
+      <div className="search-input-container">
         <SearchBar
           data={{
             autocomplete: {
-              url: this.getAutoCompleteEndpoint(),
-              apiParams: this.autocompleteQueryParams(),
+              url: getAutoCompleteEndpoint(),
+              apiParams: autocompleteQueryParams(),
             },
             bookmarks: {},
           }}
-          onSearch={this.onSearch}
+          onSearch={handleSearch}
         />
       </div>
-    );
-  }
-}
+    </>
+  );
+};
 
 RepositorySearch.propTypes = {
   onSearch: PropTypes.func.isRequired,

--- a/webpack/scenes/RedHatRepositories/components/SearchBar.js
+++ b/webpack/scenes/RedHatRepositories/components/SearchBar.js
@@ -1,18 +1,18 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import React, { Component } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
-import { Form, FormGroup } from 'react-bootstrap';
 import { translate as __ } from 'foremanReact/common/I18n';
 
-import { selectOrganizationProducts }
-  from '../../../redux/OrganizationProducts/OrganizationProductsSelectors';
-import { loadOrganizationProducts }
+import {
+  selectOrganizationProducts,
+  selectOrganizationProductsLoading,
+} from '../../../redux/OrganizationProducts/OrganizationProductsSelectors';
+import { loadOrganizationProducts as loadOrganizationProductsAction }
   from '../../../redux/OrganizationProducts/OrganizationProductsActions';
 
-import { loadEnabledRepos } from '../../../redux/actions/RedHatRepositories/enabled';
-import { loadRepositorySets } from '../../../redux/actions/RedHatRepositories/sets';
+import { loadEnabledRepos as loadEnabledReposAction } from '../../../redux/actions/RedHatRepositories/enabled';
+import { loadRepositorySets as loadRepositorySetsAction } from '../../../redux/actions/RedHatRepositories/sets';
 
 import Search from './Search';
 import MultiSelect from '../../../components/MultiSelect/index';
@@ -26,124 +26,117 @@ const filterOptions = [
   { value: 'other', label: __('Other') },
 ];
 
-class SearchBar extends Component {
-  constructor(props) {
-    super(props);
+const SearchBar = ({
+  loadOrganizationProducts,
+  loadEnabledRepos,
+  loadRepositorySets,
+  organizationProducts,
+  organizationProductsLoading,
+  enabledRepositories,
+  repositorySets,
+}) => {
+  const [query, setQuery] = useState('');
+  const [searchList, setSearchList] = useState('available');
+  const [filters, setFilters] = useState(['rpm']);
+  const [products, setProducts] = useState([]);
 
-    this.state = {
-      query: '',
-      searchList: 'available',
-      filters: ['rpm'],
-    };
-
-    this.onSearch = this.onSearch.bind(this);
-    this.onSelectSearchList = this.onSelectSearchList.bind(this);
-  }
-
-  componentDidMount() {
+  useEffect(() => {
     // load all products until we use filtering and pagination
-    this.props.loadOrganizationProducts({ per_page: 1000, redhat_only: true });
-  }
+    loadOrganizationProducts({ per_page: 1000, redhat_only: true });
+  }, [loadOrganizationProducts]);
 
-  onSearch(query) {
-    this.updateSearch({ query });
-  }
-
-  onSelectSearchList(searchList) {
-    this.updateSearch({ searchList });
-  }
-
-  onSelectFilterType(filters) {
-    this.updateSearch({ filters });
-  }
-
-  onSelectProduct(products) {
-    this.updateSearch({ products });
-  }
-
-  updateSearch(stateUpdate = {}) {
-    const newState = {
-      ...this.state,
-      ...stateUpdate,
-    };
-    this.setState(stateUpdate);
-
-    const clearSearch = stateUpdate.searchList ? {} : null;
-
-    if (newState.searchList === 'available') {
-      this.reloadRepos(newState, clearSearch);
-    } else if (newState.searchList === 'enabled') {
-      this.reloadRepos(clearSearch, newState);
-    } else {
-      this.reloadRepos(newState, newState);
-    }
-  }
-
-  reloadRepos(repoSetsSearch, enabledSearch) {
+  const reloadRepos = useCallback((repoSetsSearch, enabledSearch) => {
     if (repoSetsSearch !== null) {
       const setsParams = {
-        perPage: this.props.repositorySets.pagination.perPage,
+        perPage: repositorySets.pagination.perPage,
         search: repoSetsSearch,
       };
-      this.props.loadRepositorySets(setsParams);
+      loadRepositorySets(setsParams);
     }
 
     if (enabledSearch !== null) {
       const enabledParams = {
-        perPage: this.props.enabledRepositories.pagination.perPage,
+        perPage: enabledRepositories.pagination.perPage,
         search: enabledSearch,
       };
-      this.props.loadEnabledRepos(enabledParams);
+      loadEnabledRepos(enabledParams);
     }
-  }
+  }, [loadRepositorySets, loadEnabledRepos, repositorySets.pagination.perPage,
+    enabledRepositories.pagination.perPage]);
 
-  render() {
-    const { organizationProducts } = this.props;
+  const updateSearch = useCallback((stateUpdate = {}) => {
+    const newState = {
+      query,
+      searchList,
+      filters,
+      products,
+      ...stateUpdate,
+    };
 
-    const getMultiSelectValuesFromEvent = e => [...e.target.options]
-      .filter(({ selected }) => selected)
-      .map(({ value }) => value);
+    // Update local state
+    if (stateUpdate.query !== undefined) setQuery(stateUpdate.query);
+    if (stateUpdate.searchList !== undefined) setSearchList(stateUpdate.searchList);
+    if (stateUpdate.filters !== undefined) setFilters(stateUpdate.filters);
+    if (stateUpdate.products !== undefined) setProducts(stateUpdate.products);
 
-    return (
-      <Form className="toolbar-pf-actions">
-        <div className="search-bar-row">
-          <FormGroup className="toolbar-pf-filter">
-            <Search onSearch={this.onSearch} onSelectSearchList={this.onSelectSearchList} />
-          </FormGroup>
-        </div>
+    const clearSearch = stateUpdate.searchList ? {} : null;
 
-        <div className="search-bar-row search-bar-selects-row">
-          <MultiSelect
-            className="product-select"
-            value="product"
-            options={organizationProducts.map(product => ({
-              value: product.id, label: product.name,
-            }))}
-            defaultValues={[]}
-            noneSelectedText={__('Filter by Product')}
-            maxItemsCountForFullLabel={2}
-            onChange={(e) => {
-              const values = getMultiSelectValuesFromEvent(e);
-              this.onSelectProduct(values);
-            }}
-          />
-          <MultiSelect
-            value={this.state.filters}
-            options={filterOptions}
-            defaultValues={['rpm']}
-            noneSelectedText={__('Filter by type')}
-            onChange={(e) => {
-              const values = [...e.target.options]
-                .filter(({ selected }) => selected)
-                .map(({ value }) => value);
-              this.onSelectFilterType(values);
-            }}
-          />
-        </div>
-      </Form>
-    );
-  }
-}
+    if (newState.searchList === 'available') {
+      reloadRepos(newState, clearSearch);
+    } else if (newState.searchList === 'enabled') {
+      reloadRepos(clearSearch, newState);
+    } else {
+      reloadRepos(newState, newState);
+    }
+  }, [query, searchList, filters, products, reloadRepos]);
+
+  const handleSearch = useCallback((searchQuery) => {
+    updateSearch({ query: searchQuery });
+  }, [updateSearch]);
+
+  const handleSelectSearchList = useCallback((selectedSearchList) => {
+    updateSearch({ searchList: selectedSearchList });
+  }, [updateSearch]);
+
+  const handleSelectFilterType = useCallback((selectedFilters) => {
+    updateSearch({ filters: selectedFilters });
+  }, [updateSearch]);
+
+  const handleSelectProduct = useCallback((selectedProducts) => {
+    updateSearch({ products: selectedProducts });
+  }, [updateSearch]);
+
+  return (
+    <div className="toolbar-pf-actions">
+      <div className="search-bar-row">
+        <Search onSearch={handleSearch} onSelectSearchList={handleSelectSearchList} />
+      </div>
+
+      <div className="search-bar-row search-bar-selects-row">
+        <MultiSelect
+          className="product-select"
+          ouiaId="filter-by-product"
+          options={organizationProducts.map(product => ({
+            value: product.id, label: product.name,
+          }))}
+          defaultValues={[]}
+          noneSelectedText={__('Filter by Product')}
+          maxItemsCountForFullLabel={2}
+          onChange={handleSelectProduct}
+          isLoading={organizationProductsLoading}
+          searchable
+        />
+        <MultiSelect
+          ouiaId="filter-by-type"
+          options={filterOptions}
+          defaultValues={['rpm']}
+          noneSelectedText={__('Filter by type')}
+          onChange={handleSelectFilterType}
+        />
+      </div>
+    </div>
+  );
+};
 
 SearchBar.propTypes = {
   loadEnabledRepos: PropTypes.func.isRequired,
@@ -153,6 +146,7 @@ SearchBar.propTypes = {
     id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     name: PropTypes.string,
   })).isRequired,
+  organizationProductsLoading: PropTypes.bool.isRequired,
   enabledRepositories: PropTypes.shape({
     pagination: PropTypes.shape({
       perPage: PropTypes.number,
@@ -172,11 +166,12 @@ const mapStateToProps = (state) => {
     enabledRepositories: enabled,
     repositorySets: sets,
     organizationProducts: selectOrganizationProducts(state),
+    organizationProductsLoading: selectOrganizationProductsLoading(state),
   };
 };
 
 export default connect(mapStateToProps, {
-  loadEnabledRepos,
-  loadRepositorySets,
-  loadOrganizationProducts,
+  loadEnabledRepos: loadEnabledReposAction,
+  loadRepositorySets: loadRepositorySetsAction,
+  loadOrganizationProducts: loadOrganizationProductsAction,
 })(SearchBar);

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RecommendedRepositorySetsToggler.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RecommendedRepositorySetsToggler.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import RecommendedRepositorySetsToggler from '../RecommendedRepositorySetsToggler';
 
@@ -12,37 +12,39 @@ describe('RecommendedRepositorySetsToggler component', () => {
   describe('rendering', () => {
     test('renders without errors with default props', () => {
       const props = getBaseProps();
-      const { container, getByText } = render(<RecommendedRepositorySetsToggler {...props} />);
+      const { container, getByText, getByLabelText } = render(<RecommendedRepositorySetsToggler
+        {...props}
+      />);
       expect(container.firstChild).toBeInTheDocument();
 
       // Verify default children text appears
       expect(getByText('Recommended Repositories')).toBeInTheDocument();
 
-      // Verify star icon is rendered (legacy PF3 icon)
-      const starIcon = container.querySelector('.fa-star');
+      // Verify star icon SVG is rendered
+      const starIcon = container.querySelector('svg');
       expect(starIcon).toBeInTheDocument();
 
       // Verify Switch component is rendered
-      const switchDiv = container.querySelector('.bootstrap-switch');
-      expect(switchDiv).toBeInTheDocument();
+      const switchElement = getByLabelText('Recommended repositories toggle');
+      expect(switchElement).toBeInTheDocument();
     });
 
     test('renders with enabled state', () => {
       const props = { ...getBaseProps(), enabled: true };
-      const { container } = render(<RecommendedRepositorySetsToggler {...props} />);
+      const { getByLabelText } = render(<RecommendedRepositorySetsToggler {...props} />);
 
-      // Verify Switch is in enabled state by checking for the "on" class
-      const switchContainer = container.querySelector('.bootstrap-switch');
-      expect(switchContainer).toHaveClass('bootstrap-switch-on');
+      // Verify Switch is in enabled state
+      const switchElement = getByLabelText('Recommended repositories toggle');
+      expect(switchElement).toBeChecked();
     });
 
     test('renders with disabled state', () => {
       const props = { ...getBaseProps(), enabled: false };
-      const { container } = render(<RecommendedRepositorySetsToggler {...props} />);
+      const { getByLabelText } = render(<RecommendedRepositorySetsToggler {...props} />);
 
-      // Verify Switch is in disabled state by checking for the "off" class
-      const switchContainer = container.querySelector('.bootstrap-switch');
-      expect(switchContainer).toHaveClass('bootstrap-switch-off');
+      // Verify Switch is in disabled state
+      const switchElement = getByLabelText('Recommended repositories toggle');
+      expect(switchElement).not.toBeChecked();
     });
 
     test('renders with custom children', () => {
@@ -62,22 +64,35 @@ describe('RecommendedRepositorySetsToggler component', () => {
       expect(containerDiv).toHaveClass('custom-class-name');
     });
 
-    test('renders help icon', () => {
+    test('renders help button', () => {
       const props = getBaseProps();
-      const { container } = render(<RecommendedRepositorySetsToggler {...props} />);
+      const { getByLabelText } = render(<RecommendedRepositorySetsToggler {...props} />);
 
-      // Verify FieldLevelHelp icon is rendered (PF component)
-      const helpIcon = container.querySelector('.pficon-info');
-      expect(helpIcon).toBeInTheDocument();
+      // Verify help button is rendered
+      const helpButton = getByLabelText('Help');
+      expect(helpButton).toBeInTheDocument();
     });
 
-    test('renders with custom help text', () => {
-      const props = { ...getBaseProps(), help: 'Custom help text' };
-      const { container } = render(<RecommendedRepositorySetsToggler {...props} />);
+    test('calls onChange when switch is toggled', () => {
+      const mockOnChange = jest.fn();
+      const props = { ...getBaseProps(), onChange: mockOnChange };
+      const { getByLabelText } = render(<RecommendedRepositorySetsToggler {...props} />);
 
-      // Verify help icon is rendered (actual help text is in popover, hard to test)
-      const helpIcon = container.querySelector('.pficon-info');
-      expect(helpIcon).toBeInTheDocument();
+      const switchElement = getByLabelText('Recommended repositories toggle');
+      fireEvent.click(switchElement);
+
+      expect(mockOnChange).toHaveBeenCalledWith(true);
+    });
+
+    test('calls onChange with false when enabled and toggled', () => {
+      const mockOnChange = jest.fn();
+      const props = { ...getBaseProps(), enabled: true, onChange: mockOnChange };
+      const { getByLabelText } = render(<RecommendedRepositorySetsToggler {...props} />);
+
+      const switchElement = getByLabelText('Recommended repositories toggle');
+      fireEvent.click(switchElement);
+
+      expect(mockOnChange).toHaveBeenCalledWith(false);
     });
   });
 });

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepositories.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RepositorySetRepositories.test.js
@@ -60,9 +60,7 @@ describe('RepositorySetRepositories Component', () => {
       expect(getByText('i386 5Workstation')).toBeInTheDocument();
     });
 
-    // querySelector is acceptable here for legacy PatternFly 3 ListView component
-    // which doesn't provide accessible role attributes for list items
-    const listItems = container.querySelectorAll('.list-view-pf-main-info');
+    const listItems = container.querySelectorAll('.list-item-with-divider');
     expect(listItems).toHaveLength(7);
 
     assertNockRequest(scope);

--- a/webpack/scenes/RedHatRepositories/components/__tests__/RepositoryTypeIcon.test.js
+++ b/webpack/scenes/RedHatRepositories/components/__tests__/RepositoryTypeIcon.test.js
@@ -5,67 +5,60 @@ import RepositoryTypeIcon from '../RepositoryTypeIcon';
 
 describe('RepositoryTypeIcon component', () => {
   const getBaseProps = () => ({
-    id: 123,
     type: 'unknown-type',
   });
 
   describe('rendering', () => {
     test('renders without errors for unknown type', () => {
-      const { container } = render(<RepositoryTypeIcon {...getBaseProps()} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<RepositoryTypeIcon {...getBaseProps()} />);
 
-      // Verify it renders a question icon for unknown types (legacy PF3 icon)
-      const icon = container.querySelector('.fa-question');
+      // Verify it renders a question icon for unknown types
+      const icon = getByLabelText('unknown-type repository type icon');
       expect(icon).toBeInTheDocument();
     });
 
     test('renders yum repository icon', () => {
       const props = { ...getBaseProps(), type: 'yum' };
-      const { container } = render(<RepositoryTypeIcon {...props} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<RepositoryTypeIcon {...props} />);
 
-      // Verify it renders the PatternFly bundle icon for yum repositories
-      const icon = container.querySelector('.pficon-bundle');
+      // Verify it renders the bundle icon for yum repositories
+      const icon = getByLabelText('yum repository type icon');
       expect(icon).toBeInTheDocument();
     });
 
     test('renders file repository icon', () => {
       const props = { ...getBaseProps(), type: 'file' };
-      const { container } = render(<RepositoryTypeIcon {...props} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<RepositoryTypeIcon {...props} />);
 
       // Verify it renders the file icon for file repositories
-      const icon = container.querySelector('.fa-file');
+      const icon = getByLabelText('file repository type icon');
       expect(icon).toBeInTheDocument();
     });
 
     test('renders debug repository icon', () => {
       const props = { ...getBaseProps(), type: 'debug' };
-      const { container } = render(<RepositoryTypeIcon {...props} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<RepositoryTypeIcon {...props} />);
 
       // Verify it renders the bug icon for debug repositories
-      const icon = container.querySelector('.fa-bug');
+      const icon = getByLabelText('debug repository type icon');
       expect(icon).toBeInTheDocument();
     });
 
     test('renders containerimage repository icon', () => {
       const props = { ...getBaseProps(), type: 'containerimage' };
-      const { container } = render(<RepositoryTypeIcon {...props} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<RepositoryTypeIcon {...props} />);
 
-      // Verify it renders the cube icon for container image repositories
-      const icon = container.querySelector('.fa-cube');
+      // Verify it renders the middleware icon for container image repositories
+      const icon = getByLabelText('containerimage repository type icon');
       expect(icon).toBeInTheDocument();
     });
 
     test('renders kickstart repository icon', () => {
       const props = { ...getBaseProps(), type: 'kickstart' };
-      const { container } = render(<RepositoryTypeIcon {...props} />);
-      expect(container.firstChild).toBeInTheDocument();
+      const { getByLabelText } = render(<RepositoryTypeIcon {...props} />);
 
       // Verify it renders the futbol icon for kickstart repositories
-      const icon = container.querySelector('.fa-futbol-o');
+      const icon = getByLabelText('kickstart repository type icon');
       expect(icon).toBeInTheDocument();
     });
   });

--- a/webpack/scenes/RedHatRepositories/helpers.js
+++ b/webpack/scenes/RedHatRepositories/helpers.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ListView } from 'patternfly-react';
+import { DataList } from '@patternfly/react-core';
 import { sprintf, translate as __ } from 'foremanReact/common/I18n';
 import Pagination from 'foremanReact/components/Pagination';
 
@@ -31,7 +31,7 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
     return <p dangerouslySetInnerHTML={{ __html: noProductsMessage }} />;
   }
   return (
-    <ListView>
+    <>
       <div className="sticky-pagination">
         <Pagination
           itemCount={itemCount}
@@ -41,8 +41,10 @@ export const getSetsComponent = (repoSetsState, onPaginationChange) => {
           {...pagination}
         />
       </div>
-      {results.map(set => <RepositorySet id={set.id} key={set.id} {...set} />)}
-    </ListView>
+      <DataList aria-label={__('Available repository sets')}>
+        {results.map(set => <RepositorySet id={set.id} key={set.id} {...set} />)}
+      </DataList>
+    </>
   );
 };
 
@@ -62,7 +64,7 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
   }
 
   return (
-    <ListView>
+    <>
       <div className="sticky-pagination sticky-pagination-grey">
         <Pagination
           isCompact
@@ -72,7 +74,9 @@ export const getEnabledComponent = (enabledReposState, onPaginationChange) => {
           {...pagination}
         />
       </div>
-      {repositories.map(repo => <EnabledRepository key={repo.id} {...repo} />)}
-    </ListView>
+      <DataList aria-label={__('Enabled repositories')}>
+        {repositories.map(repo => <EnabledRepository key={repo.id} {...repo} />)}
+      </DataList>
+    </>
   );
 };

--- a/webpack/scenes/RedHatRepositories/index.scss
+++ b/webpack/scenes/RedHatRepositories/index.scss
@@ -1,137 +1,218 @@
 @import "foremanReact/common/variables";
 
-.row-eq-height {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-}
-
-.list-item-with-divider:not(:last-child) {
-  border-bottom: 1px solid $color-pf-black-200;
-}
-
-.list-error-danger {
-  color: $color-pf-red-200;
-}
-
 #redhatRepositoriesPage {
-  .deemphasize {
-    color: lightgray;
+  padding: var(--pf-v5-global--spacer--md);
+
+  // PF5 DataList items divider
+  .list-item-with-divider:not(:last-child) {
+    border-bottom: 1px solid var(--pf-v5-global--BorderColor--100);
   }
+
+  .list-error-danger {
+    color: var(--pf-v5-global--danger-color--100);
+  }
+  h1 {
+    margin-bottom: 1.5rem;
+  }
+
+  .deemphasize {
+    color: var(--pf-v5-global--Color--200);
+  }
+
+  .repository-name {
+    font-weight: var(--pf-v5-global--FontWeight--bold);
+  }
+
+  .repository-label {
+    color: var(--pf-v5-global--Color--200);
+  }
+
+  .repository-text-md {
+    font-size: var(--pf-v5-global--FontSize--md);
+  }
+
+  .toolbar-pf-actions {
+    margin-bottom: 0;
+  }
+
   .search-bar-row {
-    min-height: 26px;
-    margin-bottom: 20px;
-
-    .form-group {
-      box-sizing: border-box;
-      width: 50%;
-
-      div:first-child {
-        display: flex;
-        justify-content: space-between;
-        .foreman-search-bar {
-          flex-grow: 1;
-          margin-left: 0.7rem;
-          .pf-v5-c-search-input {
-            width: 100%;
-          }
-        }
-      }
-
-      &:first-child {
-        padding-left: 0;
-      }
-    }
-
-    .dropdown.btn-group {
-      margin-right: 0.6rem;
-    }
+    display: flex;
+    align-items: center;
+    margin-bottom: 15px;
+    gap: 0.5rem;
 
     &.search-bar-selects-row {
-      width: 50%;
-      .form-group {
-        border: none;
+      > div {
+        flex: 1;
 
         @media (min-width: 1280px) {
           &:first-child {
             min-width: 300px;
           }
+
           &:last-child {
             min-width: 180px;
           }
         }
       }
     }
-  }
 
-  .list-group-item-header .list-view-pf-description,
-  .enabled-repositories-container .list-view-pf-description {
-    width: 100%;
-
-    .list-group-item-heading {
-      white-space: pre-wrap;
+    .search-list-select-container {
+      width: 130px;
     }
-  }
 
-  .list-view-pf-view {
-    background-color: inherit;
+    .search-input-container {
+      flex: 1;
+    }
   }
 
   .recommended-repository-set-icon {
-    color: $color-pf-gold-300;
+    color: var(--pf-v5-global--warning-color--100);
     font-size: 2em;
   }
 
+  .available-repositories-container,
+  .enabled-repositories-container {
+    padding: 1rem;
+
+    .repository-item-row {
+      &:hover {
+        background-color: rgba(0, 123, 186, 0.1);
+      }
+    }
+
+    .repository-cell-content {
+      margin-right: 0;
+    }
+
+    .repository-cell-icon {
+      flex: 0 0 auto;
+      margin-right: 1rem;
+    }
+
+    .repository-set-expanded {
+      border: 1px solid var(--pf-v5-global--BorderColor--100);
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+      background-color: var(--pf-v5-global--BackgroundColor--100);
+    }
+
+    .repository-toggle-control {
+      margin: 0;
+    }
+
+    .repository-expandable-content {
+      padding-left: 2rem;
+
+      .repository-item-row {
+        padding-left: 1rem;
+      }
+    }
+  }
+
   .available-repositories-container {
-    background-color: $color-pf-white;
-    border-right: $color-pf-black-300 2px solid;
-
-    .available-repositories-header {
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      padding-top: 20px;
-
-      h2 {
-        margin: 0;
-        margin-right: 40px;
-      }
-    }
-  }
-
-  .content-view-pf-pagination {
-    background-color: $color-pf-white;
-    margin-bottom: 20px;
-  }
-
-  @media (min-width: 1280px) {
-    .toolbar-pf-filter {
-      width: 50%;
-
-      .input-group {
-        width: 400px;
-      }
-    }
+    background-color: var(--pf-v5-global--BackgroundColor--100);
+    border-right: 1px solid var(--pf-v5-global--BorderColor--100);
+    border-top: 1px solid var(--pf-v5-global--BorderColor--100);
   }
 
   .enabled-repositories-container {
-    background-color: $color-pf-black-200;
+    border-top: 1px solid var(--pf-v5-global--BorderColor--100);
+  }
 
-    .pficon.list-view-pf-icon-sm {
-      border-color: $color-pf-green-300;
+  .available-repositories-header,
+  .enabled-repositories-header {
+    margin-bottom: 1rem;
+
+    h2 {
+      margin: 0;
     }
   }
-}
 
-.sticky-pagination {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background-color: white;
-  padding-top: 10px;
-}
+  .available-repositories-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 
-.sticky-pagination-grey {
-  background-color: $color-pf-black-200;
+    h2 {
+      margin-right: 40px;
+    }
+  }
+
+  .enabled-repositories-header {
+    h2 {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+  }
+
+  .help-button-plain {
+    padding: 0.25rem 0 0 0;
+  }
+
+  .ystream-help-button {
+    padding: 0.25rem 0 0 0;
+    margin-left: 0.5rem;
+  }
+
+  .export-csv-button {
+    margin-left: auto;
+  }
+
+  .enable-repository-button,
+  .disable-repository-button {
+    color: var(--pf-v5-global--link--Color);
+
+    &:hover:not(:disabled):not([aria-disabled="true"]) {
+      color: var(--pf-v5-global--link--Color--hover);
+    }
+
+    &:disabled,
+    &[aria-disabled="true"] {
+      color: var(--pf-v5-global--disabled-color--100);
+    }
+
+    svg {
+      font-size: 1.5rem;
+    }
+  }
+
+  .repository-icon-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 50%;
+    border: 2px solid;
+
+    svg {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  }
+
+  .repository-icon-badge-blue {
+    border-color: var(--pf-v5-global--primary-color--100);
+  }
+
+  .repository-icon-badge-green {
+    border-color: var(--pf-v5-global--success-color--100);
+  }
+
+  .enabled-repositories-container {
+    background-color: var(--pf-v5-global--BackgroundColor--200);
+  }
+
+  .sticky-pagination {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background-color: var(--pf-v5-global--BackgroundColor--100);
+    padding-top: 10px;
+  }
+
+  .sticky-pagination-grey {
+    background-color: var(--pf-v5-global--BackgroundColor--200);
+  }
 }


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR migrates the RedHatRepositories scene from PF3 to PF5. All class components have been converted to function components using React hooks (useState, useEffect, useCallback, useMemo). The PF3 ListView components are replaced with PF5 DataList with proper expansion state management, react-bootstrap Grid/Row/Col is replaced with PF5 Grid/GridItem, and all PF3 components (Switch, Button, FieldLevelHelp, Icons) are replaced with their PF5 equivalents. Visual styling has been updated to use PF5 CSS variables while maintaining the original design intent. All the tests have been updated to work with the new PF5 components

#### Considerations taken when implementing this change?

The migration preserves exact functional parity with the original PF3 implementation while following PF5 best practices observed in the codebase. Critical attention was paid to the DataList expansion state to prevent lazy loading issues that could trigger premature API calls using conditional rendering instead of hidden content. OUIA IDs were added throughout for better testability, and the useEffect dependency arrays were carefully managed to prevent infinite re-render loops that were causing 500 errors. All styling uses PF5 CSS variables and utility classes, with minimal custom CSS scoped under #redhatRepositoriesPage to avoid conflicts.

#### What are the testing steps for this pull request?

1. Navigate to Content -> Red Hat Repositories and verify the page loads without errors
2. Test the search functionality by selecting "Available", "Enabled", or "Both" from the dropdown and entering search queries
3. Use the Filter by Product and Filter by type (RPM, Source RPM, Debug RPM, etc.) dropdowns to filter repositories
4. Toggle the Recommended Repositories switch and verify that only recommended repository sets are shown when enabled
5. Expand a repository set in the Available Repositories section by clicking the arrow and verify the available architectures/versions load correctly
6. Click the + (plus) button on an available repository to enable it and verify it appears in the Enabled Repositories section with a success toast notification
7. Click the - (minus) button on an enabled repository (that is not in a content view) to disable it and verify it moves back to Available Repositories
8. Test the Export as CSV button in the Enabled Repositories section and verify the CSV file downloads
9. Test pagination in both Available and Enabled sections by navigating through pages
10. Verify the unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated Repositories UI to PatternFly v5 and hooks: updated list components, toggles, popovers, buttons, icons, and enable/disable flows for improved accessibility and more predictable async behavior
* **Style**
  * Restyled to PF v5 design tokens: refreshed grid, spacing, badges, hover states, alerts, spinners, and responsive list presentation
* **Tests**
  * Updated tests to React Testing Library and accessible queries; assertions aligned to new UI output and ARIA state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->