### PR TITLE
Fix version format for gem compatibility

### DIFF
--- a/lib/katello/version.rb
+++ b/lib/katello/version.rb
@@ -1,3 +1,3 @@
 module Katello
-  VERSION = "4.21.0-rc1".freeze
+  VERSION = "4.21.0.rc1".freeze
 end


### PR DESCRIPTION
Use dot separator (4.21.0.rc1) instead of dash (4.21.0-rc1) to match Ruby gem versioning conventions and previous Katello releases. Small mistake during branching.