### PR TITLE
Set CI to use KATELLO-4.21 stable branches

### DIFF
--- a/.github/workflows/dependent_plugins.yml
+++ b/.github/workflows/dependent_plugins.yml
@@ -21,6 +21,6 @@ jobs:
     with:
       plugin: foreman_rh_cloud
       plugin_repository: theforeman/foreman_rh_cloud
-      foreman_version: develop
+      foreman_version: 3.19-stable
       environment_variables: |
         KATELLO_BRANCH=${{ github.ref }}

--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -13,4 +13,4 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
     with:
       plugin: katello
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: 3.19-stable # set to the Foreman release branch after branching :)

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: katello
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: 3.19-stable # set to the Foreman release branch after branching :)
 
   angular:
     name: Angular ${{ matrix.engine }} - NodeJS ${{ matrix.node }}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ upstream_tag_template: "{version}"
 
 actions:
   post-upstream-clone:
-    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/katello/rubygem-katello/rubygem-katello.spec -O rubygem-katello.spec"
+    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/3.19/packages/katello/rubygem-katello/rubygem-katello.spec -O rubygem-katello.spec"
   get-current-version:
     - ruby -rrubygems -e 'puts Gem::Specification::load(Dir.glob("*.gemspec").first).version'
   create-archive:
@@ -35,16 +35,10 @@ jobs:
       rhel-9:
         additional_modules: "foreman-devel:el9"
         additional_repos:
-          - https://yum.theforeman.org/releases/nightly/el9/x86_64/
-          - https://yum.theforeman.org/plugins/nightly/el9/x86_64/
-          - https://yum.theforeman.org/katello/nightly/katello/el9/x86_64/
+          - https://yum.theforeman.org/releases/3.19/el9/x86_64/
+          - https://yum.theforeman.org/plugins/3.19/el9/x86_64/
+          - https://yum.theforeman.org/katello/4.21/katello/el9/x86_64/
     module_hotfixes: true
-
-  - <<: *copr
-    trigger: commit
-    branch: master
-    owner: '@theforeman'
-    project: develop
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
- Update GitHub Actions foreman_version from develop to 3.19-stable
- Update Packit spec URL to rpm/3.19
- Update Packit repos to use 3.19/4.21 release URLs
- Remove nightly copr commit trigger job