### PR TITLE
Fixes #39330 - Remove deprecated CV/LCE params from hosts, AKs, hostgroups

### DIFF
--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -54,16 +54,16 @@ KT.hosts.refreshContentViewEnvironments = function() {
   $.get(url, params, function(data) {
     var foundPreviousValue = false;
 
-    if (previousInheritText && (previousInheritText.includes('Inherit') || previousInheritText === '')) {
+    if (inheritOption.length && (inheritOption.val() === '' || previousInheritDataId)) {
       var inheritOpt = $("<option />").text(previousInheritText).val('');
       if (previousInheritDataId) inheritOpt.attr('data-id', previousInheritDataId);
       select.append(inheritOpt);
     }
 
-    $.each(data.results, function(index, cve) {
-      var label = cve.lifecycle_environment.name + ' / ' + cve.content_view.name;
-      var option = $("<option />").val(cve.id).text(label);
-      if (cve.id === parseInt(previousValue)) {
+    $.each(data.results, function(index, cvEnv) {
+      var label = cvEnv.label;
+      var option = $("<option />").val(cvEnv.id).text(label);
+      if (cvEnv.id === parseInt(previousValue)) {
         option.prop('selected', true);
         foundPreviousValue = true;
       }
@@ -99,14 +99,20 @@ KT.hosts.onKatelloHostEditLoad = function(){
 };
 
 KT.hosts.getSelectedContentViewEnvironment = function() {
-    var cveId = $("#hostgroup_content_view_environment_id").val();
-    if (!cveId) {
-        cveId = $("#host_content_view_environment_id").val();
+    var cvEnvId = $("#hostgroup_content_view_environment_id").val();
+    if (!cvEnvId) {
+        cvEnvId = $("#host_content_view_environment_id").val();
     }
-    if (!cveId) {
-        cveId = $("#hostgroup_content_view_environment_id > option:selected").data("id");
+    if (!cvEnvId) {
+        cvEnvId = $("#hostgroup_content_view_environment_id > option:selected").data("id");
     }
-    return cveId;
+    if (!cvEnvId) {
+        var hiddenInput = $("input[name='host[content_facet_attributes][content_view_environment_ids][]']").first();
+        if (hiddenInput.length) {
+            cvEnvId = hiddenInput.val();
+        }
+    }
+    return cvEnvId;
 };
 
 KT.hosts.toggle_installation_medium = function() {

--- a/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
+++ b/app/assets/javascripts/katello/hosts/host_and_hostgroup_edit.js
@@ -4,36 +4,24 @@ KT.hosts = {};
 $(document).on('ContentLoad', function(){
     KT.hosts.onKatelloHostEditLoad();
     window.tfm.hosts.registerPluginAttributes("os",
-         ['lifecycle_environment_id', 'content_view_id', 'environment_id', 'content_source_id', 'architecture_id', 'parent_id']);
-
-    $("#hostgroup_lifecycle_environment_id").on("change",KT.hosts.environmentChanged);
-    $("#host_lifecycle_environment_id").on("change", KT.hosts.environmentChanged);
+         ['content_view_environment_id', 'content_source_id', 'architecture_id', 'parent_id']);
 
     KT.hosts.update_media_enablement();
     KT.hosts.set_media_selection_bindings();
 });
 
 KT.hosts.contentSourceChanged = function() {
-  $("#hostgroup_lifecycle_environment_id").val("");
-  $("#host_lifecycle_environment_id").val("");
   $("#hostgroup_content_view_environment_id").val("");
-  KT.hosts.fetchEnvironments();
-  KT.hosts.environmentChanged();
+  $("#host_content_view_environment_id").val("");
   KT.hosts.refreshContentViewEnvironments();
-};
-
-KT.hosts.environmentChanged = function() {
-  // if we don't save the currently selected view it's likely
-  // it will be undefined in toggle_installation_medium due to the CV dropdown reload
-  var previous_content_view = KT.hosts.getSelectedContentView();
-
-  KT.hosts.fetchContentViews();
-  KT.hosts.toggle_installation_medium(previous_content_view);
 };
 
 KT.hosts.refreshContentViewEnvironments = function() {
   var select = $("#hostgroup_content_view_environment_id");
-  if (select.length === 0) return; // Only for hostgroups
+  if (select.length === 0) {
+    select = $("#host_content_view_environment_id");
+  }
+  if (select.length === 0) return;
 
   var content_source_id = $('#content_source_id').val();
   var orgIdsElem = $("#hostgroup_organization_ids");
@@ -43,7 +31,10 @@ KT.hosts.refreshContentViewEnvironments = function() {
     orgIds = orgIdsElem.data('useds');
   }
   if (orgIds === undefined || orgIds === null || orgIds.length === 0) {
-    return; // Can't fetch without organization
+    orgIds = [$("#host_organization_id").val()];
+  }
+  if (orgIds === undefined || orgIds === null || orgIds.length === 0) {
+    return;
   }
   var orgId = Array.isArray(orgIds) ? orgIds[0] : orgIds;
 
@@ -63,7 +54,6 @@ KT.hosts.refreshContentViewEnvironments = function() {
   $.get(url, params, function(data) {
     var foundPreviousValue = false;
 
-    // Add inherit option back if it was there
     if (previousInheritText && (previousInheritText.includes('Inherit') || previousInheritText === '')) {
       var inheritOpt = $("<option />").text(previousInheritText).val('');
       if (previousInheritDataId) inheritOpt.attr('data-id', previousInheritDataId);
@@ -80,7 +70,6 @@ KT.hosts.refreshContentViewEnvironments = function() {
       select.append(option);
     });
 
-    // If previous value not found in filtered list, select the blank/inherit option
     if (!foundPreviousValue) {
       select.val('');
     }
@@ -89,126 +78,9 @@ KT.hosts.refreshContentViewEnvironments = function() {
   });
 };
 
-KT.hosts.fetchEnvironments = function () {
-  var select = KT.hosts.getEnvironmentSelect();
-  var content_source_id = $('#content_source_id').val();
-  var option;
-  select.find('option').remove();
-  if (content_source_id) {
-    var url = tfm.tools.foremanUrl('/katello/api/capsules/' + content_source_id);
-    var orgIdsElem = $("#hostgroup_organization_ids");
-    var orgIds = orgIdsElem.val();
-    if (orgIds === undefined || orgIds === null || orgIds.length === 0) {
-        orgIds = orgIdsElem.data('useds');
-    }
-    if (orgIds === undefined || orgIds === null || orgIds.length === 0) {
-        orgIds = [$("#host_organization_id").val()];
-    };
-    orgIds = orgIds.map(function (id) {
-            return Number(id);
-        });
-    $.get(url, function (content_source) {
-        $.each(content_source.lifecycle_environments, function(index, env) {
-            // Don't show environments that aren't in the selected org. See jQuery.each() docs
-            if (!orgIds.includes(env.organization_id)) return true;
-            option = $("<option />").val(env.id).text(env.name);
-            select.append(option);
-        });
-        select.trigger('change');
-    });
-  }
-};
-
-KT.hosts.fetchContentViews = function () {
-    var select = KT.hosts.getContentViewSelect();
-    var envId = KT.hosts.getSelectedEnvironment();
-    var option;
-    var previous_view = KT.hosts.getSelectedContentView();
-    var previousInheritViewText = select.find('option:first-child').text();
-    select.find('option').remove();
-    if (envId) {
-        KT.hosts.signalContentViewFetch(true);
-        var url = tfm.tools.foremanUrl('/katello/api/v2/content_views');
-        $.get(url, {environment_id: envId, full_result: true}, function (data) {
-            if ($('#hostgroup_parent_id').length > 0) {
-                select.append($("<option />").text(previousInheritViewText).val(''));
-            }
-            $.each(data.results, function(index, view) {
-                option = $("<option />").val(view.id).text(view.name);
-                if (view.id === parseInt(previous_view)) {
-                  option.prop('selected', true);
-                }
-                select.append(option);
-            });
-            select.trigger('change');
-            KT.hosts.signalContentViewFetch(false);
-        });
-    }
-};
-
-KT.hosts.signalContentViewFetch = function(fetching) {
-    var select = KT.hosts.getContentViewSelect();
-    var select2 = KT.hosts.getContentViewSelect2();
-        spinner = $('<img>').attr('src', select.data("spinner-path")),
-        spinner_id = "content_view_spinner";
-
-    if(fetching) {
-        select.hide();
-        select2.hide();
-        $(spinner).attr('id', spinner_id).insertAfter(select);
-    } else {
-        select2.show();
-        $('#' + spinner_id).remove();
-    }
-};
-
-KT.hosts.getContentViewSelect2 = function() {
-    var select = $("#s2id_host_content_view_id").first();
-    if(select.length === 0) {
-        select = $("#s2id_hostgroup_content_view_id").first();
-    }
-    return select;
-};
-
-KT.hosts.getContentViewSelect = function() {
-    var select = $("#host_content_view_id").first();
-    if(select.length === 0) {
-        select = $("#hostgroup_content_view_id").first();
-    }
-    return select;
-};
-
-KT.hosts.getSelectedContentView = function() {
-    var select = KT.hosts.getContentViewSelect();
-    return select.val() || select.find("option:selected").data("id");
-};
-
-KT.hosts.getEnvironmentSelect = function() {
-    var select = $("#hostgroup_lifecycle_environment_id").first();
-    if(select.length === 0) {
-        select = $("#host_lifecycle_environment_id").first();
-    }
-    return select;
-};
-
-KT.hosts.getSelectedEnvironment = function () {
-    var envId = $("#hostgroup_lifecycle_environment_id").val();
-    if(envId === undefined || envId === null || envId.length === 0) {
-        envId = $("#host_lifecycle_environment_id").val()
-    }
-    if(envId === undefined || envId === null || envId.length === 0) {
-        envId = $("#hostgroup_lifecycle_environment_id > option:selected").data("id");
-    }
-
-    if(envId && envId.length === 0) {
-        envId = undefined;
-    }
-    return envId;
-};
-
 KT.hosts.onKatelloHostEditLoad = function(){
     var prefixes = ['host', 'hostgroup'],
-        attributes = ['content_view_id', 'environment_id', 'architecture_id'];
+        attributes = ['content_view_environment_id', 'architecture_id'];
 
     $('body').off('.hostsContentSourceNS');
 
@@ -226,26 +98,32 @@ KT.hosts.onKatelloHostEditLoad = function(){
     });
 };
 
-KT.hosts.toggle_installation_medium = function(content_view_id) {
-    var lifecycle_environment_id, content_source_id, architecture_id, operatingsystem_id;
-
-    if (content_view_id === undefined) {
-      content_view_id = KT.hosts.getSelectedContentView();
+KT.hosts.getSelectedContentViewEnvironment = function() {
+    var cveId = $("#hostgroup_content_view_environment_id").val();
+    if (!cveId) {
+        cveId = $("#host_content_view_environment_id").val();
     }
+    if (!cveId) {
+        cveId = $("#hostgroup_content_view_environment_id > option:selected").data("id");
+    }
+    return cveId;
+};
+
+KT.hosts.toggle_installation_medium = function() {
+    var content_view_environment_id, content_source_id, architecture_id, operatingsystem_id;
+
+    content_view_environment_id = KT.hosts.getSelectedContentViewEnvironment();
+    content_source_id = $('#content_source_id').val();
 
     if ($('#hostgroup_operatingsystem_id').data('type') == 'hostgroup') {
-      lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
-      content_source_id = $('#content_source_id').val();
       architecture_id = $('#hostgroup_architecture_id').val();
       operatingsystem_id = $('#hostgroup_operatingsystem_id').val();
     } else {
-      lifecycle_environment_id = KT.hosts.getSelectedEnvironment();
-      content_source_id = $('#content_source_id').val();
       architecture_id = $('#host_architecture_id').val();
       operatingsystem_id = $('#host_operatingsystem_id').val();
     }
 
-    if (content_view_id && lifecycle_environment_id && content_source_id && architecture_id && operatingsystem_id) {
+    if (content_view_environment_id && content_source_id && architecture_id && operatingsystem_id) {
         os_selected(KT.hosts.get_os_element());
     }
 };
@@ -318,13 +196,11 @@ KT.hosts.get_synced_content_dropdown = function() {
 };
 
 KT.hosts.on_install_media_dropdown_change = function() {
-    // reset the kickstart-repository-id .. They are either or.
     KT.hosts.get_synced_content_dropdown().val("");
     activate_select2("#media_select");
 };
 
 KT.hosts.on_synced_content_dropdown_change = function() {
-    // reset the kickstart-repository-id .. They are either or.
     $("#host_medium_id").val("");
     $("#s2id_host_medium_id").val("");
     $("#hostgroup_medium_id").val("");
@@ -333,7 +209,6 @@ KT.hosts.on_synced_content_dropdown_change = function() {
 };
 
 KT.hosts.set_install_media_bindings = function() {
-    // reset the host medium id
     $("#host_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);
     $("#s2id_host_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);
     $("#hostgroup_medium_id").on("select2:select", KT.hosts.on_install_media_dropdown_change);

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -428,13 +428,13 @@ module Katello
     end
 
     def get_content_view_environment(key, value)
-      cve = nil
+      cvenv = nil
       if value
-        cve = ContentViewEnvironment.where(key => value).first
-        fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % value unless cve
-        deny_access unless cve.readable? || User.consumer?
+        cvenv = ContentViewEnvironment.where(key => value).first
+        fail HttpErrors::NotFound, _("Couldn't find environment '%s'") % value unless cvenv
+        deny_access unless cvenv.readable? || User.consumer?
       end
-      cve
+      cvenv
     end
 
     def get_content_view_environments(label = nil, organization = nil)

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -58,7 +58,7 @@ module Katello
     param_group :activation_key
     def create
       @activation_key = ActivationKey.new(activation_key_params) do |activation_key|
-        activation_key.content_view_environments = @content_view_environments if update_cves?
+        activation_key.content_view_environments = @content_view_environments if update_cvenvs?
         activation_key.organization = @organization
         activation_key.user = current_user
       end
@@ -73,7 +73,7 @@ module Katello
     param :id, :number, :desc => N_("ID of the activation key"), :required => true
     param :name, String, :desc => N_("name"), :required => false
     def update
-      if @content_view_environments.present? || update_cves?
+      if @content_view_environments.present? || update_cvenvs?
         @activation_key.update!(content_view_environments: @content_view_environments)
       end
       sync_task(::Actions::Katello::ActivationKey::Update, @activation_key, activation_key_params)
@@ -220,7 +220,7 @@ module Katello
 
     def find_content_view_environments
       @content_view_environments = []
-      if params[:content_view_environments] || params[:content_view_environment_ids]
+      if params_likely_not_from_angularjs? && (params[:content_view_environments] || params[:content_view_environment_ids])
         @content_view_environments = ::Katello::ContentViewEnvironment.fetch_content_view_environments(
           labels: params[:content_view_environments],
           ids: params[:content_view_environment_ids],
@@ -229,12 +229,27 @@ module Katello
           handle_errors(labels: params[:content_view_environments],
           ids: params[:content_view_environment_ids])
         end
+        @content_view_environments.each do |cvenv|
+          throw_resource_not_found(name: 'content_view_environment', id: cvenv.id) unless cvenv.readable?
+        end
       end
-      handle_blank_cve_params
+      handle_blank_cvenv_params
       @organization ||= @content_view_environments.first&.organization
     end
 
-    def handle_blank_cve_params
+    def params_likely_not_from_angularjs?
+      # AngularJS sends back the activation key's existing API response as params.
+      # This means content_view_environments arrives as a nested hash instead of
+      # a comma-separated string of labels, which would cause fetch_content_view_environments to fail.
+      # We detect AngularJS by the presence of multi_content_view_environment — a computed
+      # response-only value that a real API client would never submit.
+      !params.key?(:multi_content_view_environment)
+    end
+
+    def handle_blank_cvenv_params
+      if params.key?(:environment) && params.key?(:content_view)
+        return # AngularJS sends nested environment and content_view params; ignore them
+      end
       if params.key?(:content_view_environments) && params[:content_view_environments].blank?
         @content_view_environments = []
       elsif params.key?(:content_view_environment_ids) && params[:content_view_environment_ids].blank?
@@ -242,7 +257,8 @@ module Katello
       end
     end
 
-    def update_cves?
+    def update_cvenvs?
+      return false unless params_likely_not_from_angularjs?
       params.key?(:content_view_environments) ||
         params.key?(:content_view_environment_ids)
     end

--- a/app/controllers/katello/api/v2/activation_keys_controller.rb
+++ b/app/controllers/katello/api/v2/activation_keys_controller.rb
@@ -24,15 +24,11 @@ module Katello
       param :purpose_usage, String, :desc => N_("Sets the system purpose usage")
       param :purpose_role, String, :desc => N_("Sets the system purpose usage")
 
-      param :environment, Hash, :deprecated => true, :desc => N_("Hash containing the Id of the single lifecycle environment to be associated with the activation key.")
-      param :content_view_id, Integer, :deprecated => true, :desc => N_("Id of the single content view to be associated with the activation key."), :allow_nil => true
-      param :environment_id, Integer, :deprecated => true, :desc => N_("Id of the single lifecycle environment to be associated with the activation key."), :allow_nil => true
       param :content_view_environments, Array, :desc => N_("Comma-separated list of content view environment labels to be associated with the activation key,"\
                                               " in the format of 'lifecycle_environment_label/content_view_label'."\
-                                              " Ignored if content_view_environment_ids is specified, or if content_view_id and lifecycle_environment_id are specified."\
+                                              " Ignored if content_view_environment_ids is specified."\
                                               " Requires allow_multiple_content_views setting to be on.")
       param :content_view_environment_ids, Array, :desc => N_("Array of content view environment ids to be associated with the activation key."\
-                                              " Ignored if content_view_id and lifecycle_environment_id are specified."\
                                               " Requires allow_multiple_content_views setting to be on.")
     end
 
@@ -45,11 +41,10 @@ module Katello
     param :name, String, :desc => N_("activation key name to filter by")
     param :content_view_environments, Array, :desc => N_("Comma-separated list of content view environment labels associated with the activation key,"\
                                             " in the format of 'lifecycle_environment_label/content_view_label'."\
-                                            " Ignored if content_view_environment_ids is specified, or if content_view_id and lifecycle_environment_id are specified."\
+                                            " Ignored if content_view_environment_ids is specified."\
                                             " Requires allow_multiple_content_views setting to be on.")
-    param :content_view_environment_ids, Array, :desc => N_("Array of content view environment ids associated with the activation key. " \
-                                            "Ignored if content_view_id and lifecycle_environment_id are specified."\
-                                            "Requires allow_multiple_content_views setting to be on.")
+    param :content_view_environment_ids, Array, :desc => N_("Array of content view environment ids associated with the activation key."\
+                                            " Requires allow_multiple_content_views setting to be on.")
 
     param_group :search, Api::V2::ApiController
     add_scoped_search_description_for(ActivationKey)
@@ -79,14 +74,7 @@ module Katello
     param :name, String, :desc => N_("name"), :required => false
     def update
       if @content_view_environments.present? || update_cves?
-        if single_assignment? && @content_view_environments.length == 1
-          @activation_key.assign_single_environment(
-            content_view: @content_view_environments.first.content_view,
-            lifecycle_environment: @content_view_environments.first.lifecycle_environment
-          )
-        else
-          @activation_key.update!(content_view_environments: @content_view_environments)
-        end
+        @activation_key.update!(content_view_environments: @content_view_environments)
       end
       sync_task(::Actions::Katello::ActivationKey::Update, @activation_key, activation_key_params)
       respond_for_show(:resource => @activation_key)
@@ -230,38 +218,9 @@ module Katello
 
     private
 
-    def find_cve_for_single
-      environment_id = params.dig(:environment, :id) || params[:environment_id]
-      content_view_id = params.dig(:content_view, :id) || params[:content_view_id]
-      if environment_id.blank? || content_view_id.blank?
-        fail HttpErrors::BadRequest, _("Environment ID and content view ID must be provided together")
-      end
-      cve = ::Katello::ContentViewEnvironment.readable.where(environment_id: environment_id,
-                                                             content_view_id: content_view_id).first
-      if cve.blank?
-        fail HttpErrors::NotFound, _("Couldn't find content view environment with content view ID '%{cv}'"\
-                                    " and environment ID '%{env}'") % { cv: content_view_id, env: environment_id }
-      end
-      @content_view_environments = [cve]
-    end
-
-    def params_likely_not_from_angularjs?
-      # AngularJS sends back the activation key's existing API response values.
-      # A side effect of this is that when it sends params[:content_view_environments] or params[:content_view_environment_ids],
-      # it incorrectly sends the nested objects from the rabl response, instead of the required single comma-separated string of CVE labels.
-      # This would cause fetch_content_view_environments to fail.
-      # Therefore, we need a way to (a) detect if the request is from AngularJS, and (b) avoid trying to handle the nested objects as if they were strings.
-      # So we look at params[:multi_content_view_environment]. This is a computed value, not meant to be submitted as part of an update request.
-      # If it's true or false, it's likely AngularJS.
-      # And if the key is omitted, it's likely from Hammer or API, so it's safe to proceed.
-      !params.key?(:multi_content_view_environment)
-    end
-
     def find_content_view_environments
       @content_view_environments = []
-      if (params[:environment_id] || params[:environment]) || (params[:content_view_id] || params[:content_view])
-        find_cve_for_single
-      elsif params_likely_not_from_angularjs? && (params[:content_view_environments] || params[:content_view_environment_ids])
+      if params[:content_view_environments] || params[:content_view_environment_ids]
         @content_view_environments = ::Katello::ContentViewEnvironment.fetch_content_view_environments(
           labels: params[:content_view_environments],
           ids: params[:content_view_environment_ids],
@@ -276,28 +235,15 @@ module Katello
     end
 
     def handle_blank_cve_params
-      if params.key?(:environment) && params.key?(:content_view)
-        return # AngularJS sends nested environment and content_view params, but with blank _id values
-      end
-      # Activation keys do not require CVEs to be associated. So it's possible the user intends to clear them.
-      if params.key?(:environment_id) && params[:environment_id].blank? && params.key?(:content_view_id) && params[:content_view_id].blank?
-        @content_view_environments = []
-      elsif params.key?(:content_view_environments) && params[:content_view_environments].blank?
+      if params.key?(:content_view_environments) && params[:content_view_environments].blank?
         @content_view_environments = []
       elsif params.key?(:content_view_environment_ids) && params[:content_view_environment_ids].blank?
         @content_view_environments = []
       end
     end
 
-    # AngularJS sends :environment and :content_view_id
-    def single_assignment?
-      (params.key?(:environment) || params.key?(:environment_id)) &&
-      (params.key?(:content_view) || params.key?(:content_view_id))
-    end
-
     def update_cves?
-      single_assignment? ||
-        params.key?(:content_view_environments) || # multi
+      params.key?(:content_view_environments) ||
         params.key?(:content_view_environment_ids)
     end
 
@@ -325,9 +271,7 @@ module Katello
     def permitted_params
       params.require(:activation_key).permit(:name,
                                              :description,
-                                             :environment_id,
                                              :organization_id,
-                                             :content_view_id,
                                              :release_version,
                                              :service_level,
                                              :max_hosts,
@@ -341,8 +285,7 @@ module Katello
     end
 
     def activation_key_params
-      key_params = permitted_params.except(:environment_id, :content_view_id,
-                      :content_view_environments, :content_view_environment_ids)
+      key_params = permitted_params.except(:content_view_environments, :content_view_environment_ids)
 
       unlimited = params[:activation_key].try(:[], :unlimited_hosts)
       max_hosts = params[:activation_key].try(:[], :max_hosts)

--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -229,7 +229,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. New ver
           @composite_version_environments += lookup_all_composites(version_environment[:content_view_version]) if params[:propagate_all_composites]
         end
       end
-      @composite_version_environments.uniq! { |cve| cve[:content_view_version] }
+      @composite_version_environments.uniq! { |cvenv| cvenv[:content_view_version] }
     end
 
     def lookup_all_composites(component)

--- a/app/controllers/katello/api/v2/host_contents_controller.rb
+++ b/app/controllers/katello/api/v2/host_contents_controller.rb
@@ -1,13 +1,11 @@
 module Katello
   class Api::V2::HostContentsController < Katello::Api::V2::ApiController
     def_param_group :content_facet_attributes do
-      param :content_view_id, Integer, :deprecated => true, :desc => N_("Id of the single content view to be associated with the host. Ignored for multi-environment hosts.")
-      param :lifecycle_environment_id, Integer, :deprecated => true, :desc => N_("Id of the single lifecycle environment to be associated with the host. Ignored for multi-environment hosts.")
       param :content_view_environments, Array, :desc => N_("Comma-separated list of content view environment labels to be associated with the host,"\
                                               " in the format of 'lifecycle_environment_label/content_view_label'."\
-                                              " Ignored if content_view_environment_ids is specified, or if content_view_id and lifecycle_environment_id are specified."\
+                                              " Ignored if content_view_environment_ids is specified."\
                                               " Requires allow_multiple_content_views setting to be on.")
-      param :content_view_environment_ids, Array, :desc => N_("Array of content view environment ids to be associated with the host. Ignored if content_view_id and lifecycle_environment_id are specified. Requires allow_multiple_content_views setting to be on.")
+      param :content_view_environment_ids, Array, :desc => N_("Array of content view environment ids to be associated with the host. Requires allow_multiple_content_views setting to be on.")
       param :content_source_id, Integer, :desc => N_("Id of the smart proxy from which the host consumes content.")
       param :kickstart_repository_id, Integer, :desc => N_("Repository Id associated with the kickstart repo used for provisioning")
     end

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -224,13 +224,13 @@ module Katello
       version_environments = {}
       content_facets = Katello::Host::ContentFacet.with_non_installable_errata(@errata, @hosts)
 
-      ContentViewEnvironment.for_content_facets(content_facets).each do |cve|
-        version = cve.content_view_version
+      ContentViewEnvironment.for_content_facets(content_facets).each do |cvenv|
+        version = cvenv.content_view_version
         version_environment = version_environments[version] || {:content_view_version => version, :environments => []}
-        version_environment[:environments] << cve.environment unless version_environment[:environments].include?(cve.environment)
+        version_environment[:environments] << cvenv.environment unless version_environment[:environments].include?(cvenv.environment)
         version_environment[:next_version] ||= version.next_incremental_version
         version_environment[:content_host_count] ||= 0
-        version_environment[:content_host_count] += content_facets.with_content_view_environments(cve).count
+        version_environment[:content_host_count] += content_facets.with_content_view_environments(cvenv).count
 
         if version.content_view.composite?
           version_environment[:components] = version.components_needing_errata(@errata)

--- a/app/controllers/katello/concerns/api/v2/hostgroups_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hostgroups_controller_extensions.rb
@@ -7,8 +7,6 @@ module Katello
         update_api(:create, :update) do
           param :hostgroup, Hash do
             param :content_source_id, :number, :desc => N_('Content source ID')
-            param :content_view_id, :number, :desc => N_('Content view ID'), :deprecated => true
-            param :lifecycle_environment_id, :number, :desc => N_('Lifecycle environment ID'), :deprecated => true
             param :content_view_environment_id, :number, :desc => N_('Content view environment ID')
             param :kickstart_repository_id, :number, :desc => N_('Kickstart repository ID')
           end

--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -61,15 +61,15 @@ module Katello
         def validate_content_view_environment_params
           content_facet_attributes = params.dig(:host, :content_facet_attributes)
           return if content_facet_attributes.blank?
-          return unless cve_params[:content_view_environments].present? || cve_params[:content_view_environment_ids].present?
+          return unless cvenv_params[:content_view_environments].present? || cvenv_params[:content_view_environment_ids].present?
 
           cves = ::Katello::ContentViewEnvironment.fetch_content_view_environments(
-            labels: cve_params[:content_view_environments],
-            ids: cve_params[:content_view_environment_ids],
+            labels: cvenv_params[:content_view_environments],
+            ids: cvenv_params[:content_view_environment_ids],
             organization: find_organization || @host&.organization)
           if cves.blank?
-            handle_errors(labels: cve_params[:content_view_environments],
-              ids: cve_params[:content_view_environment_ids])
+            handle_errors(labels: cvenv_params[:content_view_environments],
+              ids: cvenv_params[:content_view_environment_ids])
           end
           cves
         end
@@ -88,7 +88,7 @@ module Katello
         end
         # rubocop:enable Naming/AccessorMethodName
 
-        def cve_params
+        def cvenv_params
           params.require(:host).require(:content_facet_attributes).permit(content_view_environments: [], content_view_environment_ids: [])
         end
       end

--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -60,8 +60,8 @@ module Katello
 
         def validate_content_view_environment_params
           content_facet_attributes = params.dig(:host, :content_facet_attributes)
-          return if content_facet_attributes.blank? ||
-          (cve_params[:content_view_id].present? && cve_params[:lifecycle_environment_id].present?)
+          return if content_facet_attributes.blank?
+          return unless cve_params[:content_view_environments].present? || cve_params[:content_view_environment_ids].present?
 
           cves = ::Katello::ContentViewEnvironment.fetch_content_view_environments(
             labels: cve_params[:content_view_environments],
@@ -89,7 +89,7 @@ module Katello
         # rubocop:enable Naming/AccessorMethodName
 
         def cve_params
-          params.require(:host).require(:content_facet_attributes).permit(:content_view_id, :lifecycle_environment_id, content_view_environments: [], content_view_environment_ids: [])
+          params.require(:host).require(:content_facet_attributes).permit(content_view_environments: [], content_view_environment_ids: [])
         end
       end
     end

--- a/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
+++ b/app/controllers/katello/concerns/authorization/api/v2/content_views_controller.rb
@@ -110,15 +110,15 @@ module Katello
     end
 
     def authorize_hostgroup_content_view_environment(view, options)
-      cv_env_id = options[:hostgroup_content_view_environment_id]
-      if cv_env_id
-        cv_env = ContentViewEnvironment.joins(:content_view, :environment)
-          .where(id: cv_env_id)
+      cvenv_id = options[:hostgroup_content_view_environment_id]
+      if cvenv_id
+        cvenv = ContentViewEnvironment.joins(:content_view, :environment)
+          .where(id: cvenv_id)
           .where("#{ContentView.table_name}.organization_id" => view.organization.id)
           .first
-        fail HttpErrors::NotFound, _("Couldn't find host group content view environment id '%s'") % cv_env_id unless cv_env
+        fail HttpErrors::NotFound, _("Couldn't find host group content view environment id '%s'") % cvenv_id unless cvenv
         # deny if we cannot reassign hostgroups to the new content view environment
-        return deny_access unless cv_env.content_view.readable? && cv_env.environment.readable?
+        return deny_access unless cvenv.content_view.readable? && cvenv.environment.readable?
       end
       true
     end

--- a/app/helpers/katello/content_options_helper.rb
+++ b/app/helpers/katello/content_options_helper.rb
@@ -21,7 +21,7 @@ module Katello
         end
 
         if orgs.count > 1
-          all_options << %(<optgroup label="#{org.name}">#{content_object_options}</optgroup>)
+          all_options << %(<optgroup label="#{h(org.name)}">#{content_object_options}</optgroup>)
         else
           all_options << content_object_options
         end
@@ -58,54 +58,54 @@ module Katello
       include_blank = '<option></option>' if include_blank == true
 
       orgs = relevant_organizations(hostgroup)
-      current_cve = fetch_content_view_environment(hostgroup, options)
+      current_cvenv = fetch_content_view_environment(hostgroup, options)
       content_source = fetch_content_source(hostgroup, options)
 
-      all_options = build_cve_options_for_orgs(orgs, current_cve, content_source)
+      all_options = build_cvenv_options_for_orgs(orgs, current_cvenv, content_source)
       all_options = all_options.join
       all_options.insert(0, include_blank) if include_blank
       all_options.html_safe # User content is safely escaped with h()
     end
     # rubocop:enable Rails/OutputSafety
 
-    def build_cve_options_for_orgs(orgs, current_cve, content_source)
+    def build_cvenv_options_for_orgs(orgs, current_cvenv, content_source)
       orgs.map do |org|
-        cves = fetch_cves_for_org(org, current_cve, content_source)
-        cve_options = build_cve_option_tags(cves, current_cve)
+        cvenvs = fetch_cvenvs_for_org(org, current_cvenv, content_source)
+        cvenv_options = build_cvenv_option_tags(cvenvs, current_cvenv)
 
         if orgs.count > 1
-          %(<optgroup label="#{org.name}">#{cve_options}</optgroup>)
+          %(<optgroup label="#{h(org.name)}">#{cvenv_options}</optgroup>)
         else
-          cve_options
+          cvenv_options
         end
       end
     end
 
-    def fetch_cves_for_org(org, current_cve, content_source)
-      cves = Katello::ContentViewEnvironment.joins(:content_view, :environment)
+    def fetch_cvenvs_for_org(org, current_cvenv, content_source)
+      cvenvs = Katello::ContentViewEnvironment.joins(:content_view, :environment)
                .where("#{Katello::ContentView.table_name}.organization_id" => org.id)
                .order("#{Katello::KTEnvironment.table_name}.name", "#{Katello::ContentView.table_name}.name")
                .to_a
 
-      cves = filter_cves_by_content_source(cves, content_source, org) if content_source.present?
-      cves |= [current_cve] if current_cve.present? && current_cve.content_view.organization_id == org.id
-      cves
+      cvenvs = filter_cvenvs_by_content_source(cvenvs, content_source, org) if content_source.present?
+      cvenvs |= [current_cvenv] if current_cvenv.present? && current_cvenv.content_view.organization_id == org.id
+      cvenvs
     end
 
-    def filter_cves_by_content_source(cves, content_source, org)
-      return cves if content_source.pulp_primary?
+    def filter_cvenvs_by_content_source(cvenvs, content_source, org)
+      return cvenvs if content_source.pulp_primary?
 
       available_env_ids = content_source.lifecycle_environments.where(organization_id: org.id).pluck(:id)
-      return cves unless available_env_ids.any?
+      return cvenvs unless available_env_ids.any?
 
-      cves.select { |cve| available_env_ids.include?(cve.environment_id) }
+      cvenvs.select { |cvenv| available_env_ids.include?(cvenv.environment_id) }
     end
 
-    def build_cve_option_tags(cves, current_cve)
-      option_tags = cves.map do |cve|
-        selected = current_cve&.id == cve.id ? 'selected' : ''
-        label = cve.default_environment? ? cve.environment.name : "#{cve.environment.name} / #{cve.content_view.name}"
-        %(<option value="#{cve.id}" #{selected}>#{h(label)}</option>)
+    def build_cvenv_option_tags(cvenvs, current_cvenv)
+      option_tags = cvenvs.map do |cvenv|
+        selected = current_cvenv&.id == cvenv.id ? 'selected' : ''
+        label = cvenv.label
+        %(<option value="#{cvenv.id}" #{selected}>#{h(label)}</option>)
       end
       option_tags.join
     end
@@ -160,16 +160,11 @@ module Katello
 
     def blank_or_inherit_cvenv(f) # f is Rails convention for form objects
       return true unless f.object.respond_to?(:parent_id) && f.object.parent_id
-      parent_cve = f.object.parent&.content_view_environment
-      inherited_value = parent_cve.try(:id) || ''
+      parent_cvenv = f.object.parent&.content_view_environment
+      inherited_value = parent_cvenv.try(:id) || ''
 
-      if parent_cve
-        cve_name = if parent_cve.default_environment?
-                     parent_cve.environment.name
-                   else
-                     "#{parent_cve.environment.name} / #{parent_cve.content_view.name}"
-                   end
-        %(<option data-id="#{inherited_value}" value="">#{h(_('Inherit parent (%s)') % cve_name)}</option>)
+      if parent_cvenv
+        %(<option data-id="#{inherited_value}" value="">#{h(_('Inherit parent (%s)') % parent_cvenv.label)}</option>)
       else
         %(<option value="">#{_('Inherit parent')}</option>)
       end

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -73,9 +73,10 @@ module Katello
     def fetch_content_view_environment(host_or_hostgroup, options = {})
       if host_or_hostgroup&.content_facet.present?
         if host_or_hostgroup.is_a?(::Hostgroup)
-          return host_or_hostgroup.content_facet.content_view_environment
+          return host_or_hostgroup.content_facet.content_view_environment if host_or_hostgroup.content_facet.content_view_environment.present?
         else
-          return host_or_hostgroup.content_facet.content_view_environments.first
+          first_cvenv = host_or_hostgroup.content_facet.content_view_environments.first
+          return first_cvenv if first_cvenv.present?
         end
       end
       selected_host_group = options.fetch(:selected_host_group, nil)
@@ -135,29 +136,29 @@ module Katello
       content_source_id
     end
 
-    def inherited_or_own_cve_id(host_or_hostgroup, hostgroup)
-      inherited_cve_id = hostgroup.content_facet&.content_view_environment_id
-      inherited_cve_id ||= hostgroup.send(:inherited_ancestry_attribute, :content_view_environment_id, :content_facet) if hostgroup.ancestry.present?
+    def inherited_or_own_cvenv_id(host_or_hostgroup, hostgroup)
+      inherited_cvenv_id = hostgroup.content_facet&.content_view_environment_id
+      inherited_cvenv_id ||= hostgroup.send(:inherited_ancestry_attribute, :content_view_environment_id, :content_facet) if hostgroup.ancestry.present?
 
       case host_or_hostgroup
       when ::Hostgroup
-        own_cve_id = host_or_hostgroup.content_facet&.content_view_environment_id
-        own_cve_id && own_cve_id != inherited_cve_id ? own_cve_id : inherited_cve_id
+        own_cvenv_id = host_or_hostgroup.content_facet&.content_view_environment_id
+        own_cvenv_id && own_cvenv_id != inherited_cvenv_id ? own_cvenv_id : inherited_cvenv_id
       when ::Host::Managed
-        own_cve = host_or_hostgroup.content_view_environments.first
-        own_cve && own_cve.id != inherited_cve_id ? own_cve.id : inherited_cve_id
+        own_cvenv = host_or_hostgroup.content_view_environments.first
+        own_cvenv && own_cvenv.id != inherited_cvenv_id ? own_cvenv.id : inherited_cvenv_id
       else
-        inherited_cve_id
+        inherited_cvenv_id
       end
     end
 
     def hostgroup_content_facet(hostgroup, param_host)
-      cve_id = inherited_or_own_cve_id(param_host, hostgroup)
+      cvenv_id = inherited_or_own_cvenv_id(param_host, hostgroup)
       content_source_id = inherited_or_own_content_source_id(param_host, hostgroup)
       facet = ::Katello::Host::ContentFacet.new(:content_source_id => content_source_id)
-      if cve_id
-        cve = ::Katello::ContentViewEnvironment.find_by(id: cve_id)
-        facet.content_view_environments = [cve] if cve
+      if cvenv_id
+        cvenv = ::Katello::ContentViewEnvironment.find_by(id: cvenv_id)
+        facet.content_view_environments = [cvenv] if cvenv
       end
       facet
     end

--- a/app/helpers/katello/hosts_and_hostgroups_helper.rb
+++ b/app/helpers/katello/hosts_and_hostgroups_helper.rb
@@ -70,8 +70,14 @@ module Katello
       return selected_host_group.content_view if selected_host_group.present?
     end
 
-    def fetch_content_view_environment(hostgroup, options = {})
-      return hostgroup.content_facet.content_view_environment if hostgroup.content_facet.present?
+    def fetch_content_view_environment(host_or_hostgroup, options = {})
+      if host_or_hostgroup&.content_facet.present?
+        if host_or_hostgroup.is_a?(::Hostgroup)
+          return host_or_hostgroup.content_facet.content_view_environment
+        else
+          return host_or_hostgroup.content_facet.content_view_environments.first
+        end
+      end
       selected_host_group = options.fetch(:selected_host_group, nil)
       return selected_host_group.content_facet.content_view_environment if selected_host_group&.content_facet.present?
     end
@@ -129,37 +135,29 @@ module Katello
       content_source_id
     end
 
-    def inherited_or_own_facet_attributes(host_or_hostgroup, hostgroup)
-      lifecycle_environment_id = hostgroup.inherited_lifecycle_environment_id
-      content_view_id = hostgroup.inherited_content_view_id
+    def inherited_or_own_cve_id(host_or_hostgroup, hostgroup)
+      inherited_cve_id = hostgroup.content_facet&.content_view_environment_id
+      inherited_cve_id ||= hostgroup.send(:inherited_ancestry_attribute, :content_view_environment_id, :content_facet) if hostgroup.ancestry.present?
+
       case host_or_hostgroup
       when ::Hostgroup
-        if host_or_hostgroup.lifecycle_environment_id && (hostgroup.inherited_lifecycle_environment_id != host_or_hostgroup.lifecycle_environment_id)
-          lifecycle_environment_id = host_or_hostgroup.lifecycle_environment_id
-        end
-        if host_or_hostgroup.content_view_id && (hostgroup.inherited_content_view_id != host_or_hostgroup.content_view_id)
-          content_view_id = host_or_hostgroup.content_view_id
-        end
+        own_cve_id = host_or_hostgroup.content_facet&.content_view_environment_id
+        own_cve_id && own_cve_id != inherited_cve_id ? own_cve_id : inherited_cve_id
       when ::Host::Managed
-        if host_or_hostgroup.single_lifecycle_environment && (hostgroup.inherited_lifecycle_environment_id != host_or_hostgroup.single_lifecycle_environment.id)
-          lifecycle_environment_id = host_or_hostgroup.single_lifecycle_environment.id
-        end
-        if host_or_hostgroup.single_content_view && (hostgroup.inherited_content_view_id != host_or_hostgroup.single_content_view.id)
-          content_view_id = host_or_hostgroup.single_content_view.id
-        end
+        own_cve = host_or_hostgroup.content_view_environments.first
+        own_cve && own_cve.id != inherited_cve_id ? own_cve.id : inherited_cve_id
+      else
+        inherited_cve_id
       end
-      [lifecycle_environment_id, content_view_id]
     end
 
     def hostgroup_content_facet(hostgroup, param_host)
-      lifecycle_environment_id, content_view_id = inherited_or_own_facet_attributes(param_host, hostgroup)
+      cve_id = inherited_or_own_cve_id(param_host, hostgroup)
       content_source_id = inherited_or_own_content_source_id(param_host, hostgroup)
       facet = ::Katello::Host::ContentFacet.new(:content_source_id => content_source_id)
-      if content_view_id && lifecycle_environment_id
-        facet.assign_single_environment(
-          :lifecycle_environment_id => lifecycle_environment_id,
-          :content_view_id => content_view_id
-        )
+      if cve_id
+        cve = ::Katello::ContentViewEnvironment.find_by(id: cve_id)
+        facet.content_view_environments = [cve] if cve
       end
       facet
     end

--- a/app/helpers/katello/kickstart_repository_helper.rb
+++ b/app/helpers/katello/kickstart_repository_helper.rb
@@ -56,15 +56,17 @@ module Katello
 
         if (host.is_a? ::Hostgroup)
           new_host.content_facet = hostgroup_content_facet(host, param_host)
-        elsif host.content_facet.present?
+        elsif host.content_facet.present? && host.content_facet.content_view_environments.any?
           new_host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => host.content_source_id)
           if host.single_content_view_environment?
-            # assign new_host the same CVEnv as host
-            new_host.content_facet.assign_single_environment(
-              :lifecycle_environment => host.content_facet.single_lifecycle_environment,
-              :content_view => host.content_facet.single_content_view
+            cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+              host.content_facet.single_content_view.id,
+              host.content_facet.single_lifecycle_environment.id
             )
+            new_host.content_facet.content_view_environments = [cve]
           end
+        else
+          return os_updated_kickstart_options(new_host)
         end
         new_host.operatingsystem.kickstart_repos(new_host).map { |repo| OpenStruct.new(repo) }
       else
@@ -74,11 +76,7 @@ module Katello
     end
 
     def os_updated_kickstart_options(host = nil)
-      # this method gets called in 1 place Once you chose a diff os/content source/arch/lifecycle env/cv
-      # via the os_selected method.
-      # In this case we want it play by the rules of "one of these params" and
-      # need to figure out the available KS repos for the given params.
-      os_selection_params = ["operatingsystem_id", 'content_view_id', 'lifecycle_environment_id',
+      os_selection_params = ["operatingsystem_id", 'content_view_environment_id',
                              'content_source_id', 'architecture_id']
       view_options = []
 
@@ -90,15 +88,13 @@ module Katello
         end
         host.operatingsystem = fetch_inherited_param(host_params[:operatingsystem_id], ::Operatingsystem, parent&.os)
         host.architecture = fetch_inherited_param(host_params[:architecture_id], ::Architecture, parent&.architecture)
-        lifecycle_env = fetch_inherited_param(host_params[:lifecycle_environment_id], ::Katello::KTEnvironment, parent&.lifecycle_environment)
-        content_view = fetch_inherited_param(host_params[:content_view_id], ::Katello::ContentView, parent&.content_view)
         content_source = fetch_inherited_param(host_params[:content_source_id], ::SmartProxy, parent&.content_source)
 
+        cve_id = host_params[:content_view_environment_id]
+        cve = cve_id.present? ? ::Katello::ContentViewEnvironment.find_by(id: cve_id) : parent&.content_view_environment
+
         host.content_facet = Host::ContentFacet.new(:content_source => content_source)
-        host.content_facet.assign_single_environment(
-          :lifecycle_environment_id => lifecycle_env.id,
-          :content_view_id => content_view.id
-        )
+        host.content_facet.content_view_environments = [cve] if cve
         if host.operatingsystem.is_a?(Redhat)
           view_options = host.operatingsystem.kickstart_repos(host).map { |repo| OpenStruct.new(repo) }
         end

--- a/app/helpers/katello/kickstart_repository_helper.rb
+++ b/app/helpers/katello/kickstart_repository_helper.rb
@@ -59,11 +59,11 @@ module Katello
         elsif host.content_facet.present? && host.content_facet.content_view_environments.any?
           new_host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => host.content_source_id)
           if host.single_content_view_environment?
-            cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+            cvenv = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(
               host.content_facet.single_content_view.id,
               host.content_facet.single_lifecycle_environment.id
             )
-            new_host.content_facet.content_view_environments = [cve]
+            new_host.content_facet.content_view_environments = [cvenv]
           end
         else
           return os_updated_kickstart_options(new_host)
@@ -90,11 +90,11 @@ module Katello
         host.architecture = fetch_inherited_param(host_params[:architecture_id], ::Architecture, parent&.architecture)
         content_source = fetch_inherited_param(host_params[:content_source_id], ::SmartProxy, parent&.content_source)
 
-        cve_id = host_params[:content_view_environment_id]
-        cve = cve_id.present? ? ::Katello::ContentViewEnvironment.find_by(id: cve_id) : parent&.content_view_environment
+        cvenv_id = host_params[:content_view_environment_id]
+        cvenv = cvenv_id.present? ? ::Katello::ContentViewEnvironment.find_by(id: cvenv_id) : parent&.content_view_environment
 
         host.content_facet = Host::ContentFacet.new(:content_source => content_source)
-        host.content_facet.content_view_environments = [cve] if cve
+        host.content_facet.content_view_environments = [cvenv] if cvenv
         if host.operatingsystem.is_a?(Redhat)
           view_options = host.operatingsystem.kickstart_repos(host).map { |repo| OpenStruct.new(repo) }
         end

--- a/app/lib/actions/katello/activation_key/reassign.rb
+++ b/app/lib/actions/katello/activation_key/reassign.rb
@@ -3,10 +3,9 @@ module Actions
     module ActivationKey
       class Reassign < Actions::Base
         def plan(activation_key, content_view_id, environment_id)
-          activation_key.assign_single_environment(
-            content_view: ::Katello::ContentView.find(content_view_id),
-            lifecycle_environment: ::Katello::KTEnvironment.find(environment_id)
-          )
+          cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, environment_id)
+          activation_key.content_view_environments = [cve]
+          activation_key.save!
         end
       end
     end

--- a/app/lib/actions/katello/activation_key/reassign.rb
+++ b/app/lib/actions/katello/activation_key/reassign.rb
@@ -3,8 +3,8 @@ module Actions
     module ActivationKey
       class Reassign < Actions::Base
         def plan(activation_key, content_view_id, environment_id)
-          cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, environment_id)
-          activation_key.content_view_environments = [cve]
+          cvenv = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, environment_id)
+          activation_key.content_view_environments = [cvenv]
           activation_key.save!
         end
       end

--- a/app/lib/actions/katello/content_view/add_to_environment.rb
+++ b/app/lib/actions/katello/content_view/add_to_environment.rb
@@ -3,13 +3,13 @@ module Actions
     module ContentView
       class AddToEnvironment < Actions::Base
         def plan(content_view_version, environment)
-          cve = ::Katello::ContentViewManager.add_version_to_environment(
+          cvenv = ::Katello::ContentViewManager.add_version_to_environment(
             content_view_version: content_view_version,
             environment: environment
           )
 
           ::Katello::ContentViewManager.create_candlepin_environment(
-            content_view_environment: cve
+            content_view_environment: cvenv
           )
 
           content_view_version.save!

--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -17,7 +17,7 @@ module Actions
           old_new_version_map = {}
           output_for_version_ids = []
           # Extract composite CV IDs that will be updated via propagate to prevent duplicate auto-publish
-          propagated_composite_cv_ids = composite_version_environments.map { |cve| cve[:content_view_version].content_view_id }.compact.uniq
+          propagated_composite_cv_ids = composite_version_environments.map { |cvenv| cvenv[:content_view_version].content_view_id }.compact.uniq
 
           sequence do
             concurrence do

--- a/app/lib/actions/katello/content_view/remove.rb
+++ b/app/lib/actions/katello/content_view/remove.rb
@@ -19,37 +19,37 @@ module Actions
         # rubocop:disable Metrics/MethodLength
         # rubocop:disable Metrics/CyclomaticComplexity
         def plan(content_view, options)
-          cv_envs = options.fetch(:content_view_environments, [])
+          cvenvs = options.fetch(:content_view_environments, [])
           versions = options.fetch(:content_view_versions, [])
           organization_destroy = options.fetch(:organization_destroy, false)
           skip_repo_destroy = options.fetch(:skip_repo_destroy, false)
           action_subject(content_view)
-          validate_options(content_view, cv_envs, versions, options) unless organization_destroy
+          validate_options(content_view, cvenvs, versions, options) unless organization_destroy
 
-          all_cv_envs = combined_cv_envs(cv_envs, versions)
-          check_version_deletion(versions, cv_envs)
+          all_cvenvs = combined_cvenvs(cvenvs, versions)
+          check_version_deletion(versions, cvenvs)
 
           sequence do
             unless organization_destroy
               concurrence do
-                all_cv_envs.each do |cv_env|
-                  if cv_env.hosts.any? || cv_env.activation_keys.any? || cv_env.hostgroups.any?
-                    plan_action(ContentViewEnvironment::ReassignObjects, cv_env, options)
+                all_cvenvs.each do |cvenv|
+                  if cvenv.hosts.any? || cvenv.activation_keys.any? || cvenv.hostgroups.any?
+                    plan_action(ContentViewEnvironment::ReassignObjects, cvenv, options)
                   end
                 end
               end
             end
 
             cv_histories = []
-            all_cv_envs.each do |cve|
-              cv_histories << ::Katello::ContentViewHistory.create!(:content_view_version => cve.content_view_version,
+            all_cvenvs.each do |cvenv|
+              cv_histories << ::Katello::ContentViewHistory.create!(:content_view_version => cvenv.content_view_version,
                                                                     :user => ::User.current.login,
-                                                                    :environment => cve.environment,
+                                                                    :environment => cvenv.environment,
                                                                     :status => ::Katello::ContentViewHistory::IN_PROGRESS,
                                                                     :action => ::Katello::ContentViewHistory.actions[:removal],
                                                                     :task => self.task)
               plan_action(ContentViewEnvironment::Destroy,
-                          cve,
+                          cvenv,
                           :skip_repo_destroy => skip_repo_destroy,
                           :organization_destroy => organization_destroy)
             end
@@ -68,8 +68,8 @@ module Actions
             end
             plan_self(content_view_id: content_view.id,
                       destroy_content_view: options[:destroy_content_view],
-                      environment_ids: cv_envs.map(&:environment_id),
-                      environment_names: cv_envs.map { |cve| cve.environment.name },
+                      environment_ids: cvenvs.map(&:environment_id),
+                      environment_names: cvenvs.map { |cvenv| cvenv.environment.name },
                       version_ids: versions.map(&:id),
                       content_view_history_ids: cv_histories.map { |history| history.id })
 
@@ -89,10 +89,10 @@ module Actions
           ::Katello::Host::SubscriptionFacet.where(:host_id => host_ids).destroy_all
         end
 
-        def check_version_deletion(versions, cv_envs)
+        def check_version_deletion(versions, cvenvs)
           versions.each do |version|
             version.environments.each do |env|
-              if cv_envs.none? { |cv_env| cv_env.content_view_version == version && cv_env.environment == env }
+              if cvenvs.none? { |cvenv| cvenv.content_view_version == version && cvenv.environment == env }
                 fail _("Cannot delete version while it is in environment %s") % env.name
               end
             end
@@ -119,44 +119,44 @@ module Actions
           end
         end
 
-        def validate_options(_content_view, cv_envs, versions, options)
-          if !options[:destroy_content_view] && cv_envs.empty? && versions.empty?
+        def validate_options(_content_view, cvenvs, versions, options)
+          if !options[:destroy_content_view] && cvenvs.empty? && versions.empty?
             fail _("Either environments or versions must be specified.")
           end
-          all_cv_envs = combined_cv_envs(cv_envs, versions)
+          all_cvenvs = combined_cvenvs(cvenvs, versions)
 
-          single_env_hosts_exist = all_cv_envs.flat_map(&:hosts).any? do |host|
+          single_env_hosts_exist = all_cvenvs.flat_map(&:hosts).any? do |host|
             !host.content_facet.multi_content_view_environment?
           end
-          if single_env_hosts_exist && !cve_exists?(options[:system_environment_id], options[:system_content_view_id])
+          if single_env_hosts_exist && !cvenv_exists?(options[:system_environment_id], options[:system_content_view_id])
             fail _("Unable to reassign systems. Please check system_content_view_id and system_environment_id.")
           end
 
-          single_env_keys_exist = all_cv_envs.flat_map(&:activation_keys).any? do |key|
+          single_env_keys_exist = all_cvenvs.flat_map(&:activation_keys).any? do |key|
             !key.multi_content_view_environment?
           end
-          if single_env_keys_exist && !cve_exists?(options[:key_environment_id], options[:key_content_view_id])
+          if single_env_keys_exist && !cvenv_exists?(options[:key_environment_id], options[:key_content_view_id])
             fail _("Unable to reassign activation_keys. Please check activation_key_content_view_id and activation_key_environment_id.")
           end
 
-          hostgroups_exist = all_cv_envs.flat_map(&:hostgroups).any?
-          if hostgroups_exist && !cve_exists_by_id?(options[:hostgroup_content_view_environment_id])
+          hostgroups_exist = all_cvenvs.flat_map(&:hostgroups).any?
+          if hostgroups_exist && !cvenv_exists_by_id?(options[:hostgroup_content_view_environment_id])
             fail _("Unable to reassign host groups. Please check hostgroup_content_view_environment_id.")
           end
         end
 
-        def combined_cv_envs(cv_envs, versions)
-          (cv_envs + versions.flat_map(&:content_view_environments)).uniq
+        def combined_cvenvs(cvenvs, versions)
+          (cvenvs + versions.flat_map(&:content_view_environments)).uniq
         end
 
-        def cve_exists?(environment_id, content_view_id)
+        def cvenv_exists?(environment_id, content_view_id)
           ::Katello::ContentViewEnvironment.where(:environment_id => environment_id,
                                                   :content_view_id => content_view_id
                                                  ).exists?
         end
 
-        def cve_exists_by_id?(cv_env_id)
-          ::Katello::ContentViewEnvironment.where(:id => cv_env_id).exists?
+        def cvenv_exists_by_id?(cvenv_id)
+          ::Katello::ContentViewEnvironment.where(:id => cvenv_id).exists?
         end
       end
     end

--- a/app/lib/actions/katello/content_view/remove_from_environment.rb
+++ b/app/lib/actions/katello/content_view/remove_from_environment.rb
@@ -8,22 +8,22 @@ module Actions
           action_subject(content_view)
           content_view.check_remove_from_environment!(environment)
 
-          cv_env = ::Katello::ContentViewEnvironment.where(:content_view_id => content_view.id,
+          cvenv = ::Katello::ContentViewEnvironment.where(:content_view_id => content_view.id,
                                                            :environment_id => environment.id).first
 
-          if cv_env.nil?
+          if cvenv.nil?
             fail _("Cannot remove content view from environment. Content view '%{view}' is not in lifecycle environment '%{env}'.") %
               {view: content_view.name, env: environment.name}
           end
 
-          history = ::Katello::ContentViewHistory.create!(:content_view_version => cv_env.content_view_version,
+          history = ::Katello::ContentViewHistory.create!(:content_view_version => cvenv.content_view_version,
                                                           :environment => environment,
                                                           :user => ::User.current.login,
                                                           :status => ::Katello::ContentViewHistory::IN_PROGRESS,
                                                           :action => ::Katello::ContentViewHistory.actions[:removal],
                                                           :task => self.task)
 
-          plan_action(ContentViewEnvironment::Destroy, cv_env)
+          plan_action(ContentViewEnvironment::Destroy, cvenv)
           plan_self(history_id: history.id)
         end
 

--- a/app/lib/actions/katello/environment/destroy.rb
+++ b/app/lib/actions/katello/environment/destroy.rb
@@ -18,8 +18,8 @@ module Actions
             action_subject(env)
 
             concurrence do
-              env.content_view_environments.each do |cve|
-                plan_action(ContentView::Remove, cve.content_view, :content_view_environments => [cve], :skip_repo_destroy => skip_repo_destroy, :organization_destroy => organization_destroy)
+              env.content_view_environments.each do |cvenv|
+                plan_action(ContentView::Remove, cvenv.content_view, :content_view_environments => [cvenv], :skip_repo_destroy => skip_repo_destroy, :organization_destroy => organization_destroy)
               end
             end
 

--- a/app/lib/actions/katello/host/reassign.rb
+++ b/app/lib/actions/katello/host/reassign.rb
@@ -3,8 +3,8 @@ module Actions
     module Host
       class Reassign < Actions::Base
         def plan(host, content_view_id, environment_id)
-          cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, environment_id)
-          host.content_facet.content_view_environments = [cve]
+          cvenv = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, environment_id)
+          host.content_facet.content_view_environments = [cvenv]
           host.update_candlepin_associations
         end
       end

--- a/app/lib/actions/katello/host/reassign.rb
+++ b/app/lib/actions/katello/host/reassign.rb
@@ -3,10 +3,8 @@ module Actions
     module Host
       class Reassign < Actions::Base
         def plan(host, content_view_id, environment_id)
-          host.content_facet.assign_single_environment(
-            content_view: ::Katello::ContentView.find(content_view_id),
-            lifecycle_environment: ::Katello::KTEnvironment.find(environment_id)
-          )
+          cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, environment_id)
+          host.content_facet.content_view_environments = [cve]
           host.update_candlepin_associations
         end
       end

--- a/app/lib/actions/katello/host/update_content_view.rb
+++ b/app/lib/actions/katello/host/update_content_view.rb
@@ -4,10 +4,8 @@ module Actions
       class UpdateContentView < Actions::EntryAction
         def plan(host, content_view_id, lifecycle_environment_id)
           if host.content_facet
-            host.content_facet.assign_single_environment(
-              content_view_id: content_view_id,
-              lifecycle_environment_id: lifecycle_environment_id
-            )
+            cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, lifecycle_environment_id)
+            host.content_facet.content_view_environments = [cve]
             host.update_candlepin_associations
             plan_self(:hostname => host.name)
           else

--- a/app/lib/actions/katello/host/update_content_view.rb
+++ b/app/lib/actions/katello/host/update_content_view.rb
@@ -4,8 +4,8 @@ module Actions
       class UpdateContentView < Actions::EntryAction
         def plan(host, content_view_id, lifecycle_environment_id)
           if host.content_facet
-            cve = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, lifecycle_environment_id)
-            host.content_facet.content_view_environments = [cve]
+            cvenv = ::Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view_id, lifecycle_environment_id)
+            host.content_facet.content_view_environments = [cvenv]
             host.update_candlepin_associations
             plan_self(:hostname => host.name)
           else

--- a/app/lib/actions/katello/organization/destroy.rb
+++ b/app/lib/actions/katello/organization/destroy.rb
@@ -64,8 +64,8 @@ module Actions
           plan_action(Katello::Environment::Destroy, organization.library, :skip_repo_destroy => true, :organization_destroy => true)
         end
 
-        def remove_content_view_environment(cv_env)
-          plan_action(ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => true, :organization_destroy => true)
+        def remove_content_view_environment(cvenv)
+          plan_action(ContentViewEnvironment::Destroy, cvenv, :skip_repo_destroy => true, :organization_destroy => true)
         end
 
         def remove_content_views(organization)
@@ -86,7 +86,7 @@ module Actions
 
         def remove_default_content_view(organization)
           organization.default_content_view.tap do |view|
-            view.content_view_environments.each { |cve| remove_content_view_environment(cve) }
+            view.content_view_environments.each { |cvenv| remove_content_view_environment(cvenv) }
             plan_action(ContentView::Destroy, organization.default_content_view, :check_ready_to_destroy => false, :organization_destroy => true)
           end
         end

--- a/app/lib/actions/katello/organization/environment_contents_refresh.rb
+++ b/app/lib/actions/katello/organization/environment_contents_refresh.rb
@@ -5,12 +5,12 @@ module Actions
         middleware.use Actions::Middleware::PropagateCandlepinErrors
 
         def plan(organization)
-          organization.content_view_environments.each do |cve|
+          organization.content_view_environments.each do |cvenv|
             plan_action(
               Actions::Candlepin::Environment::SetContent,
-              cve.content_view,
-              cve.owner,
-              cve
+              cvenv.content_view,
+              cvenv.owner,
+              cvenv
             )
           end
         end

--- a/app/lib/katello/util/cve_hgcf_migrator.rb
+++ b/app/lib/katello/util/cve_hgcf_migrator.rb
@@ -16,8 +16,8 @@ module Katello
       private
 
       def validate_hostgroup_facets
-        hostgroups_with_no_cve = []
-        hostgroups_with_missing_cve = []
+        hostgroups_with_no_cvenv = []
+        hostgroups_with_missing_cvenv = []
         hostgroups_with_partial_data = []
 
         FakeHostgroupContentFacet.all.each do |hg_facet|
@@ -26,13 +26,13 @@ module Katello
           if partial_data?(hg_facet)
             hostgroups_with_partial_data << hg_facet
           else
-            categorize_facet(hg_facet, hostgroups_with_no_cve, hostgroups_with_missing_cve)
+            categorize_facet(hg_facet, hostgroups_with_no_cvenv, hostgroups_with_missing_cvenv)
           end
         end
 
         {
           partial_data_count: hostgroups_with_partial_data.count,
-          problematic_facets: build_problematic_facets_info(hostgroups_with_no_cve + hostgroups_with_missing_cve),
+          problematic_facets: build_problematic_facets_info(hostgroups_with_no_cvenv + hostgroups_with_missing_cvenv),
         }
       end
 
@@ -40,12 +40,12 @@ module Katello
         hg_facet.content_view_id.blank? || hg_facet.lifecycle_environment_id.blank?
       end
 
-      def categorize_facet(hg_facet, hostgroups_with_no_cve, hostgroups_with_missing_cve)
+      def categorize_facet(hg_facet, hostgroups_with_no_cvenv, hostgroups_with_missing_cvenv)
         if valid_cv_and_lce?(hg_facet)
-          cve = find_content_view_environment(hg_facet)
-          hostgroups_with_no_cve << hg_facet if cve.blank?
+          cvenv = find_content_view_environment(hg_facet)
+          hostgroups_with_no_cvenv << hg_facet if cvenv.blank?
         else
-          hostgroups_with_missing_cve << hg_facet
+          hostgroups_with_missing_cvenv << hg_facet
         end
       end
 

--- a/app/lib/katello/util/cveak_migrator.rb
+++ b/app/lib/katello/util/cveak_migrator.rb
@@ -6,27 +6,27 @@ module Katello
 
     class CVEAKMigrator # used in db/migrate/20240730163043_add_content_view_environment_activation_key.rb
       def execute!
-        aks_with_no_cve = []
-        aks_with_missing_cve = []
+        aks_with_no_cvenv = []
+        aks_with_missing_cvenv = []
 
         FakeActivationKey.all.each do |ak|
           next if ak.content_view_id.blank? && ak.environment_id.blank?
           if ::Katello::ContentView.exists?(id: ak.content_view_id) && ::Katello::KTEnvironment.exists?(ak.environment_id)
-            cve = ::Katello::ContentViewEnvironment.find_by(content_view_id: ak.content_view_id, environment_id: ak.environment_id)
-            if cve.blank?
-              aks_with_no_cve << ak
+            cvenv = ::Katello::ContentViewEnvironment.find_by(content_view_id: ak.content_view_id, environment_id: ak.environment_id)
+            if cvenv.blank?
+              aks_with_no_cvenv << ak
             end
           else
-            aks_with_missing_cve << ak
+            aks_with_missing_cvenv << ak
           end
         end
 
-        if aks_with_missing_cve.present? || aks_with_no_cve.present?
-          Rails.logger.warn "Found #{aks_with_no_cve.count} activation keys whose combination of content view and lifecycle environment does not have a corresponding ContentViewEnvironment"
-          Rails.logger.warn "Found #{aks_with_missing_cve.count} activation keys which are missing either content_view_id or lifecycle_environment_id"
+        if aks_with_missing_cvenv.present? || aks_with_no_cvenv.present?
+          Rails.logger.warn "Found #{aks_with_no_cvenv.count} activation keys whose combination of content view and lifecycle environment does not have a corresponding ContentViewEnvironment"
+          Rails.logger.warn "Found #{aks_with_missing_cvenv.count} activation keys which are missing either content_view_id or lifecycle_environment_id"
           Rails.logger.info "You may want to change the content view / lifecycle environment for these activation keys manually."
         end
-        (aks_with_no_cve + aks_with_missing_cve).each do |ak|
+        (aks_with_no_cvenv + aks_with_missing_cvenv).each do |ak|
           ak_organization = ::Organization.find_by(id: ak.organization_id)
           default_content_view = ak_organization.default_content_view
           library = ak_organization.library

--- a/app/lib/katello/util/cvecf_migrator.rb
+++ b/app/lib/katello/util/cvecf_migrator.rb
@@ -2,27 +2,27 @@ module Katello
   module Util
     class CVECFMigrator # used in db/migrate/20220929204746_add_content_view_environment_content_facet.rb
       def execute!
-        hosts_with_no_cve = []
-        hosts_with_missing_cve = []
+        hosts_with_no_cvenv = []
+        hosts_with_missing_cvenv = []
 
         ::Host::Managed.all.each do |host|
           next if host.content_facet.blank?
           if ::Katello::ContentView.exists?(id: host.content_facet.content_view_id) && ::Katello::KTEnvironment.exists?(host.content_facet.lifecycle_environment_id)
-            cve = ::Katello::ContentViewEnvironment.find_by(content_view_id: host.content_facet.content_view_id, environment_id: host.content_facet.lifecycle_environment_id)
-            if cve.blank?
-              hosts_with_no_cve << host
+            cvenv = ::Katello::ContentViewEnvironment.find_by(content_view_id: host.content_facet.content_view_id, environment_id: host.content_facet.lifecycle_environment_id)
+            if cvenv.blank?
+              hosts_with_no_cvenv << host
             end
           else
-            hosts_with_missing_cve << host
+            hosts_with_missing_cvenv << host
           end
         end
 
-        if hosts_with_missing_cve.present? || hosts_with_no_cve.present?
-          Rails.logger.warn "Found #{hosts_with_no_cve.count} hosts whose lifecycle environment does not have a corresponding ContentViewEnvironment"
-          Rails.logger.warn "Found #{hosts_with_missing_cve.count} hosts whose content facet is missing either content_view_id or lifecycle_environment_id"
+        if hosts_with_missing_cvenv.present? || hosts_with_no_cvenv.present?
+          Rails.logger.warn "Found #{hosts_with_no_cvenv.count} hosts whose lifecycle environment does not have a corresponding ContentViewEnvironment"
+          Rails.logger.warn "Found #{hosts_with_missing_cvenv.count} hosts whose content facet is missing either content_view_id or lifecycle_environment_id"
           Rails.logger.info "You may want to change the content view / lifecycle environment for these hosts manually."
         end
-        (hosts_with_no_cve + hosts_with_missing_cve).each do |host|
+        (hosts_with_no_cvenv + hosts_with_missing_cvenv).each do |host|
           default_content_view = host.organization.default_content_view
           library = host.organization.library
           Rails.logger.info "Updating host #{host.name} with default content_view_id and lifecycle_environment_id"

--- a/app/lib/katello/validators/generated_content_view_validator.rb
+++ b/app/lib/katello/validators/generated_content_view_validator.rb
@@ -2,9 +2,9 @@ module Katello
   module Validators
     class GeneratedContentViewValidator < ActiveModel::Validator
       def validate(record)
-        record.content_view_environments.each do |cve|
-          if cve.content_view_id
-            view = ContentView.where(:id => cve.content_view_id).first
+        record.content_view_environments.each do |cvenv|
+          if cvenv.content_view_id
+            view = ContentView.where(:id => cvenv.content_view_id).first
             if view&.generated_for_repository?
               record.errors.add(:base, _("Content view '%{cv_name}' is a generated content view, which cannot be assigned to hosts or activation keys.") % { :cv_name => view.name })
             end

--- a/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
+++ b/app/lib/katello/validators/hostgroup_kickstart_repository_validator.rb
@@ -27,10 +27,9 @@ module Katello
       end
 
       def content_view_in_env?(facet)
-        env = facet.lifecycle_environment || facet.hostgroup.lifecycle_environment
-        cv = facet.content_view || facet.hostgroup.content_view
-        return true if env.blank? || cv.blank?
-        env.content_views.include?(cv)
+        cvenv = facet.content_view_environment || facet.hostgroup.content_view_environment
+        return false if cvenv.blank?
+        cvenv.environment.content_views.include?(cvenv.content_view)
       end
     end
   end

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -110,14 +110,6 @@ module Katello
       content_view_environments&.first&.content_view
     end
 
-    def content_view
-      single_content_view
-    end
-
-    def environment
-      single_lifecycle_environment
-    end
-
     def single_lifecycle_environment
       if multi_content_view_environment?
         Rails.logger.warn _("Activation key %s has more than one lifecycle environment. Use #lifecycle_environments instead.") % name
@@ -125,38 +117,6 @@ module Katello
       content_view_environments&.first&.lifecycle_environment
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
-    def assign_single_environment(
-      content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,
-      content_view: nil, lifecycle_environment: nil, environment: nil
-    )
-      lifecycle_environment_id ||= environment_id || lifecycle_environment&.id || environment&.id || self.single_lifecycle_environment&.id
-      content_view_id ||= content_view&.id || self.single_content_view&.id
-
-      unless lifecycle_environment_id
-        fail _("Lifecycle environment must be specified")
-      end
-
-      unless content_view_id
-        fail _("Content view must be specified")
-      end
-
-      content_view_environment = ::Katello::ContentViewEnvironment
-        .where(:content_view_id => content_view_id, :environment_id => lifecycle_environment_id)
-        .first_or_create do |cve|
-        Rails.logger.info("ContentViewEnvironment not found for content view '#{cve.content_view_name}' and environment '#{cve.environment&.name}'; creating a new one.")
-      end
-      fail _("Unable to create ContentViewEnvironment. Check the logs for more information.") if content_view_environment.nil?
-
-      if self.content_view_environments.include?(content_view_environment)
-        Rails.logger.info("Activation key '#{name}' already has the content view environment '#{content_view_environment.content_view_name}' and environment '#{content_view_environment.environment&.name}'.")
-      else
-        self.content_view_environments = [content_view_environment]
-      end
-    end
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
 
     def usage_count
       subscription_facet_activation_keys.count

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -49,7 +49,7 @@ module Katello
       end
     end
     validates_with Katello::Validators::GeneratedContentViewValidator
-    validate :check_cves
+    validate :check_cvenvs
 
     scope :with_environments, ->(lifecycle_environments) do
       joins(:content_view_environment_activation_keys => :content_view_environment).
@@ -83,13 +83,13 @@ module Katello
       with_environments(envs)
     end
 
-    def content_view_environments=(new_cves)
-      if new_cves.length > 1 && !Setting['allow_multiple_content_views']
+    def content_view_environments=(new_cvenvs)
+      if new_cvenvs.length > 1 && !Setting['allow_multiple_content_views']
         fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
         _("Assigning an activation key to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")
       end
-      super(new_cves)
-      Katello::ContentViewEnvironmentActivationKey.reprioritize_for_activation_key(self, new_cves)
+      super(new_cvenvs)
+      Katello::ContentViewEnvironmentActivationKey.reprioritize_for_activation_key(self, new_cvenvs)
       self.content_view_environments.reload unless self.new_record?
     end
 
@@ -117,7 +117,6 @@ module Katello
       content_view_environments&.first&.lifecycle_environment
     end
 
-
     def usage_count
       subscription_facet_activation_keys.count
     end
@@ -127,8 +126,8 @@ module Katello
     end
 
     def available_releases
-      releases = self.content_view_environments.flat_map do |cve|
-        cve.content_view.version(cve.lifecycle_environment).available_releases
+      releases = self.content_view_environments.flat_map do |cvenv|
+        cvenv.content_view.version(cvenv.lifecycle_environment).available_releases
       end
       return self.organization.library.available_releases if releases.blank?
       releases
@@ -172,13 +171,13 @@ module Katello
       true
     end
 
-    def check_cves
-      cves_not_in_org = self.content_view_environments.any? do |cve|
-        cve.content_view.organization != cve.environment.organization ||
-          self.organization != cve.content_view.organization
+    def check_cvenvs
+      cvenvs_not_in_org = self.content_view_environments.any? do |cvenv|
+        cvenv.content_view.organization != cvenv.environment.organization ||
+          self.organization != cvenv.content_view.organization
       end
 
-      errors.add(:base, _("Cannot add content view environments from a different organization")) if cves_not_in_org
+      errors.add(:base, _("Cannot add content view environments from a different organization")) if cvenvs_not_in_org
     end
 
     apipie :class, desc: "A class representing #{model_name.human} object" do

--- a/app/models/katello/authorization/repository.rb
+++ b/app/models/katello/authorization/repository.rb
@@ -43,8 +43,8 @@ module Katello
         if host&.subscription_facet&.uuid.present?
           repo_ids = []
           if host&.content_view_environments&.any?
-            repo_ids = host.content_view_environments.flat_map do |cve|
-              cve&.content_view_version&.repositories&.where(environment_id: cve.environment)&.pluck(:id)
+            repo_ids = host.content_view_environments.flat_map do |cvenv|
+              cvenv&.content_view_version&.repositories&.where(environment_id: cvenv.environment)&.pluck(:id)
             end
             repo_ids = repo_ids.compact.uniq
           end

--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -72,10 +72,11 @@ module Katello
         )
 
         def content_facet_ignore_update?(attributes)
+          attrs = attributes.with_indifferent_access
+          cvenv_ids = attrs[:content_view_environment_ids]&.reject(&:blank?)
           self.content_facet.blank? && (
             attributes.values.all?(&:blank?) ||
-            attributes['content_view_id'].blank? ||
-            attributes['lifecycle_environment_id'].blank?
+            cvenv_ids.blank?
           )
         end
 

--- a/app/models/katello/concerns/host_managed_extensions.rb
+++ b/app/models/katello/concerns/host_managed_extensions.rb
@@ -7,42 +7,6 @@ module Katello
       include ForemanTasks::Concerns::ActionSubject
 
       module Overrides
-        def check_cve_attributes(attrs)
-          if attrs[:content_facet_attributes]
-            cv_id = attrs[:content_facet_attributes].delete(:content_view_id)
-            lce_id = attrs[:content_facet_attributes].delete(:lifecycle_environment_id)
-            # Running validations on a host will clear out any existing errors, and then
-            # validate all attributes. As we know, running update or save will run validations.
-            # Since we've just removed two attributes that may
-            # have caused an error, we need to save those so we can explicitly validate
-            # them below in add_back_cve_errors.
-            @pending_cve_attrs = { content_view_id: cv_id, lifecycle_environment_id: lce_id }
-            if cv_id && lce_id
-              if content_facet&.multi_content_view_environment?
-                Rails.logger.warn "content_view_id and lifecycle_environment_id cannot be used to reassign multi-environment host '#{name}'. Use content_view_environment_ids instead"
-                @pending_cve_attrs = {}
-                return
-              end
-              cve = content_facet&.assign_single_environment(content_view_id: cv_id, lifecycle_environment_id: lce_id)
-              Rails.logger.warn "Couldn't assign content view environment; host has no content facet" if cve.blank?
-              @pending_cve_attrs = {}
-            end
-            if (cv_id.present? && lce_id.blank?) || (cv_id.blank? && lce_id.present?)
-              errors.add(:base, _("Content view and lifecycle environment must be provided together"))
-            end
-          end
-        end
-
-        def attributes=(attrs)
-          check_cve_attributes(attrs) unless self.content_facet.blank?
-          super
-        end
-
-        def update(attrs)
-          check_cve_attributes(attrs) unless self.content_facet.blank?
-          super
-        end
-
         def validate_media?
           (content_source_id.blank? || (content_facet && content_facet.kickstart_repository.blank?)) && super
         end
@@ -124,8 +88,6 @@ module Katello
         validates :name, format: { with: Net::Validations::HOST_REGEXP, message: _("%{value} can contain only lowercase letters, numbers, dashes and dots.") }
 
         before_validation :correct_kickstart_repository
-        after_validation :add_back_cve_errors
-        after_update :clear_pending_cve_attributes
         before_update :check_host_registration, :if => proc { organization_id_changed? }
 
         after_validation :queue_reset_content_host_status
@@ -155,16 +117,6 @@ module Katello
         scoped_search :relation => :content_views, :on => :id, :complete_value => true, :rename => :content_view_id, :only_explicit => true
 
         smart_proxy_reference :content_facet => [:content_source_id]
-
-        def add_back_cve_errors
-          if @pending_cve_attrs&.[](:content_view_id).present? || @pending_cve_attrs&.[](:lifecycle_environment_id).present?
-            check_cve_attributes({ content_facet_attributes: @pending_cve_attrs })
-          end
-        end
-
-        def clear_pending_cve_attributes
-          @pending_cve_attrs = {}
-        end
 
         apipie :class do
           property :content_source, 'SmartProxy', desc: 'Returns Smart Proxy object as the content source for the host'

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -29,8 +29,7 @@ module Katello
 
         delegate :content_source_name, to: :content_facet, allow_nil: true
         delegate :content_source_id, :kickstart_repository_id, :content_view_id, :lifecycle_environment_id, :content_view_environment_id, to: :content_facet, allow_nil: true
-        delegate :'content_source_id=', :'kickstart_repository_id=', :'content_view_id=', :'lifecycle_environment_id=', :'content_view_environment_id=', to: :safe_content_facet, allow_nil: true
-        delegate :'content_view=', :'lifecycle_environment=', :'content_view_environment=', to: :safe_content_facet, allow_nil: true
+        delegate :'content_source_id=', :'kickstart_repository_id=', :'content_view_environment_id=', to: :safe_content_facet, allow_nil: true
 
         apipie :class do
           property :content_source, 'SmartProxy', desc: 'Returns Smart Proxy object as the content source for the host group'

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -56,8 +56,8 @@ module Katello
 
       def content_view_environment
         return super if ancestry.nil? || self.content_view_environment_id.present?
-        cve_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
-        Katello::ContentViewEnvironment.find_by(:id => cve_id)
+        cvenv_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
+        Katello::ContentViewEnvironment.find_by(:id => cvenv_id)
       end
 
       def content_view
@@ -85,18 +85,22 @@ module Katello
         inherited_ancestry_attribute(:content_source_id, :content_facet)
       end
 
-      def inherited_content_view_id
-        cv_env_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
-        return nil unless cv_env_id
+      def inherited_content_view_environment_id
+        inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
+      end
 
-        Katello::ContentViewEnvironment.find_by(id: cv_env_id)&.content_view_id
+      def inherited_content_view_id
+        cvenv_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
+        return nil unless cvenv_id
+
+        Katello::ContentViewEnvironment.find_by(id: cvenv_id)&.content_view_id
       end
 
       def inherited_lifecycle_environment_id
-        cv_env_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
-        return nil unless cv_env_id
+        cvenv_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
+        return nil unless cvenv_id
 
-        Katello::ContentViewEnvironment.find_by(id: cv_env_id)&.environment_id
+        Katello::ContentViewEnvironment.find_by(id: cvenv_id)&.environment_id
       end
 
       def inherited_kickstart_repository_id

--- a/app/models/katello/concerns/subscription_facet_host_extensions.rb
+++ b/app/models/katello/concerns/subscription_facet_host_extensions.rb
@@ -35,7 +35,7 @@ module Katello
 
       def update_candlepin_associations(consumer_params = nil)
         Rails.logger.debug "Updating Candlepin associations for host #{name}"
-        content_facet.cves_changed = false if content_facet
+        content_facet.cvenvs_changed = false if content_facet
         content_facet&.save!
 
         if subscription_facet

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -82,51 +82,55 @@ module Katello
     end
 
     def self.find_by_cv_and_lce!(content_view_id, lifecycle_environment_id)
-      cve = find_by(content_view_id: content_view_id, environment_id: lifecycle_environment_id)
-      return cve if cve
+      cvenv = find_by(content_view_id: content_view_id, environment_id: lifecycle_environment_id)
+      return cvenv if cvenv
 
       env_label = Katello::KTEnvironment.find_by(id: lifecycle_environment_id)&.label
-      fail Katello::Errors::ContentViewEnvironmentError,
-        _("Unable to find a lifecycle environment with ID %s") % lifecycle_environment_id if env_label.nil?
+      if env_label.nil?
+        fail Katello::Errors::ContentViewEnvironmentError,
+          _("Unable to find a lifecycle environment with ID %s") % lifecycle_environment_id
+      end
       cv_label = Katello::ContentView.find_by(id: content_view_id)&.label
+      if cv_label.nil?
+        fail Katello::Errors::ContentViewEnvironmentError,
+          _("Unable to find a content view with ID %s") % content_view_id
+      end
       fail Katello::Errors::ContentViewEnvironmentError,
-        _("Unable to find a content view with ID %s") % content_view_id if cv_label.nil?
-      fail Katello::Errors::ContentViewEnvironmentError,
-        _("Cannot assign content view environment %s/%s: The content view has either not been published or has not been promoted to that lifecycle environment.") % [env_label, cv_label]
+        _("Cannot assign content view environment %{env}/%{cv}: The content view has either not been published or has not been promoted to that lifecycle environment.") % {env: env_label, cv: cv_label}
     end
 
     def self.fetch_content_view_environments(organization:, labels: [], ids: [])
-      # Must ensure CVEs remain in the same order.
+      # Must ensure content view environments remain in the same order.
       # Using ActiveRecord .where will return them in a different order.
       id_errors = []
       label_errors = []
-      cves = []
+      cvenvs = []
       if ids.present?
         ids.each do |id|
-          cve = ::Katello::ContentViewEnvironment.find_by(id: id)
-          if cve.blank?
+          cvenv = ::Katello::ContentViewEnvironment.find_by(id: id)
+          if cvenv.blank?
             id_errors << id
           else
-            cves << cve
+            cvenvs << cvenv
           end
         end
       elsif labels.present?
         environment_names = labels.map(&:strip)
         environment_names.each do |name|
-          cve = with_label_and_org(name, organization: organization)
-          if cve.blank?
+          cvenv = with_label_and_org(name, organization: organization)
+          if cvenv.blank?
             label_errors << name
           else
-            cves << cve
+            cvenvs << cvenv
           end
         end
       end
-      if labels.present? && labels.length != cves.length
+      if labels.present? && labels.length != cvenvs.length
         fail HttpErrors::UnprocessableEntity, _("No content view environments found with names: %{names}") % {names: label_errors.join(', ')} if label_errors.present?
-      elsif ids.present? && ids.length != cves.length
+      elsif ids.present? && ids.length != cvenvs.length
         fail HttpErrors::UnprocessableEntity, _("No content view environments found with ids: %{ids}") % {ids: id_errors.join(', ')} if id_errors.present?
       end
-      cves
+      cvenvs
     end
 
     private

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -81,6 +81,20 @@ module Katello
       end
     end
 
+    def self.find_by_cv_and_lce!(content_view_id, lifecycle_environment_id)
+      cve = find_by(content_view_id: content_view_id, environment_id: lifecycle_environment_id)
+      return cve if cve
+
+      env_label = Katello::KTEnvironment.find_by(id: lifecycle_environment_id)&.label
+      fail Katello::Errors::ContentViewEnvironmentError,
+        _("Unable to find a lifecycle environment with ID %s") % lifecycle_environment_id if env_label.nil?
+      cv_label = Katello::ContentView.find_by(id: content_view_id)&.label
+      fail Katello::Errors::ContentViewEnvironmentError,
+        _("Unable to find a content view with ID %s") % content_view_id if cv_label.nil?
+      fail Katello::Errors::ContentViewEnvironmentError,
+        _("Cannot assign content view environment %s/%s: The content view has either not been published or has not been promoted to that lifecycle environment.") % [env_label, cv_label]
+    end
+
     def self.fetch_content_view_environments(organization:, labels: [], ids: [])
       # Must ensure CVEs remain in the same order.
       # Using ActiveRecord .where will return them in a different order.

--- a/app/models/katello/content_view_environment_activation_key.rb
+++ b/app/models/katello/content_view_environment_activation_key.rb
@@ -8,9 +8,9 @@ module Katello
     validates :content_view_environment_id, presence: true
     validates :activation_key_id, presence: true, unless: :new_record?
 
-    def self.reprioritize_for_activation_key(activation_key, new_cves)
-      new_order = new_cves.map do |cve|
-        activation_key.content_view_environment_activation_keys.find_by(:content_view_environment_id => cve.id)
+    def self.reprioritize_for_activation_key(activation_key, new_cvenvs)
+      new_order = new_cvenvs.map do |cvenv|
+        activation_key.content_view_environment_activation_keys.find_by(:content_view_environment_id => cvenv.id)
       end
       new_order.compact.each_with_index do |cveak, index|
         cveak.update_column(:priority, index)

--- a/app/models/katello/content_view_environment_content_facet.rb
+++ b/app/models/katello/content_view_environment_content_facet.rb
@@ -22,9 +22,9 @@ module Katello
       end
     end
 
-    def self.reprioritize_for_content_facet(content_facet, new_cves)
-      new_order = new_cves.map do |cve|
-        content_facet.content_view_environment_content_facets.find_by(:content_view_environment_id => cve.id)
+    def self.reprioritize_for_content_facet(content_facet, new_cvenvs)
+      new_order = new_cvenvs.map do |cvenv|
+        content_facet.content_view_environment_content_facets.find_by(:content_view_environment_id => cvenv.id)
       end
       new_order.compact.each_with_index do |cvecf, index|
         cvecf.update_column(:priority, index)

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -39,7 +39,7 @@ module Katello
       has_many :content_view_environment_content_facets, :class_name => "Katello::ContentViewEnvironmentContentFacet", :dependent => :destroy, :inverse_of => :content_facet
       has_many :content_view_environments, :through => :content_view_environment_content_facets,
                :class_name => "Katello::ContentViewEnvironment", :source => :content_view_environment,
-               :after_add => :mark_cves_changed, :after_remove => :mark_cves_changed
+               :after_add => :mark_cvenvs_changed, :after_remove => :mark_cvenvs_changed
       has_many :content_views, :through => :content_view_environments, :class_name => "Katello::ContentView"
       has_many :lifecycle_environments, :through => :content_view_environments, :class_name => "Katello::KTEnvironment"
 
@@ -82,25 +82,26 @@ module Katello
           where("#{::Katello::ContentViewEnvironment.table_name}.id" => content_view_environments)
       end
 
-      attr_accessor :cves_changed
+      attr_accessor :cvenvs_changed
 
       def initialize(*args)
         init_args = args.first || {}
-        cve_ids = init_args.delete(:content_view_environment_ids)
+        cvenv_ids = init_args.delete(:content_view_environment_ids)&.reject(&:blank?)
         super(*args)
-        if cve_ids.present?
-          self.content_view_environments = ContentViewEnvironment.where(id: cve_ids)
+        if cvenv_ids.present?
+          # find() preserves input order and raises on missing IDs, unlike where()
+          self.content_view_environments = ContentViewEnvironment.find(cvenv_ids)
         end
-        self.cves_changed = false
+        self.cvenvs_changed = false
       end
 
-      def mark_cves_changed(_cve)
-        Rails.logger.debug("ContentFacet: Marking CVEs changed for host #{host&.to_label}")
-        self.cves_changed = true
+      def mark_cvenvs_changed(_cvenv)
+        Rails.logger.debug("ContentFacet: Marking content view environments changed for host #{host&.to_label}")
+        self.cvenvs_changed = true
       end
 
-      def mark_cves_unchanged
-        self.cves_changed = false
+      def mark_cvenvs_unchanged
+        self.cvenvs_changed = false
       end
 
       def image_mode_host?
@@ -115,8 +116,8 @@ module Katello
         end
       end
 
-      def cves_changed?
-        cves_changed
+      def cvenvs_changed?
+        cvenvs_changed
       end
 
       def multi_content_view_environment?
@@ -143,13 +144,13 @@ module Katello
         content_view_environments&.first&.lifecycle_environment
       end
 
-      def content_view_environments=(new_cves)
-        if new_cves.length > 1 && !Setting['allow_multiple_content_views']
+      def content_view_environments=(new_cvenvs)
+        if new_cvenvs.length > 1 && !Setting['allow_multiple_content_views']
           fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
           _("Assigning a host to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")
         end
-        super(new_cves)
-        Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cves)
+        super(new_cvenvs)
+        Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cvenvs)
         self.content_view_environments.reload unless self.new_record?
         self.host&.update_candlepin_associations unless self.host&.new_record?
       end
@@ -158,11 +159,10 @@ module Katello
         content_view_environments.map(&:label).join(',')
       end
 
-
       def default_environment?
         return if content_view_environments.blank?
-        # if default cve is first, this is equivalent to default being the only one.
-        # if default cve is not first, candlepin will prioritize CV repos over library repos in case of conflicts.
+        # if default content view environment is first, this is equivalent to default being the only one.
+        # if default content view environment is not first, candlepin will prioritize CV repos over library repos in case of conflicts.
         content_view_environments.first.default_environment?
       end
 
@@ -174,8 +174,8 @@ module Katello
         # This determines whether the Applicable/Installable toggle should be hidden.
         return true if content_view_environments.first.default_environment?
 
-        content_view_environments.all? do |cve|
-          cve.content_view&.rolling? || cve.default_environment?
+        content_view_environments.all? do |cvenv|
+          cvenv.content_view&.rolling? || cvenv.default_environment?
         end
       end
 
@@ -379,8 +379,8 @@ module Katello
       end
 
       def available_releases
-        self.content_view_environments.flat_map do |cve|
-          cve.content_view.version(cve.lifecycle_environment).available_releases
+        self.content_view_environments.flat_map do |cvenv|
+          cvenv.content_view.version(cvenv.lifecycle_environment).available_releases
         end
       end
 
@@ -424,9 +424,9 @@ module Katello
         facet_attributes[:kickstart_repository_id] ||= hostgroup.inherited_kickstart_repository_id
         facet_attributes[:content_source_id] ||= hostgroup.inherited_content_source_id
         unless facet_attributes.key?(:content_view_environment_ids)
-          cve_id = hostgroup.content_facet&.content_view_environment_id
-          cve_id ||= hostgroup.send(:inherited_ancestry_attribute, :content_view_environment_id, :content_facet) if cve_id.nil? && hostgroup.ancestry.present?
-          facet_attributes[:content_view_environment_ids] = [cve_id] if cve_id
+          cvenv_id = hostgroup.content_facet&.content_view_environment_id
+          cvenv_id ||= hostgroup.inherited_content_view_environment_id if cvenv_id.nil? && hostgroup.ancestry.present?
+          facet_attributes[:content_view_environment_ids] = [cvenv_id] if cvenv_id
         end
         facet_attributes
       end

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -86,14 +86,10 @@ module Katello
 
       def initialize(*args)
         init_args = args.first || {}
-        env_id = init_args.delete(:lifecycle_environment_id)
-        cv_id = init_args.delete(:content_view_id)
+        cve_ids = init_args.delete(:content_view_environment_ids)
         super(*args)
-        if env_id && cv_id
-          assign_single_environment(
-            lifecycle_environment_id: env_id,
-            content_view_id: cv_id
-          )
+        if cve_ids.present?
+          self.content_view_environments = ContentViewEnvironment.where(id: cve_ids)
         end
         self.cves_changed = false
       end
@@ -162,36 +158,6 @@ module Katello
         content_view_environments.map(&:label).join(',')
       end
 
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
-      def assign_single_environment(
-        content_view_id: nil, lifecycle_environment_id: nil, environment_id: nil,
-        content_view: nil, lifecycle_environment: nil, environment: nil
-      )
-        lifecycle_environment_id ||= environment_id || lifecycle_environment&.id || environment&.id || self.single_lifecycle_environment&.id
-        content_view_id ||= content_view&.id || self.single_content_view&.id
-
-        unless lifecycle_environment_id
-          fail _("Lifecycle environment must be specified")
-        end
-
-        unless content_view_id
-          fail _("Content view must be specified")
-        end
-
-        content_view_environment = ::Katello::ContentViewEnvironment
-          .find_by(:content_view_id => content_view_id, :environment_id => lifecycle_environment_id)
-        if content_view_environment.nil?
-          env_label = ::Katello::KTEnvironment.find_by(:id => lifecycle_environment_id)&.label
-          fail ::Katello::Errors::ContentViewEnvironmentError, _("Unable to find a lifecycle environment with ID %s") % lifecycle_environment_id if env_label.nil?
-          cv_label = ::Katello::ContentView.find_by(:id => content_view_id)&.label
-          fail ::Katello::Errors::ContentViewEnvironmentError, _("Unable to find a content view with ID %s") % content_view_id if cv_label.nil?
-          hypothetical_cve_label = "%s/%s" % [env_label, cv_label]
-          fail ::Katello::Errors::ContentViewEnvironmentError, _("Cannot assign content view environment %s: The content view has either not been published or has not been promoted to that lifecycle environment.") % hypothetical_cve_label
-        end
-
-        self.content_view_environments = [content_view_environment]
-      end
 
       def default_environment?
         return if content_view_environments.blank?
@@ -456,9 +422,12 @@ module Katello
 
       def self.inherited_attributes(hostgroup, facet_attributes)
         facet_attributes[:kickstart_repository_id] ||= hostgroup.inherited_kickstart_repository_id
-        facet_attributes[:content_view_id] ||= hostgroup.inherited_content_view_id
-        facet_attributes[:lifecycle_environment_id] ||= hostgroup.inherited_lifecycle_environment_id
         facet_attributes[:content_source_id] ||= hostgroup.inherited_content_source_id
+        unless facet_attributes.key?(:content_view_environment_ids)
+          cve_id = hostgroup.content_facet&.content_view_environment_id
+          cve_id ||= hostgroup.send(:inherited_ancestry_attribute, :content_view_environment_id, :content_facet) if cve_id.nil? && hostgroup.ancestry.present?
+          facet_attributes[:content_view_environment_ids] = [cve_id] if cve_id
+        end
         facet_attributes
       end
 

--- a/app/models/katello/host/info_provider.rb
+++ b/app/models/katello/host/info_provider.rb
@@ -14,9 +14,9 @@ module Katello
             info['parameters']['content_view'] = host.single_content_view.try(:label)
             info['parameters']['content_view_info'] = content_view_info(host.content_view_environments.first)
           end
-          info['parameters']['content_views'] = host.content_view_environments.map do |cve|
-            content_view_info(cve).merge(
-              'lifecycle_environment' => cve.lifecycle_environment.try(:label)
+          info['parameters']['content_views'] = host.content_view_environments.map do |cvenv|
+            content_view_info(cvenv).merge(
+              'lifecycle_environment' => cvenv.lifecycle_environment.try(:label)
             )
           end
         end

--- a/app/models/katello/host/subscription_facet.rb
+++ b/app/models/katello/host/subscription_facet.rb
@@ -128,8 +128,8 @@ module Katello
 
       def candlepin_environments
         if self.host.content_facet
-          self.host.content_facet.content_view_environments.map do |cve|
-            { :id => cve.content_view.cp_environment_id(cve.lifecycle_environment) }
+          self.host.content_facet.content_view_environments.map do |cvenv|
+            { :id => cvenv.content_view.cp_environment_id(cvenv.lifecycle_environment) }
           end
         else
           [{ :id => self.host.organization.default_content_view.cp_environment_id(self.host.organization.library) }]
@@ -144,12 +144,12 @@ module Katello
         self.host.content_facet.try(:content_view_environments)
       end
 
-      def consumer_cve_order_from_candlepin
+      def consumer_cvenv_order_from_candlepin
         Katello::Resources::Candlepin::Consumer.get(uuid)['environments'].map { |e| e['id'] }
       end
 
-      def cves_ordered_correctly?
-        consumer_cve_order_from_candlepin == candlepin_environments_cp_ids
+      def cvenvs_ordered_correctly?
+        consumer_cvenv_order_from_candlepin == candlepin_environments_cp_ids
       end
 
       def organization
@@ -256,8 +256,8 @@ module Katello
           end
         end
         facet = self.host&.content_facet
-        if facet&.cves_changed? && !facet.new_record?
-          Rails.logger.debug("backend_update_needed: content facet CVEs changed")
+        if facet&.cvenvs_changed? && !facet.new_record?
+          Rails.logger.debug("backend_update_needed: content facet CVEnvs changed")
           return true
         end
         false

--- a/app/models/katello/hostgroup/content_facet.rb
+++ b/app/models/katello/hostgroup/content_facet.rb
@@ -13,150 +13,20 @@ module Katello
       validates_with Katello::Validators::ContentViewEnvironmentValidator
       validates_with ::AssociationExistsValidator, attributes: [:content_source]
 
-      validate :validate_content_view_and_environment_together
-
-      # Virtual attributes for API compatibility
-      # These provide backward compatibility for the deprecated content_view_id and lifecycle_environment_id
-      # attributes. Since we now use a single content_view_environment_id relationship, we need to ensure
-      # both values are provided together before we can look up the corresponding ContentViewEnvironment.
-      #
-      # The pending variables (@pending_content_view_id, @pending_lifecycle_environment_id) serve as a
-      # temporary holding place when the API sends these values separately (e.g., in different order or
-      # in a single hash). Once both values are set, assign_single_environment() attempts to find the
-      # matching ContentViewEnvironment and assign it, then clears the pending variables.
       def content_view_id
-        if instance_variable_defined?(:@pending_content_view_id)
-          @pending_content_view_id
-        else
-          content_view_environment&.content_view_id
-        end
-      end
-
-      def content_view_id=(value)
-        # Store in pending variable and attempt to resolve to a ContentViewEnvironment
-        @pending_content_view_id = value
-        assign_cv_env_from_pending
+        content_view_environment&.content_view_id
       end
 
       def lifecycle_environment_id
-        if instance_variable_defined?(:@pending_lifecycle_environment_id)
-          @pending_lifecycle_environment_id
-        else
-          content_view_environment&.environment_id
-        end
+        content_view_environment&.environment_id
       end
 
-      def lifecycle_environment_id=(value)
-        # Store in pending variable and attempt to resolve to a ContentViewEnvironment
-        @pending_lifecycle_environment_id = value
-        assign_cv_env_from_pending
-      end
-
-      # Object getters for backward compatibility
-      # These check for pending values first, then fall back to the CVEnv association
       def content_view
-        cv_id = content_view_id
-        return nil if cv_id.nil?
-        return content_view_environment&.content_view if content_view_environment&.content_view_id == cv_id
-
-        # If pending value differs from CVEnv, look it up
-        ::Katello::ContentView.find_by(id: cv_id)
+        content_view_environment&.content_view
       end
 
       def lifecycle_environment
-        lce_id = lifecycle_environment_id
-        return nil if lce_id.nil?
-        return content_view_environment&.lifecycle_environment if content_view_environment&.environment_id == lce_id
-
-        # If pending value differs from CVEnv, look it up
-        ::Katello::KTEnvironment.find_by(id: lce_id)
-      end
-
-      # Object setters for backward compatibility
-      def content_view=(value)
-        self.content_view_id = value&.id
-      end
-
-      def lifecycle_environment=(value)
-        self.lifecycle_environment_id = value&.id
-      end
-
-      # Override the content_view_environment setter to always clear pending variables
-      # when the association is assigned (either to a CVEnv or to nil)
-      def content_view_environment=(cve)
-        super(cve)
-        clear_pending_variables
-      end
-
-      private
-
-      def validate_content_view_and_environment_together
-        # Get the effective CV and LCE IDs (including pending values)
-        cv_id = content_view_id
-        lce_id = lifecycle_environment_id
-
-        # Both must be set together, or both must be nil
-        if (cv_id.present? && lce_id.blank?) || (cv_id.blank? && lce_id.present?)
-          errors.add(:base, _("Content view and lifecycle environment must both be set, or both be empty"))
-        end
-      end
-
-      # Attempts to find and assign the ContentViewEnvironment when both content_view_id
-      # and lifecycle_environment_id are explicitly set via the setters (API backwards compatibility).
-      # This is called each time either setter is invoked, but only succeeds when BOTH
-      # pending variables are set (not falling back to current values from the CVEnv).
-      # Special case: If one is set to nil/blank (for inheritance), automatically clear both.
-      def assign_cv_env_from_pending
-        # Only proceed if at least one pending variable is set
-        cv_id_set = instance_variable_defined?(:@pending_content_view_id)
-        env_id_set = instance_variable_defined?(:@pending_lifecycle_environment_id)
-
-        # Special case: If setting one to nil/blank (inherit parent), clear both for inheritance
-        if inherit_parent_case?(cv_id_set, env_id_set)
-          clear_content_view_environment
-          return
-        end
-
-        # If both are explicitly set
-        if cv_id_set && env_id_set
-          cv_id = @pending_content_view_id
-          env_id = @pending_lifecycle_environment_id
-
-          if cv_id.nil? && env_id.nil?
-            clear_content_view_environment
-            return
-          end
-
-          # Both are set and at least one is non-nil, try to find the CVEnv
-          if cv_id && env_id
-            cve = find_content_view_environment(cv_id, env_id)
-            self.content_view_environment = cve if cve
-          end
-        end
-      end
-
-      # Check if this is an "inherit parent" case: one field set to blank, the other not set at all
-      # This happens when user selects "Inherit parent" for one field via API (sends nil/blank value)
-      def inherit_parent_case?(cv_id_set, env_id_set)
-        (cv_id_set && !env_id_set && @pending_content_view_id.blank?) ||
-          (env_id_set && !cv_id_set && @pending_lifecycle_environment_id.blank?)
-      end
-
-      def clear_content_view_environment
-        self.content_view_environment = nil
-        # clear_pending_variables is called automatically by the content_view_environment= setter
-      end
-
-      def clear_pending_variables
-        remove_instance_variable(:@pending_content_view_id) if instance_variable_defined?(:@pending_content_view_id)
-        remove_instance_variable(:@pending_lifecycle_environment_id) if instance_variable_defined?(:@pending_lifecycle_environment_id)
-      end
-
-      def find_content_view_environment(cv_id, env_id)
-        ::Katello::ContentViewEnvironment.where(
-          content_view_id: cv_id,
-          environment_id: env_id
-        ).first
+        content_view_environment&.lifecycle_environment
       end
     end
   end

--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -545,9 +545,9 @@ module Katello
       _org, _content, content_path = library_instance_or_self.relative_path.split("/", 3) if content_path.blank?
       content_path = content_path.sub(%r|^/|, '')
       if self.environment
-        cve = ContentViewEnvironment.where(:environment_id => self.environment,
+        cvenv = ContentViewEnvironment.where(:environment_id => self.environment,
                                            :content_view_id => self.content_view).first
-        "#{organization.label}/#{cve.label}/#{content_path}"
+        "#{organization.label}/#{cvenv.label}/#{content_path}"
       else
         "#{organization.label}/#{ContentView::CONTENT_DIR}/#{self.content_view.label}/#{self.content_view_version.version}/#{content_path}"
       end
@@ -556,11 +556,11 @@ module Katello
     def generate_docker_repo_path
       org = self.organization.label.downcase
       if self.environment
-        cve = ContentViewEnvironment.where(:environment_id => self.environment,
+        cvenv = ContentViewEnvironment.where(:environment_id => self.environment,
                                            :content_view_id => self.content_view).first
         view = self.content_view.label
         product = self.product.label
-        env = cve.label.split('/').first
+        env = cvenv.label.split('/').first
         "#{org}/#{env.downcase}/#{view}/#{product}/#{self.root.label}"
       else
         "#{org}/#{self.content_view.label}/#{self.content_view_version.version}/#{self.root.product.label}/#{self.root.label}"

--- a/app/services/katello/content_view_manager.rb
+++ b/app/services/katello/content_view_manager.rb
@@ -2,12 +2,12 @@ module Katello
   class ContentViewManager
     def self.add_version_to_environment(content_view_version:, environment:)
       content_view = content_view_version.content_view
-      if (cve = content_view.content_view_environment(environment))
-        content_view_version.content_view_environments << cve
+      if (cvenv = content_view.content_view_environment(environment))
+        content_view_version.content_view_environments << cvenv
       else
-        cve = content_view.add_environment(environment, content_view_version)
+        cvenv = content_view.add_environment(environment, content_view_version)
       end
-      cve
+      cvenv
     end
 
     def self.create_candlepin_environment(content_view_environment:)

--- a/app/services/katello/product_content_finder.rb
+++ b/app/services/katello/product_content_finder.rb
@@ -29,8 +29,8 @@ module Katello
         deb_repos_library = Set.new
         deb_repos_batch = []
         if match_environment
-          consumable.content_view_environments.each do |cve|
-            deb_repos_batch = deb_repos_query.where("content_view_version_id = ? AND environment_id = ?", cve.content_view_version_id, cve.environment_id).where.not(library_instance_id: deb_repos_library.to_a)
+          consumable.content_view_environments.each do |cvenv|
+            deb_repos_batch = deb_repos_query.where("content_view_version_id = ? AND environment_id = ?", cvenv.content_view_version_id, cvenv.environment_id).where.not(library_instance_id: deb_repos_library.to_a)
             deb_repos_library.merge(deb_repos_batch.pluck(:library_instance_id))
             content_ids += deb_repos_batch.pluck(:content_id)
           end

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -69,8 +69,8 @@ module Katello
 
       def validate_content_view_environment_org(content_view_environments, activation_key)
         orgs = Set.new([activation_key&.organization])
-        content_view_environments&.each do |cve|
-          orgs << cve&.environment&.organization
+        content_view_environments&.each do |cvenv|
+          orgs << cvenv&.environment&.organization
         end
         orgs.delete(nil)
         if orgs.size != 1
@@ -177,7 +177,7 @@ module Katello
         host_uuid = get_uuid(consumer_params)
         consumer_params[:uuid] = host_uuid
         host.content_facet = populate_content_facet(host, content_view_environments)
-        host.content_facet.cves_changed = false # prevent backend_update_needed from triggering an update on a nonexistent consumer
+        host.content_facet.cvenvs_changed = false # prevent backend_update_needed from triggering an update on a nonexistent consumer
         host.subscription_facet = populate_subscription_facet(host, activation_keys, consumer_params, host_uuid)
         host.save! # the host has content and subscription facets at this point
 
@@ -266,14 +266,14 @@ module Katello
       end
 
       def lookup_content_view_environments(activation_keys)
-        # If the setting is on, we combine all CVEs from all AKs
+        # If the setting is on, we combine all CVEnvs from all AKs
         if Setting['allow_multiple_content_views']
-          cves = activation_keys.map do |act_key|
+          cvenvs = activation_keys.map do |act_key|
             act_key.content_view_environments
           end
-          cves = cves.flatten.uniq
-          fail _('At least one activation key must have a lifecycle environment and content view assigned to it') if cves.blank?
-          return cves
+          cvenvs = cvenvs.flatten.uniq
+          fail _('At least one activation key must have a lifecycle environment and content view assigned to it') if cvenvs.blank?
+          return cvenvs
         end
 
         # If the setting is off, we stick with the previous behavior (the last AK with a valid cv/lce wins).
@@ -281,7 +281,7 @@ module Katello
           act_key.content_view_environments.any?
         end
         if activation_key
-          ::Katello::ContentViewEnvironment.where(:content_view_id => activation_key.content_view, :environment_id => activation_key.environment)
+          [activation_key.content_view_environments.first]
         else
           fail _('At least one activation key must have a lifecycle environment and content view assigned to it')
         end
@@ -326,11 +326,11 @@ module Katello
             host.content_facet.kickstart_repository_id = nil
             host.content_facet.content_source = ::SmartProxy.pulp_primary
           end
-          # If setting is enabled, keep current values (CVEs, kickstart_repository_id, content_source)
+          # If setting is enabled, keep current values (CVEnvs, kickstart_repository_id, content_source)
 
           host.content_facet.save!
-          Rails.logger.debug "remove_host_artifacts: marking CVEs unchanged to prevent backend update"
-          host.content_facet.mark_cves_unchanged
+          Rails.logger.debug "remove_host_artifacts: marking CVEnvs unchanged to prevent backend update"
+          host.content_facet.mark_cvenvs_unchanged
           host.content_facet.calculate_and_import_applicability
         end
 

--- a/app/views/katello/api/v2/activation_keys/base.json.rabl
+++ b/app/views/katello/api/v2/activation_keys/base.json.rabl
@@ -35,23 +35,6 @@ child :content_view_environments => :content_view_environments do
   end
 end
 
-# single cv/lce for backward compatibility
-node :content_view_id do |ak|
-  ak.single_content_view&.id
-end
-
-node :content_view do |ak|
-  ak.single_content_view&.slice(:id, :name)
-end
-
-node :environment_id do |ak|
-  ak.single_lifecycle_environment&.id
-end
-
-node :environment do |ak|
-  ak.single_lifecycle_environment&.slice(:id, :name)
-end
-
 attributes :usage_count, :user_id, :max_hosts, :system_template_id, :release_version, :purpose_usage, :purpose_role
 
 node :permissions do |activation_key|

--- a/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
+++ b/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
@@ -1,4 +1,4 @@
 object @hostgroup
 extends 'api/v2/hostgroups/show'
-attributes :content_source_id, :content_source_name, :content_view_id, :content_view_name, :lifecycle_environment_id, :lifecycle_environment_name
+attributes :content_source_id, :content_source_name, :content_view_id, :content_view_name, :lifecycle_environment_id, :lifecycle_environment_name, :content_view_environment_id
 attributes :kickstart_repository_id, :kickstart_repository_name

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -29,32 +29,32 @@
 
 <% if using_hostgroups_page? %>
   <%# Hostgroups use a single Content View Environment field %>
-  <% cve_select_id = :hostgroup_content_view_environment_id %>
-  <% cve_select_name = 'hostgroup[content_view_environment_id]' %>
-  <% cve_select_attr = 'content_facet.content_view_environment' %>
-  <% cve_inherited = content_view_inherited?(@hostgroup) || lifecycle_environment_inherited?(@hostgroup) %>
+  <% cv_env_select_id = :hostgroup_content_view_environment_id %>
+  <% cv_env_select_name = 'hostgroup[content_view_environment_id]' %>
+  <% cvenv_select_attr = 'content_facet.content_view_environment' %>
+  <% cvenv_inherited = content_view_inherited?(@hostgroup) || lifecycle_environment_inherited?(@hostgroup) %>
 
-  <%= field(f, cve_select_attr, {:label => _("Content View Environment"), :help_inline => cve_inherited ? 'Inherited from host group' : nil}) do %>
-    <%= select_tag cve_select_id, content_view_environment_options(@hostgroup, :include_blank => blank_or_inherit_cvenv(f)), :class => 'form-control', :name => cve_select_name %>
+  <%= field(f, cvenv_select_attr, {:label => _("Content View Environment"), :help_inline => cvenv_inherited ? 'Inherited from host group' : nil}) do %>
+    <%= select_tag cv_env_select_id, content_view_environment_options(@hostgroup, :include_blank => blank_or_inherit_cvenv(f)), :class => 'form-control', :name => cv_env_select_name %>
   <% end %>
 <% else %>
   <%# Hosts use a single Content View Environment field %>
-  <% cve_inherited = content_view_inherited?(@host) || lifecycle_environment_inherited?(@host) %>
+  <% cvenv_inherited = content_view_inherited?(@host) || lifecycle_environment_inherited?(@host) %>
 
   <% if cv_lce_disabled? %>
     <%# On host edit, submit existing CVEnv IDs as hidden fields to preserve them %>
-    <% host_cve_ids = @host.content_view_environments.any? ? @host.content_view_environment_ids : (@host.hostgroup&.content_view_environment_id ? [@host.hostgroup.content_view_environment_id] : []) %>
-    <% host_cve_ids.each do |cve_id| %>
-      <%= hidden_field_tag 'host[content_facet_attributes][content_view_environment_ids][]', cve_id %>
+    <% host_cvenv_ids = @host.content_view_environments.any? ? @host.content_view_environment_ids : (@host.hostgroup&.content_view_environment_id ? [@host.hostgroup.content_view_environment_id] : []) %>
+    <% host_cvenv_ids.each do |cvenv_id| %>
+      <%= hidden_field_tag 'host[content_facet_attributes][content_view_environment_ids][]', cvenv_id, :id => nil %>
     <% end %>
   <% else %>
     <%# On host create, show a CVEnv dropdown %>
-    <% host_cve_select_id = :host_content_view_environment_id %>
-    <% host_cve_select_name = 'host[content_facet_attributes][content_view_environment_ids][]' %>
-    <% host_cve_select_attr = 'content_facet.content_view_environment' %>
+    <% host_cv_env_select_id = :host_content_view_environment_id %>
+    <% host_cv_env_select_name = 'host[content_facet_attributes][content_view_environment_ids][]' %>
+    <% host_cvenv_select_attr = 'content_facet.content_view_environment' %>
 
-    <%= field(f, host_cve_select_attr, {:label => _("Content View Environment"), :help_inline => cve_inherited ? 'Inherited from host group' : nil}) do %>
-      <%= select_tag host_cve_select_id, content_view_environment_options(@host, :include_blank => true, :selected_host_group => @hostgroup || @host&.hostgroup), :class => 'form-control', :name => host_cve_select_name %>
+    <%= field(f, host_cvenv_select_attr, {:label => _("Content View Environment"), :help_inline => cvenv_inherited ? 'Inherited from host group' : nil}) do %>
+      <%= select_tag host_cv_env_select_id, content_view_environment_options(@host, :include_blank => true, :selected_host_group => @hostgroup || @host&.hostgroup), :class => 'form-control', :name => host_cv_env_select_name %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -38,31 +38,23 @@
     <%= select_tag cve_select_id, content_view_environment_options(@hostgroup, :include_blank => blank_or_inherit_cvenv(f)), :class => 'form-control', :name => cve_select_name %>
   <% end %>
 <% else %>
-  <%# Hosts use separate Lifecycle Environment and Content View fields %>
-  <% env_select_id = :host_lifecycle_environment_id %>
-  <% env_select_name = 'host[content_facet_attributes][lifecycle_environment_id]' %>
-  <% env_select_attr = 'content_facet.single_lifecycle_environment' %>
+  <%# Hosts use a single Content View Environment field %>
+  <% cve_inherited = content_view_inherited?(@host) || lifecycle_environment_inherited?(@host) %>
 
-  <%= field(f, env_select_attr, {:label => _("Lifecycle Environment"), :help_inline => lifecycle_environment_inherited?(@host) ? 'Inherited from host group' : nil}) do %>
-    <% if cv_lce_disabled? %>
-      <% host_or_hostgroup_lce = (@host.content_view_environments.empty? && @host.hostgroup.present? && @host.hostgroup.lifecycle_environment.present?) ? fetch_lifecycle_environment(@host.hostgroup) : fetch_lifecycle_environment(@host) %>
-      <%= hidden_field_tag 'host[content_facet_attributes][lifecycle_environment_id]', host_or_hostgroup_lce.try(:id) %>
-      <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name, :disabled => true %>
-    <% else %>
-      <%= select_tag env_select_id, lifecycle_environment_options(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :lifecycle_environment)), :class => 'form-control',  :name => env_select_name %>
+  <% if cv_lce_disabled? %>
+    <%# On host edit, submit existing CVEnv IDs as hidden fields to preserve them %>
+    <% host_cve_ids = @host.content_view_environments.any? ? @host.content_view_environment_ids : (@host.hostgroup&.content_view_environment_id ? [@host.hostgroup.content_view_environment_id] : []) %>
+    <% host_cve_ids.each do |cve_id| %>
+      <%= hidden_field_tag 'host[content_facet_attributes][content_view_environment_ids][]', cve_id %>
     <% end %>
-  <% end %>
+  <% else %>
+    <%# On host create, show a CVEnv dropdown %>
+    <% host_cve_select_id = :host_content_view_environment_id %>
+    <% host_cve_select_name = 'host[content_facet_attributes][content_view_environment_ids][]' %>
+    <% host_cve_select_attr = 'content_facet.content_view_environment' %>
 
-  <% cv_select_id = :host_content_view_id %>
-  <% cv_select_name = 'host[content_facet_attributes][content_view_id]' %>
-  <% cv_select_attr = 'content_facet.single_content_view' %>
-
-  <%= field(f, cv_select_attr, {:label => _("Content View"), :help_inline => content_view_inherited?(@host) ? 'Inherited from host group' : nil}) do %>
-    <% if cv_lce_disabled? %>
-      <%= hidden_field_tag 'host[content_facet_attributes][content_view_id]', fetch_content_view(@host).try(:id) %>
-      <%= select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name, :disabled =>  true %>
-    <% else %>
-      <%= select_tag cv_select_id,  content_views_for_host(@host, :selected_host_group => @hostgroup || @host.hostgroup, :include_blank => blank_or_inherit_with_id(f, :content_view)), :data => {"spinner_path" => spinner_path}, :class => 'form-control',  :name => cv_select_name %>
+    <%= field(f, host_cve_select_attr, {:label => _("Content View Environment"), :help_inline => cve_inherited ? 'Inherited from host group' : nil}) do %>
+      <%= select_tag host_cve_select_id, content_view_environment_options(@host, :include_blank => true, :selected_host_group => @hostgroup || @host&.hostgroup), :class => 'form-control', :name => host_cve_select_name %>
     <% end %>
   <% end %>
 <% end %>

--- a/developer_docs/quick_reference.md
+++ b/developer_docs/quick_reference.md
@@ -7,7 +7,7 @@ Katello is a plugin for Foreman that orchestrates content distribution and subsc
 - **Commands must use `bundle exec` prefix** to ensure correct gem versions
 - **Edit files in Katello directory** (`/home/vagrant/katello`)
 - **Run commands from Foreman directory** (`/home/vagrant/foreman`)
-- **Never use "CVE" as abbreviation for content view environment** - CVE means "Common Vulnerabilities and Exposures" in security contexts. Use "CVEnv" or spell out "content view environment" instead.
+- **Never use "CVE" as abbreviation for content view environment** - CVE means "Common Vulnerabilities and Exposures" in security contexts. Use "CVEnv" or spell out "content view environment" instead. In Ruby/ERB code, use `cvenv` for variables (e.g. `cvenv`, `cvenv_id`, `cvenvs`). In JavaScript, use `cvEnv` (e.g. `cvEnv`, `cvEnvId`).
 
 ### Command Quick Reference
 **Development Server:**

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -240,11 +240,11 @@ Foreman::Plugin.register :katello do
   ]
 
   parameter_filter ::Host::Managed, :host_collection_ids => [],
-    :content_facet_attributes => [:content_view_id, :lifecycle_environment_id, :content_source_id,
-                                  :host, :kickstart_repository_id],
+    :content_facet_attributes => [:content_source_id,
+                                  :host, :kickstart_repository_id, {:content_view_environment_ids => []}],
     :subscription_facet_attributes => [:release_version, :purpose_usage, :purpose_role, :service_level, :host,
                                        {:installed_products => [:product_id, :product_name, :arch, :version]}, :facts, {:hypervisor_guest_uuids => []}]
-  parameter_filter ::Hostgroup, :content_view_id, :lifecycle_environment_id, :content_view_environment_id,
+  parameter_filter ::Hostgroup, :content_view_environment_id,
     :content_source_id, :kickstart_repository_id
   parameter_filter Organization, :label, :service_level
   parameter_filter SmartProxy, :download_policy, :http_proxy_id, :lifecycle_environment_ids => []

--- a/test/actions/katello/content_view_test.rb
+++ b/test/actions/katello/content_view_test.rb
@@ -402,7 +402,7 @@ module ::Actions::Katello::ContentView
                       content_view_version: content_view.versions.first,
                       environment: library
     end
-    let(:cv_env) { content_view.content_view_environment(library) }
+    let(:cvenv) { content_view.content_view_environment(library) }
 
     before do
       [repository_rpm, repository_deb].each do |repository|
@@ -423,9 +423,9 @@ module ::Actions::Katello::ContentView
       assert_action_planned_with action, ::Actions::Katello::ContentView::RefreshRollingRepo, clone_deb, false
 
       assert_action_planned_with action, ::Actions::Candlepin::Environment::AddContentToEnvironment,
-                                 view_env_cp_id: cv_env.cp_id, content_id: repository_rpm.content_id
+                                 view_env_cp_id: cvenv.cp_id, content_id: repository_rpm.content_id
       assert_action_planned_with action, ::Actions::Candlepin::Environment::AddContentToEnvironment,
-                                 view_env_cp_id: cv_env.cp_id, content_id: repository_deb.content_id
+                                 view_env_cp_id: cvenv.cp_id, content_id: repository_deb.content_id
     end
 
     it 'plan refresh for existing' do
@@ -442,7 +442,7 @@ module ::Actions::Katello::ContentView
       assert_equal 1, content_view.get_repo_clone(library, repository_deb).count
       assert_action_planned_with action, ::Actions::Katello::ContentView::RefreshRollingRepo, clone_deb, false
       assert_action_planned_with action, ::Actions::Candlepin::Environment::AddContentToEnvironment,
-                                 view_env_cp_id: cv_env.cp_id, content_id: repository_deb.content_id
+                                 view_env_cp_id: cvenv.cp_id, content_id: repository_deb.content_id
     end
 
     it 'plans nothing' do
@@ -492,8 +492,8 @@ module ::Actions::Katello::ContentView
       assert_action_planned_with action, ::Actions::Pulp3::Repository::DeleteDistributions, clone_rpm.id, primary
       assert_action_planned_with action, ::Actions::Pulp3::Repository::DeleteDistributions, clone_deb.id, primary
 
-      cv_env = content_view.content_view_environment(library)
-      assert_action_planned_with action, ::Actions::Candlepin::Environment::SetContent, content_view, library, cv_env
+      cvenv = content_view.content_view_environment(library)
+      assert_action_planned_with action, ::Actions::Candlepin::Environment::SetContent, content_view, library, cvenv
     end
 
     it 'plan ignores gone repo' do
@@ -503,8 +503,8 @@ module ::Actions::Katello::ContentView
 
       refute_action_planned action, ::Actions::Pulp3::Repository::DeleteDistributions
 
-      cv_env = content_view.content_view_environment(library)
-      assert_action_planned_with action, ::Actions::Candlepin::Environment::SetContent, content_view, library, cv_env
+      cvenv = content_view.content_view_environment(library)
+      assert_action_planned_with action, ::Actions::Candlepin::Environment::SetContent, content_view, library, cvenv
     end
 
     it 'plans nothing' do
@@ -603,15 +603,15 @@ module ::Actions::Katello::ContentView
     end
 
     it 'plans' do
-      cve = Katello::ContentViewEnvironment.where(:content_view_id => content_view, :environment_id => environment).first
-      cve.hosts.each { |host| host.content_facet.destroy }
-      Katello::ContentViewEnvironment.stubs(:where).returns([cve])
+      cvenv = Katello::ContentViewEnvironment.where(:content_view_id => content_view, :environment_id => environment).first
+      cvenv.hosts.each { |host| host.content_facet.destroy }
+      Katello::ContentViewEnvironment.stubs(:where).returns([cvenv])
 
       action.stubs(:task).returns(success_task)
 
       action.expects(:action_subject).with(content_view)
       plan_action(action, content_view, environment)
-      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cve)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cvenv)
     end
   end
 
@@ -659,7 +659,7 @@ module ::Actions::Katello::ContentView
       katello_environments(:dev)
     end
 
-    let(:cv_env) do
+    let(:cvenv) do
       Katello::ContentViewEnvironment.where(content_view_id: content_view,
                                             environment_id: environment
                                            ).first
@@ -669,7 +669,7 @@ module ::Actions::Katello::ContentView
       katello_environments(:library)
     end
 
-    let(:library_cv_env) do
+    let(:library_cvenv) do
       Katello::ContentViewEnvironment.where(content_view_id: content_view,
                                             environment_id: library
                                            ).first
@@ -679,7 +679,7 @@ module ::Actions::Katello::ContentView
       katello_content_views(:acme_default)
     end
 
-    let(:default_cv_env) do
+    let(:default_cvenv) do
       Katello::ContentViewEnvironment.where(content_view_id: default_content_view.id,
                                             environment_id: library.id
                                            ).first
@@ -687,41 +687,41 @@ module ::Actions::Katello::ContentView
 
     it 'plans for removing environments' do
       assert_raises(RuntimeError) do
-        action.validate_options(content_view, [cv_env], [], {})
+        action.validate_options(content_view, [cvenv], [], {})
       end
 
-      options = {content_view_environments: [cv_env],
+      options = {content_view_environments: [cvenv],
                  system_content_view_id: default_content_view.id,
                  system_environment_id: library.id,
                 }
       action.expects(:action_subject).with(content_view)
       plan_action(action, content_view, options)
 
-      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => false, :organization_destroy => false)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cvenv, :skip_repo_destroy => false, :organization_destroy => false)
     end
 
     it 'plans for removing a version and an environment' do
-      cve = Katello::ContentViewEnvironment.where(content_view_id: content_view.id,
+      cvenv_local = Katello::ContentViewEnvironment.where(content_view_id: content_view.id,
                                                       environment_id: environment.id
                                                  ).first
-      version = cve.content_view_version
-      cve.hosts.each { |h| h.content_facet.destroy }
-      options = {content_view_environments: [cv_env, library_cv_env],
+      version = cvenv_local.content_view_version
+      cvenv_local.hosts.each { |h| h.content_facet.destroy }
+      options = {content_view_environments: [cvenv, library_cvenv],
                  content_view_versions: [version],
                 }
       action.expects(:action_subject).with(content_view)
 
       plan_action(action, content_view, options)
-      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cv_env, :skip_repo_destroy => false, :organization_destroy => false)
+      assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::Destroy, cvenv, :skip_repo_destroy => false, :organization_destroy => false)
       assert_action_planned_with(action, ::Actions::Katello::ContentViewVersion::Destroy, version, :skip_environment_check => true, :skip_destroy_env_content => true)
     end
 
     it 'plans deleting all CV env and versions and removing repository references with destroy_content_view param' do
       smart_proxy_service_1 = new_capsule_content(:three)
       ::SmartProxy.stubs(:pulp_primary).returns(smart_proxy_service_1.smart_proxy)
-      cve = Katello::ContentViewEnvironment.where(content_view_id: content_view.id,
+      cvenv_local = Katello::ContentViewEnvironment.where(content_view_id: content_view.id,
                                                   environment_id: environment.id).first
-      cve.hosts.each { |h| h.content_facet.destroy }
+      cvenv_local.hosts.each { |h| h.content_facet.destroy }
       options = {content_view_environments: content_view.content_view_environments,
                  content_view_versions: content_view.versions,
                  destroy_content_view: true,
@@ -741,8 +741,7 @@ module ::Actions::Katello::ContentView
     context 'organization destroy' do
       it 'works' do
         ::Hostgroup.create!(name: 'foo',
-                            content_view: content_view,
-                            lifecycle_environment: environment)
+                            content_view_environment_id: cvenv.id)
         options = { organization_destroy: true }
         action.expects(:action_subject).with(content_view)
         refute_empty content_view.hosts.first.content_facet.content_facet_errata
@@ -755,17 +754,16 @@ module ::Actions::Katello::ContentView
         # Scenario 3: Removing version from environment
         # Setup: Create hostgroup using this CV/env
         ::Hostgroup.create!(name: 'test-hostgroup',
-                            content_view: content_view,
-                            lifecycle_environment: environment)
+                            content_view_environment_id: cvenv.id)
 
         # Setup reassignment target (default CV in library)
         reassign_options = {
-          content_view_environments: [cv_env],
+          content_view_environments: [cvenv],
           # Need to provide params for hosts too (they exist in the test fixture)
           system_content_view_id: default_content_view.id,
           system_environment_id: library.id,
           # Params for hostgroups
-          hostgroup_content_view_environment_id: default_cv_env.id,
+          hostgroup_content_view_environment_id: default_cvenv.id,
         }
 
         action.expects(:action_subject).with(content_view)
@@ -773,28 +771,27 @@ module ::Actions::Katello::ContentView
         # Act: Remove the CV environment
         plan_action(action, content_view, reassign_options)
 
-        # Assert: ReassignObjects action should be planned for the CVE with hostgroups
-        assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::ReassignObjects, cv_env, reassign_options)
+        # Assert: ReassignObjects action should be planned for the content view environment with hostgroups
+        assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::ReassignObjects, cvenv, reassign_options)
       end
 
       it 'plans reassigning hostgroups when deleting CV version (scenario 2)' do
         # Scenario 2: CV version deletion
-        cve = Katello::ContentViewEnvironment.where(content_view_id: content_view.id,
+        cvenv_local = Katello::ContentViewEnvironment.where(content_view_id: content_view.id,
                                                     environment_id: environment.id).first
-        version = cve.content_view_version
+        version = cvenv_local.content_view_version
 
         ::Hostgroup.create!(name: 'test-hostgroup-version',
-                            content_view: content_view,
-                            lifecycle_environment: environment)
+                            content_view_environment_id: cvenv.id)
 
         # Remove hosts so we can focus on hostgroups
-        cve.hosts.each { |h| h.content_facet.destroy }
+        cvenv_local.hosts.each { |h| h.content_facet.destroy }
 
         reassign_options = {
           # Must specify both the version AND the environment to remove it from
           content_view_versions: [version],
-          content_view_environments: [cve, library_cv_env],
-          hostgroup_content_view_environment_id: default_cv_env.id,
+          content_view_environments: [cvenv_local, library_cvenv],
+          hostgroup_content_view_environment_id: default_cvenv.id,
         }
 
         action.expects(:action_subject).with(content_view)
@@ -803,7 +800,7 @@ module ::Actions::Katello::ContentView
         plan_action(action, content_view, reassign_options)
 
         # Assert: ReassignObjects action should be planned
-        assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::ReassignObjects, cve, reassign_options)
+        assert_action_planned_with(action, ::Actions::Katello::ContentViewEnvironment::ReassignObjects, cvenv_local, reassign_options)
       end
 
       it 'validates hostgroup reassignment params when deleting entire CV (scenario 1)' do
@@ -812,8 +809,7 @@ module ::Actions::Katello::ContentView
         # (they're not automatically deleted with the CV)
 
         ::Hostgroup.create!(name: 'test-hostgroup-cv-delete',
-                            content_view: content_view,
-                            lifecycle_environment: environment)
+                            content_view_environment_id: cvenv.id)
 
         reassign_options_without_hg = {
           content_view_environments: content_view.content_view_environments,
@@ -831,26 +827,24 @@ module ::Actions::Katello::ContentView
       it 'validates hostgroup reassignment params when hostgroups exist' do
         # Setup: Create hostgroup using this CV/env
         ::Hostgroup.create!(name: 'test-hostgroup-validate',
-                            content_view: content_view,
-                            lifecycle_environment: environment)
+                            content_view_environment_id: cvenv.id)
 
         # Act/Assert: Should raise error if reassignment params not provided
         assert_raises(RuntimeError) do
-          action.validate_options(content_view, [cv_env], [], {})
+          action.validate_options(content_view, [cvenv], [], {})
         end
       end
 
-      it 'always reassigns hostgroups since they are single-CVE only' do
+      it 'always reassigns hostgroups since they are single content view environment only' do
         # Verify that hostgroups don't have multi_content_view_environment check
         # (unlike hosts and activation keys)
-        hostgroup = ::Hostgroup.create!(name: 'single-cve-hg',
-                                        content_view: content_view,
-                                        lifecycle_environment: environment)
+        hostgroup = ::Hostgroup.create!(name: 'single-cvenv-hg',
+                                        content_view_environment_id: cvenv.id)
 
         # Hostgroups should not respond to multi_content_view_environment?
         refute_respond_to hostgroup.content_facet, :multi_content_view_environment?
 
-        # They should have exactly one CVE
+        # They should have exactly one content view environment
         assert_equal 1, [hostgroup.content_view_environment].compact.count
       end
     end

--- a/test/actions/katello/environment_test.rb
+++ b/test/actions/katello/environment_test.rb
@@ -43,12 +43,12 @@ module ::Actions::Katello::Environment
     it 'plans' do
       stub_remote_user
       content_view = stub
-      cve = mock(:content_view => content_view)
+      cvenv = mock(:content_view => content_view)
       action.stubs(:action_subject).with(environment)
-      environment.expects(:content_view_environments).returns([cve])
+      environment.expects(:content_view_environments).returns([cvenv])
       environment.expects(:deletable?).returns(true)
       plan_action(action, environment)
-      assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => false)
+      assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cvenv], :skip_repo_destroy => false, :organization_destroy => false)
     end
   end
 
@@ -61,13 +61,13 @@ module ::Actions::Katello::Environment
     it 'plans' do
       stub_remote_user
       content_view = stub
-      cve = mock(:content_view => content_view)
+      cvenv = mock(:content_view => content_view)
       action.stubs(:action_subject).with(environment)
-      environment.expects(:content_view_environments).returns([cve])
+      environment.expects(:content_view_environments).returns([cvenv])
       environment.expects(:deletable?).returns(true)
       environment.expects(:delete_host_and_hostgroup_associations)
       plan_action(action, environment, :organization_destroy => true)
-      assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cve], :skip_repo_destroy => false, :organization_destroy => true)
+      assert_action_planned_with(action, ::Actions::Katello::ContentView::Remove, content_view, :content_view_environments => [cvenv], :skip_repo_destroy => false, :organization_destroy => true)
     end
   end
 end

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -125,15 +125,16 @@ module Katello
     end
 
     def test_create_protected_object
-      #don't have view on LCE or CV
+      cve = katello_content_view_environments(:library_view_library)
       denied_perms = [{:name => @create_permission, :search => "name=\"Key A2\""}]
 
       assert_protected_object(:create, [], denied_perms, [@organization]) do
-        post :create, params: { :environment => { :id => @library.id }, :content_view_id => @view.id, :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
+        post :create, params: { :content_view_environment_ids => [cve.id], :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
       end
     end
 
     def test_create_protected
+      cve = katello_content_view_environments(:library_view_library)
       dev_env_read_permission = {:name => :view_lifecycle_environments, :search => "id=\"#{@library.id}\"" }
       view_read_permission = {:name => :view_content_views, :search => "label=\"#{@view.label}\"" }
 
@@ -141,7 +142,7 @@ module Katello
       denied_perms = [@view_permission, @update_permission, @destroy_permission]
 
       assert_protected_action(:create, allowed_perms, denied_perms, [@organization]) do
-        post :create, params: { :environment => { :id => @library.id }, :content_view_id => @view.id, :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
+        post :create, params: { :content_view_environment_ids => [cve.id], :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
       end
     end
 
@@ -259,26 +260,6 @@ module Katello
       assert_template 'katello/api/v2/common/create'
     end
 
-    def test_create_from_angularjs_with_environments_param
-      cve = katello_content_view_environments(:library_default_view_environment)
-      cve.update(organization: @organization)
-      content_view_environments = ['library_default_view_library']
-      ActivationKey.any_instance.expects(:reload)
-      assert_sync_task(::Actions::Katello::ActivationKey::Create) do |activation_key|
-        assert_equal content_view_environments, activation_key.content_view_environments.map(&:label), [cve.label]
-        assert_valid activation_key
-      end
-
-      post :create, params: {
-        :organization_id => @organization.id,
-        :environment => {:id => @library.id},
-        :content_view_id => @acme_view.id,
-        :activation_key => {:name => 'new key'},
-      }
-
-      assert_response :success
-      assert_template 'katello/api/v2/common/create'
-    end
 
     def test_create_with_content_view_environment_ids_param
       cve = katello_content_view_environments(:library_dev_view_library)
@@ -449,49 +430,6 @@ module Katello
       assert_equal 0, @activation_key.content_view_environments.size
     end
 
-    def test_update_with_cleared_cv_lce_ids
-      cve = katello_content_view_environments(:library_dev_view_library)
-      cve.update(organization: @organization)
-      assert_sync_task(::Actions::Katello::ActivationKey::Update) do |activation_key, _activation_key_params|
-        assert_valid activation_key
-      end
-      assert_operator @activation_key.content_view_environments.size, :>, 0
-
-      put :update, params: {
-        :organization_id => @organization.id,
-        :id => @activation_key.id,
-        :content_view_id => nil,
-        :environment_id => nil,
-      }
-
-      assert_response :success
-      assert_equal 0, @activation_key.content_view_environments.size
-    end
-
-    def test_update_from_angularjs_does_not_clear_cves
-      cve = katello_content_view_environments(:library_dev_view_library)
-      cve.update(organization: @organization)
-      assert_sync_task(::Actions::Katello::ActivationKey::Update) do |activation_key, _activation_key_params|
-        assert_valid activation_key
-      end
-      assert_operator @activation_key.content_view_environments.size, :>, 0
-
-      put :update, params: {
-        :organization_id => @organization.id,
-        :id => @activation_key.id,
-        :content_view_id => nil,
-        :environment_id => nil,
-        :content_view => {
-          :id => @view.id,
-        },
-        :environment => {
-          :id => @library.id,
-        },
-      }
-
-      assert_response :success
-      assert_operator @activation_key.content_view_environments.size, :>, 0
-    end
 
     def test_update_protected
       allowed_perms = [@update_permission]

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -125,16 +125,16 @@ module Katello
     end
 
     def test_create_protected_object
-      cve = katello_content_view_environments(:library_view_library)
+      cvenv = katello_content_view_environments(:library_view_library)
       denied_perms = [{:name => @create_permission, :search => "name=\"Key A2\""}]
 
       assert_protected_object(:create, [], denied_perms, [@organization]) do
-        post :create, params: { :content_view_environment_ids => [cve.id], :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
+        post :create, params: { :content_view_environment_ids => [cvenv.id], :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
       end
     end
 
     def test_create_protected
-      cve = katello_content_view_environments(:library_view_library)
+      cvenv = katello_content_view_environments(:library_view_library)
       dev_env_read_permission = {:name => :view_lifecycle_environments, :search => "id=\"#{@library.id}\"" }
       view_read_permission = {:name => :view_content_views, :search => "label=\"#{@view.label}\"" }
 
@@ -142,7 +142,7 @@ module Katello
       denied_perms = [@view_permission, @update_permission, @destroy_permission]
 
       assert_protected_action(:create, allowed_perms, denied_perms, [@organization]) do
-        post :create, params: { :content_view_environment_ids => [cve.id], :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
+        post :create, params: { :content_view_environment_ids => [cvenv.id], :activation_key => {:name => 'Key A2', :description => 'Key A2, Key to the World'} }
       end
     end
 
@@ -241,12 +241,12 @@ module Katello
     end
 
     def test_create_with_content_view_environments_param
-      cve = katello_content_view_environments(:library_dev_view_library)
-      cve.update(organization: @organization)
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      cvenv.update(organization: @organization)
       content_view_environments = ['published_dev_view_library']
       ActivationKey.any_instance.expects(:reload)
       assert_sync_task(::Actions::Katello::ActivationKey::Create) do |activation_key|
-        assert_equal content_view_environments, activation_key.content_view_environments.map(&:label), [cve.label]
+        assert_equal content_view_environments, activation_key.content_view_environments.map(&:label), [cvenv.label]
         assert_valid activation_key
       end
 
@@ -260,11 +260,10 @@ module Katello
       assert_template 'katello/api/v2/common/create'
     end
 
-
     def test_create_with_content_view_environment_ids_param
-      cve = katello_content_view_environments(:library_dev_view_library)
-      cve.update(organization: @organization)
-      content_view_environment_ids = [cve.id]
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      cvenv.update(organization: @organization)
+      content_view_environment_ids = [cvenv.id]
       ActivationKey.any_instance.expects(:reload)
       assert_sync_task(::Actions::Katello::ActivationKey::Create) do |activation_key|
         assert_equal content_view_environment_ids, activation_key.content_view_environments.map(&:id)
@@ -394,9 +393,9 @@ module Katello
       assert_response :unprocessable_entity
     end
 
-    def test_update_with_cleared_cves
-      cve = katello_content_view_environments(:library_dev_view_library)
-      cve.update(organization: @organization)
+    def test_update_with_cleared_cvenvs
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      cvenv.update(organization: @organization)
       assert_sync_task(::Actions::Katello::ActivationKey::Update) do |activation_key, _activation_key_params|
         assert_valid activation_key
       end
@@ -412,9 +411,9 @@ module Katello
       assert_equal 0, @activation_key.content_view_environments.size
     end
 
-    def test_update_with_cleared_cve_ids
-      cve = katello_content_view_environments(:library_dev_view_library)
-      cve.update(organization: @organization)
+    def test_update_with_cleared_cvenv_ids
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      cvenv.update(organization: @organization)
       assert_sync_task(::Actions::Katello::ActivationKey::Update) do |activation_key, _activation_key_params|
         assert_valid activation_key
       end
@@ -430,6 +429,45 @@ module Katello
       assert_equal 0, @activation_key.content_view_environments.size
     end
 
+    def test_update_from_angularjs_does_not_clear_cvenvs
+      assert_operator @activation_key.content_view_environments.size, :>, 0
+
+      put :update, params: {
+        :id => @activation_key.id,
+        :organization_id => @organization.id,
+        :multi_content_view_environment => false,
+        :content_view_environments => {"foo" => "bar"},
+        :activation_key => {:name => @activation_key.name},
+      }
+
+      assert_response :success
+      @activation_key.reload
+      assert_operator @activation_key.content_view_environments.size, :>, 0
+    end
+
+    def test_update_from_angularjs_preserves_multi_cvenv
+      original_setting = Setting['allow_multiple_content_views']
+      Setting['allow_multiple_content_views'] = true
+      multi_key = katello_activation_keys(:library_dev_staging_view_key)
+      cvenv2 = katello_content_view_environments(:library_dev_view_library)
+      multi_key.content_view_environments << cvenv2
+      assert_equal 2, multi_key.content_view_environments.size
+
+      put :update, params: {
+        :id => multi_key.id,
+        :organization_id => @organization.id,
+        :multi_content_view_environment => true,
+        :content_view_environments => {"foo" => "bar"},
+        :activation_key => {:name => 'Renamed Multi Key'},
+      }
+
+      assert_response :success
+      multi_key.reload
+      assert_equal 'Renamed Multi Key', multi_key.name
+      assert_equal 2, multi_key.content_view_environments.size
+    ensure
+      Setting['allow_multiple_content_views'] = original_setting
+    end
 
     def test_update_protected
       allowed_perms = [@update_permission]

--- a/test/controllers/api/v2/api_controller_test.rb
+++ b/test/controllers/api/v2/api_controller_test.rb
@@ -88,7 +88,7 @@ module Katello
       User.current = users(:restricted)
       key = katello_activation_keys(:simple_key)
       setup_current_user_with_permissions({ :name => "view_activation_keys",
-                                            :search => "environment = #{key.environment}" },
+                                            :search => "environment = #{key.single_lifecycle_environment}" },
                                           organizations: [key.organization])
 
       @options = { :resource_class => Katello::ActivationKey }

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -580,10 +580,10 @@ module Katello
       ak_edit_permission = {:name => :edit_activation_keys, :search => "name=\"#{ak.name}\"" }
 
       ak_env_remove_permission = {:name => :promote_or_remove_content_views_to_environments,
-                                  :search => "name=\"#{ak.environment.name}\"" }
+                                  :search => "name=\"#{ak.single_lifecycle_environment.name}\"" }
 
       ak_cv_remove_permission = {:name => :promote_or_remove_content_views,
-                                 :search => "name=\"#{ak.content_view.name}\"" }
+                                 :search => "name=\"#{ak.single_content_view.name}\"" }
 
       alternate_env = @staging
       alternate_env_read_permission = {:name => :view_lifecycle_environments,
@@ -616,7 +616,7 @@ module Katello
                      ]
 
       assert_protected_action(:remove, allowed_perms, denied_perms, [@organization]) do
-        put :remove, params: { :id => ak.content_view.id, :environment_ids => [ak.environment.id], :key_content_view_id => alternate_cv.id, :key_environment_id => alternate_env.id }
+        put :remove, params: { :id => ak.single_content_view.id, :environment_ids => [ak.single_lifecycle_environment.id], :key_content_view_id => alternate_cv.id, :key_environment_id => alternate_env.id }
       end
     end
 
@@ -630,10 +630,10 @@ module Katello
       hostgroup.organizations = [content_view.organization]
       hostgroup.save!
 
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view.id, environment.id)
       Katello::Hostgroup::ContentFacet.create!(
         :hostgroup => hostgroup,
-        :content_view_id => content_view.id,
-        :lifecycle_environment_id => environment.id
+        :content_view_environment => cvenv
       )
 
       hg_edit_permission = { :name => :edit_hostgroups, :search => "name=\"#{hostgroup.name}\"" }
@@ -652,11 +652,7 @@ module Katello
       alternate_cv_read_permission = { :name => :view_content_views,
                                        :search => "name=\"#{alternate_cv.name}\"" }
 
-      # Get the CVE ID for the alternate CV and environment
-      alternate_cve = Katello::ContentViewEnvironment.find_by(
-        :content_view_version_id => alternate_cv.versions.first.id,
-        :environment_id => alternate_env.id
-      )
+      alternate_cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(alternate_cv.id, alternate_env.id)
 
       bad_cv = ContentView.find(katello_content_views(:candlepin_default_cv).id)
       bad_cv_read_permission = { :name => :view_content_views,
@@ -687,7 +683,7 @@ module Katello
                             at_least_once.returns(with_environments)
 
       assert_protected_action(:remove, allowed_perms, denied_perms, hostgroup.organizations, hostgroup.locations) do
-        put :remove, params: { :id => content_view.id, :environment_ids => env_ids, :hostgroup_content_view_environment_id => alternate_cve.id }
+        put :remove, params: { :id => content_view.id, :environment_ids => env_ids, :hostgroup_content_view_environment_id => alternate_cvenv.id }
       end
     end
   end

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -64,14 +64,14 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     library = FactoryBot.create(:katello_environment, :library, organization: org)
     view = FactoryBot.create(:katello_content_view, organization: org)
     view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
-    cve = FactoryBot.create(:katello_content_view_environment,
+    cvenv = FactoryBot.create(:katello_content_view_environment,
                             content_view_version: view_version,
                             environment: library)
 
     post :create, params: {
       :hostgroup => {
         :name => 'Test HG with CVEnv',
-        :content_view_environment_id => cve.id,
+        :content_view_environment_id => cvenv.id,
       },
     }
 
@@ -92,21 +92,21 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     view1_version = FactoryBot.create(:katello_content_view_version, content_view: view1)
     view2_version = FactoryBot.create(:katello_content_view_version, content_view: view2)
 
-    cve1 = FactoryBot.create(:katello_content_view_environment,
+    cvenv1 = FactoryBot.create(:katello_content_view_environment,
                              content_view_version: view1_version,
                              environment: library)
-    cve2 = FactoryBot.create(:katello_content_view_environment,
+    cvenv2 = FactoryBot.create(:katello_content_view_environment,
                              content_view_version: view2_version,
                              environment: dev)
 
     hostgroup = ::Hostgroup.create!(name: 'TestHG')
-    hostgroup.content_view_environment_id = cve1.id
+    hostgroup.content_view_environment_id = cvenv1.id
     hostgroup.save!
 
     put :update, params: {
       :id => hostgroup.id,
       :hostgroup => {
-        :content_view_environment_id => cve2.id,
+        :content_view_environment_id => cvenv2.id,
       },
     }
 
@@ -121,12 +121,12 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     library = FactoryBot.create(:katello_environment, :library, organization: org)
     view = FactoryBot.create(:katello_content_view, organization: org)
     view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
-    cve = FactoryBot.create(:katello_content_view_environment,
+    cvenv = FactoryBot.create(:katello_content_view_environment,
                             content_view_version: view_version,
                             environment: library)
 
     hostgroup = ::Hostgroup.create!(name: 'TestShowHG')
-    hostgroup.content_view_environment_id = cve.id
+    hostgroup.content_view_environment_id = cvenv.id
     hostgroup.save!
 
     get :show, params: { :id => hostgroup.id }
@@ -137,7 +137,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_equal library.name, response['lifecycle_environment_name']
     assert_equal view.id, response['content_view_id']
     assert_equal view.name, response['content_view_name']
-    assert_equal cve.id, response['content_view_environment_id']
+    assert_equal cvenv.id, response['content_view_environment_id']
   end
 
   def test_create_with_content_view_environment_id
@@ -145,20 +145,20 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     library = FactoryBot.create(:katello_environment, :library, organization: org)
     view = FactoryBot.create(:katello_content_view, organization: org)
     view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
-    cve = FactoryBot.create(:katello_content_view_environment,
+    cvenv = FactoryBot.create(:katello_content_view_environment,
                             content_view_version: view_version,
                             environment: library)
 
     post :create, params: {
       :hostgroup => {
         :name => 'Test HG with CVE ID',
-        :content_view_environment_id => cve.id,
+        :content_view_environment_id => cvenv.id,
       },
     }
 
     assert_response :success
     assert_equal 'Test HG with CVE ID', assigns[:hostgroup].name
-    assert_equal cve.id, assigns[:hostgroup].content_facet.content_view_environment_id
+    assert_equal cvenv.id, assigns[:hostgroup].content_facet.content_view_environment_id
     assert_equal library.id, assigns[:hostgroup].lifecycle_environment_id
     assert_equal view.id, assigns[:hostgroup].content_view_id
   end
@@ -174,29 +174,28 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     view1_version = FactoryBot.create(:katello_content_view_version, content_view: view1)
     view2_version = FactoryBot.create(:katello_content_view_version, content_view: view2)
 
-    cve1 = FactoryBot.create(:katello_content_view_environment,
+    cvenv1 = FactoryBot.create(:katello_content_view_environment,
                              content_view_version: view1_version,
                              environment: library)
-    cve2 = FactoryBot.create(:katello_content_view_environment,
+    cvenv2 = FactoryBot.create(:katello_content_view_environment,
                              content_view_version: view2_version,
                              environment: dev)
 
     hostgroup = ::Hostgroup.create!(name: 'TestHG')
-    hostgroup.content_view_environment_id = cve1.id
+    hostgroup.content_view_environment_id = cvenv1.id
     hostgroup.save!
 
     put :update, params: {
       :id => hostgroup.id,
       :hostgroup => {
-        :content_view_environment_id => cve2.id,
+        :content_view_environment_id => cvenv2.id,
       },
     }
 
     assert_response :success
     hostgroup.reload
-    assert_equal cve2.id, hostgroup.content_facet.content_view_environment_id
+    assert_equal cvenv2.id, hostgroup.content_facet.content_view_environment_id
     assert_equal dev.id, hostgroup.lifecycle_environment_id
     assert_equal view2.id, hostgroup.content_view_id
   end
-
 end

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -26,6 +26,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
       content_source_name
       content_view_id
       content_view_name
+      content_view_environment_id
       lifecycle_environment_id
       lifecycle_environment_name
     ].sort
@@ -58,30 +59,29 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_equal content_source_id, assigns[:hostgroup].content_source_id
   end
 
-  def test_create_with_content_view_and_lifecycle_environment
+  def test_create_with_content_view_environment_id_sets_cv_and_lce
     org = FactoryBot.create(:katello_organization)
     library = FactoryBot.create(:katello_environment, :library, organization: org)
     view = FactoryBot.create(:katello_content_view, organization: org)
     view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
-    FactoryBot.create(:katello_content_view_environment,
-                      content_view_version: view_version,
-                      environment: library)
+    cve = FactoryBot.create(:katello_content_view_environment,
+                            content_view_version: view_version,
+                            environment: library)
 
     post :create, params: {
       :hostgroup => {
-        :name => 'Test HG with CV',
-        :lifecycle_environment_id => library.id,
-        :content_view_id => view.id,
+        :name => 'Test HG with CVEnv',
+        :content_view_environment_id => cve.id,
       },
     }
 
     assert_response :success
-    assert_equal 'Test HG with CV', assigns[:hostgroup].name
+    assert_equal 'Test HG with CVEnv', assigns[:hostgroup].name
     assert_equal library.id, assigns[:hostgroup].lifecycle_environment_id
     assert_equal view.id, assigns[:hostgroup].content_view_id
   end
 
-  def test_update_content_view_and_lifecycle_environment
+  def test_update_content_view_environment_id
     org = FactoryBot.create(:katello_organization)
     library = FactoryBot.create(:katello_environment, :library, organization: org)
     dev = FactoryBot.create(:katello_environment, name: 'Dev', organization: org, prior: library)
@@ -92,23 +92,21 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     view1_version = FactoryBot.create(:katello_content_view_version, content_view: view1)
     view2_version = FactoryBot.create(:katello_content_view_version, content_view: view2)
 
-    FactoryBot.create(:katello_content_view_environment,
-                      content_view_version: view1_version,
-                      environment: library)
-    FactoryBot.create(:katello_content_view_environment,
-                      content_view_version: view2_version,
-                      environment: dev)
+    cve1 = FactoryBot.create(:katello_content_view_environment,
+                             content_view_version: view1_version,
+                             environment: library)
+    cve2 = FactoryBot.create(:katello_content_view_environment,
+                             content_view_version: view2_version,
+                             environment: dev)
 
     hostgroup = ::Hostgroup.create!(name: 'TestHG')
-    hostgroup.lifecycle_environment_id = library.id
-    hostgroup.content_view_id = view1.id
+    hostgroup.content_view_environment_id = cve1.id
     hostgroup.save!
 
     put :update, params: {
       :id => hostgroup.id,
       :hostgroup => {
-        :lifecycle_environment_id => dev.id,
-        :content_view_id => view2.id,
+        :content_view_environment_id => cve2.id,
       },
     }
 
@@ -123,13 +121,12 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     library = FactoryBot.create(:katello_environment, :library, organization: org)
     view = FactoryBot.create(:katello_content_view, organization: org)
     view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
-    FactoryBot.create(:katello_content_view_environment,
-                      content_view_version: view_version,
-                      environment: library)
+    cve = FactoryBot.create(:katello_content_view_environment,
+                            content_view_version: view_version,
+                            environment: library)
 
     hostgroup = ::Hostgroup.create!(name: 'TestShowHG')
-    hostgroup.lifecycle_environment_id = library.id
-    hostgroup.content_view_id = view.id
+    hostgroup.content_view_environment_id = cve.id
     hostgroup.save!
 
     get :show, params: { :id => hostgroup.id }
@@ -140,6 +137,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_equal library.name, response['lifecycle_environment_name']
     assert_equal view.id, response['content_view_id']
     assert_equal view.name, response['content_view_name']
+    assert_equal cve.id, response['content_view_environment_id']
   end
 
   def test_create_with_content_view_environment_id
@@ -201,35 +199,4 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_equal view2.id, hostgroup.content_view_id
   end
 
-  def test_create_with_only_content_view_fails_validation
-    org = FactoryBot.create(:katello_organization)
-    view = FactoryBot.create(:katello_content_view, organization: org)
-
-    post :create, params: {
-      :hostgroup => {
-        :name => 'Invalid HG',
-        :content_view_id => view.id,
-        # Missing lifecycle_environment_id
-      },
-    }
-
-    # Should fail validation - need both CV and LCE together
-    assert_response 422
-  end
-
-  def test_create_with_only_lifecycle_environment_fails_validation
-    org = FactoryBot.create(:katello_organization)
-    library = FactoryBot.create(:katello_environment, :library, organization: org)
-
-    post :create, params: {
-      :hostgroup => {
-        :name => 'Invalid HG',
-        :lifecycle_environment_id => library.id,
-        # Missing content_view_id
-      },
-    }
-
-    # Should fail validation - need both CV and LCE together
-    assert_response 422
-  end
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -52,25 +52,25 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     host_index_and_show(host)
   end
 
-  def test_content_facet_attributes_assigned_as_cve
+  def test_content_facet_attributes_assigned_as_cvenv
     ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
     host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem,
                               :content_view => @content_view, :lifecycle_environment => @environment)
     Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
-    orig_cves = host.content_facet.content_view_environment_ids.to_a
-    target_cve = ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
+    orig_cvenvs = host.content_facet.content_view_environment_ids.to_a
+    target_cvenv = ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
       :environment_id => @dev.id).first
     put :update, params: {
       :id => host.id,
       :content_facet_attributes => {
-        :content_view_environment_ids => [target_cve.id],
+        :content_view_environment_ids => [target_cvenv.id],
       },
     }, session: set_session_user
     assert_response :success
     host.content_facet.reload
     assert_equal 1, host.content_facet.content_view_environment_ids.count
-    refute_equal orig_cves, host.content_facet.content_view_environment_ids
-    assert_equal target_cve, host.content_facet.content_view_environments.first
+    refute_equal orig_cvenvs, host.content_facet.content_view_environment_ids
+    assert_equal target_cvenv, host.content_facet.content_view_environments.first
   end
 
   def test_host_contents_environments_param
@@ -79,46 +79,46 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem,
                               :content_view => @content_view, :lifecycle_environment => @environment, :organization => @environment.organization)
     Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
-    orig_cves = host.content_facet.content_view_environment_ids.to_a
-    target_cves = [::Katello::ContentViewEnvironment.where(:content_view_id => @cv4.id,
+    orig_cvenvs = host.content_facet.content_view_environment_ids.to_a
+    target_cvenvs = [::Katello::ContentViewEnvironment.where(:content_view_id => @cv4.id,
       :environment_id => @dev.id).first, ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
       :environment_id => @dev.id).first]
-    target_cves_ids = target_cves.map(&:id)
+    target_cvenvs_ids = target_cvenvs.map(&:id)
     put :update, params: {
       :id => host.id,
       :content_facet_attributes => {
-        :content_view_environments => target_cves.map(&:label),
+        :content_view_environments => target_cvenvs.map(&:label),
       },
     }, session: set_session_user
     assert_response :success
     host.content_facet.reload
     assert_equal 2, host.content_facet.content_view_environment_ids.count
-    refute_equal orig_cves, host.content_facet.content_view_environment_ids
-    assert_equal_arrays target_cves_ids, host.content_facet.content_view_environments.ids
+    refute_equal orig_cvenvs, host.content_facet.content_view_environment_ids
+    assert_equal_arrays target_cvenvs_ids, host.content_facet.content_view_environments.ids
   end
 
-  def test_host_contents_cve_ids_param
+  def test_host_contents_cvenv_ids_param
     Setting[:allow_multiple_content_views] = true
     ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
     host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem,
                               :content_view => @content_view, :lifecycle_environment => @environment)
     Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
-    orig_cves = host.content_facet.content_view_environment_ids.to_a
-    target_cves_ids = [::Katello::ContentViewEnvironment.where(:content_view_id => @cv4.id,
+    orig_cvenvs = host.content_facet.content_view_environment_ids.to_a
+    target_cvenvs_ids = [::Katello::ContentViewEnvironment.where(:content_view_id => @cv4.id,
       :environment_id => @dev.id).first, ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
       :environment_id => @dev.id).first].map(&:id)
     put :update, params: {
       :id => host.id,
       :content_facet_attributes => {
-        :content_view_environment_ids => target_cves_ids,
+        :content_view_environment_ids => target_cvenvs_ids,
       },
     }, session: set_session_user
     assert_response :success
     host.content_facet.reload
 
     assert_equal 2, host.content_facet.content_view_environment_ids.count
-    refute_equal orig_cves, host.content_facet.content_view_environment_ids
-    assert_equal_arrays target_cves_ids, host.content_facet.content_view_environments.ids
+    refute_equal orig_cvenvs, host.content_facet.content_view_environment_ids
+    assert_equal_arrays target_cvenvs_ids, host.content_facet.content_view_environments.ids
   end
 
   def test_set_content_view_environments_with_valid_content_view_environs_param

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -58,17 +58,16 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
                               :content_view => @content_view, :lifecycle_environment => @environment)
     Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
     orig_cves = host.content_facet.content_view_environment_ids.to_a
+    target_cve = ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
+      :environment_id => @dev.id).first
     put :update, params: {
       :id => host.id,
       :content_facet_attributes => {
-        :content_view_id => @cv3.id,
-        :lifecycle_environment_id => @dev.id,
+        :content_view_environment_ids => [target_cve.id],
       },
     }, session: set_session_user
     assert_response :success
     host.content_facet.reload
-    target_cve = ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
-      :environment_id => @dev.id).first
     assert_equal 1, host.content_facet.content_view_environment_ids.count
     refute_equal orig_cves, host.content_facet.content_view_environment_ids
     assert_equal target_cve, host.content_facet.content_view_environments.first
@@ -122,30 +121,6 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal_arrays target_cves_ids, host.content_facet.content_view_environments.ids
   end
 
-  def test_host_update_with_env_only
-    host = FactoryBot.create(:host, :with_content, :with_subscription,
-                              :content_view => @content_view, :lifecycle_environment => @environment)
-    put :update, params: {
-      :id => host.id,
-      :content_facet_attributes => {
-        :lifecycle_environment_id => @dev.id,
-      },
-    }, session: set_session_user
-    assert_response 422
-  end
-
-  def test_host_update_with_cv_only
-    host = FactoryBot.create(:host, :with_content, :with_subscription,
-                              :content_view => @content_view, :lifecycle_environment => @environment)
-    put :update, params: {
-      :id => host.id,
-      :content_facet_attributes => {
-        :content_view_id => @cv2.id,
-      },
-    }, session: set_session_user
-    assert_response :unprocessable_entity
-  end
-
   def test_set_content_view_environments_with_valid_content_view_environs_param
     Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
     ::Host::Managed.any_instance.expects(:update_candlepin_associations)
@@ -197,20 +172,6 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       },
     }, session: set_session_user
     assert_response 422
-  end
-
-  def test_host_update_with_invalid_env
-    host = FactoryBot.create(:host, :with_content, :with_subscription,
-                              :content_view => @content_view, :lifecycle_environment => @environment)
-    @dev.destroy
-    put :update, params: {
-      :id => host.id,
-      :content_facet_attributes => {
-        :content_view_id => @cv2.id,
-        :lifecycle_environment_id => @dev.id,
-      },
-    }, session: set_session_user
-    assert_response :error
   end
 
   def test_handle_content_view_environments_for_create

--- a/test/controllers/foreman/hostgroups_controller_test.rb
+++ b/test/controllers/foreman/hostgroups_controller_test.rb
@@ -19,13 +19,11 @@ class HostgroupsControllerTest < ActionController::TestCase
   end
 
   def test_create
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@library_view.id, @library.id)
     post :create, params: {
       :hostgroup => {
         :name => "foobar",
-        :content_facet_attributes => {
-          :content_view_id => @library_view.id,
-          :lifecycle_environment_id => @library.id,
-        },
+        :content_view_environment_id => cvenv.id,
       },
     }
 
@@ -40,18 +38,17 @@ class HostgroupsControllerTest < ActionController::TestCase
     os = Redhat.find_or_create_operating_system(repo)
     arch = Architecture.where(:name => repo.distribution_arch).first_or_create!
     os.architectures << arch unless os.architectures.include?(arch)
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
 
     post :create, params: {
       :hostgroup => {
         :name => "foobar",
         :architecture_id => arch.id,
         :operatingsystem_id => os.id,
-        :content_view_id => repo.content_view.id,
-        :lifecycle_environment_id => repo.environment.id,
+        :content_view_environment_id => cvenv.id,
         :content_source_id => smart_proxy.id,
         :kickstart_repository_id => repo.id,
       },
-
     }
 
     assert_equal 1, ::Hostgroup.unscoped.where(:name => "foobar").count

--- a/test/factories/host_factory.rb
+++ b/test/factories/host_factory.rb
@@ -16,10 +16,11 @@ FactoryBot.modify do
       after(:build) do |host, evaluator|
         if host.content_facet
           if evaluator.content_view && evaluator.lifecycle_environment
-            host.content_facet.assign_single_environment(
-              content_view_id: evaluator.content_view.id,
-              lifecycle_environment_id: evaluator.lifecycle_environment.id
+            cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+              evaluator.content_view.id,
+              evaluator.lifecycle_environment.id
             )
+            host.content_facet.content_view_environments = [cve]
           end
           host.content_facet.content_source = evaluator.content_source if evaluator.content_source
         end

--- a/test/factories/host_factory.rb
+++ b/test/factories/host_factory.rb
@@ -16,11 +16,11 @@ FactoryBot.modify do
       after(:build) do |host, evaluator|
         if host.content_facet
           if evaluator.content_view && evaluator.lifecycle_environment
-            cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+            cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
               evaluator.content_view.id,
               evaluator.lifecycle_environment.id
             )
-            host.content_facet.content_view_environments = [cve]
+            host.content_facet.content_view_environments = [cvenv]
           end
           host.content_facet.content_source = evaluator.content_source if evaluator.content_source
         end

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -14,11 +14,11 @@ class HostAndHostGroupsHelperLifecycleEnvironmentTests < HostsAndHostGroupsHelpe
     @library = katello_environments(:library)
     @host =  FactoryBot.build(:host, :with_content, :with_subscription, :id => 343)
     content_facet = Katello::Host::ContentFacet.new
-    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
       katello_content_views(:library_dev_view).id,
       katello_environments(:library).id
     )
-    content_facet.content_view_environments = [cve]
+    content_facet.content_view_environments = [cvenv]
     @host.content_facet = content_facet
     @host.organization = taxonomies(:organization1)
     @group = FactoryBot.build(:hostgroup)
@@ -85,10 +85,10 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   end
 
   test "kickstart_repository_options should handle os - selected call with all params" do
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     self.params = {"host" => {
       "operatingsystem_id" => @os.id,
-      "content_view_id" => @cv.id,
-      "lifecycle_environment_id" => @env.id,
+      "content_view_environment_id" => cvenv.id,
       "content_source_id" => @content_source.id,
       "architecture_id" => @arch.id,
     }}.with_indifferent_access
@@ -108,9 +108,9 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   end
 
   test "kickstart_repository_options should provide options for a populated host" do
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     host = ::Host.new(:architecture => @arch, :operatingsystem => @os,
-                      :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                    :content_view_id => @cv.id,
+                      :content_facet_attributes => {:content_view_environment_ids => [cvenv.id],
                                                     :content_source_id => @content_source.id})
     ret = [{:name => "boo" }]
 
@@ -129,10 +129,10 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   end
 
   test "kickstart_repository_options should_handle_non_redhat_host" do
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     hostgroup = ::Hostgroup.new(:operatingsystem => @os)
     host = ::Host.new(:architecture => @arch, :operatingsystem => operatingsystems(:opensuse), :hostgroup => hostgroup,
-                      :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                    :content_view_id => @cv.id,
+                      :content_facet_attributes => {:content_view_environment_ids => [cvenv.id],
                                                     :content_source_id => @content_source.id})
 
     options = kickstart_repository_options(host, :selected_host_group => hostgroup)
@@ -141,10 +141,9 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
 
   test "kickstart_repository_options should provide options for a populated hostgroup" do
     self.params = {}
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     hostgroup = ::Hostgroup.new(
-      :content_facet_attributes => {
-        :lifecycle_environment_id => @env.id,
-        :content_view_id => @cv.id })
+      :content_view_environment_id => cvenv.id)
     hostgroup.architecture = @arch
     hostgroup.operatingsystem = @os
     hostgroup.content_source = @content_source
@@ -165,11 +164,10 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   end
 
   test "kickstart_repository_options should provide options for a populated host with a selected_host_group" do
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     host = ::Host.new
     hostgroup = ::Hostgroup.new(
-      :content_facet_attributes => {
-        :lifecycle_environment_id => @env.id,
-        :content_view_id => @cv.id})
+      :content_view_environment_id => cvenv.id)
     hostgroup.architecture = @arch
     hostgroup.operatingsystem = @os
     hostgroup.content_source = @content_source
@@ -193,13 +191,12 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   test "kickstart_repository_options should provide options for a populated host with a selected_host_group and differing consumed content" do
     host = ::Host.new
     host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => 999)
-    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv2.id, @env.id)
-    host.content_facet.content_view_environments = [cve]
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv2.id, @env.id)
+    host.content_facet.content_view_environments = [cvenv]
     host.content_facet.content_view_environments.first.stubs(:generate_info)
+    cvenv2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     hostgroup = ::Hostgroup.new(
-      :content_facet_attributes => {
-        :lifecycle_environment_id => @env.id,
-        :content_view_id => @cv.id})
+      :content_view_environment_id => cvenv2.id)
     hostgroup.architecture = @arch
     hostgroup.operatingsystem = @os
     hostgroup.content_source = @content_source
@@ -227,18 +224,17 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
     @arch = architectures(:x86_64)
     @cv = @repo_with_distro.content_view
     @env = @repo_with_distro.environment
+    @cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
     @hostgroup = ::Hostgroup.new
     @hostgroup.architecture = @arch
     @hostgroup.operatingsystem = @os
     @hostgroup.build_content_facet(
-      :lifecycle_environment_id => @env.id,
-      :content_view_id => @cv.id,
+      :content_view_environment => @cvenv,
       :content_source => @content_source
     )
 
     @host = ::Host.new(:architecture => @arch, :operatingsystem => @os,
-                       :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                     :content_view_id => @cv.id,
+                       :content_facet_attributes => {:content_view_environment_ids => [@cvenv.id],
                                                      :content_source_id => @content_source.id}
                       )
   end
@@ -302,8 +298,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
     @hostgroup.medium_id = 1000
 
     host = ::Host.new(:architecture => @arch, :operatingsystem => @os, :hostgroup => @hostgroup,
-                      :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                    :content_view_id => @cv.id,
+                      :content_facet_attributes => {:content_view_environment_ids => [@cvenv.id],
                                                     :content_source_id => @content_source.id,
                                                     :kickstart_repository_id => id}
                      )
@@ -318,8 +313,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
 
     host = ::Host.new(:architecture => @arch, :operatingsystem => @os, :hostgroup => @hostgroup,
                       :medium_id => id,
-                      :content_facet_attributes => {:lifecycle_environment_id => @env.id,
-                                                    :content_view_id => @cv.id,
+                      :content_facet_attributes => {:content_view_environment_ids => [@cvenv.id],
                                                     :content_source_id => @content_source.id,
                                                     :kickstart_repository_id => nil}
                      )

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -14,10 +14,11 @@ class HostAndHostGroupsHelperLifecycleEnvironmentTests < HostsAndHostGroupsHelpe
     @library = katello_environments(:library)
     @host =  FactoryBot.build(:host, :with_content, :with_subscription, :id => 343)
     content_facet = Katello::Host::ContentFacet.new
-    content_facet.assign_single_environment(
-      :content_view => katello_content_views(:library_dev_view),
-      :lifecycle_environment => katello_environments(:library)
+    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+      katello_content_views(:library_dev_view).id,
+      katello_environments(:library).id
     )
+    content_facet.content_view_environments = [cve]
     @host.content_facet = content_facet
     @host.organization = taxonomies(:organization1)
     @group = FactoryBot.build(:hostgroup)
@@ -192,10 +193,8 @@ class HostsAndHostGroupsHelperKickstartRepositoryOptionsTest < HostsAndHostGroup
   test "kickstart_repository_options should provide options for a populated host with a selected_host_group and differing consumed content" do
     host = ::Host.new
     host.content_facet = ::Katello::Host::ContentFacet.new(:content_source_id => 999)
-    host.content_facet.assign_single_environment(
-      lifecycle_environment_id: @env.id,
-      content_view_id: @cv2.id
-    )
+    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv2.id, @env.id)
+    host.content_facet.content_view_environments = [cve]
     host.content_facet.content_view_environments.first.stubs(:generate_info)
     hostgroup = ::Hostgroup.new(
       :content_facet_attributes => {

--- a/test/helpers/url_helpers_test.rb
+++ b/test/helpers/url_helpers_test.rb
@@ -33,10 +33,8 @@ class HostUrlHelpers < UrlHelperBase
                        :location => @location,
                        :organization => @organization
                       )
-    @host.content_facet.assign_single_environment(
-      :lifecycle_environment_id => @env.id,
-      :content_view_id => @cv.id
-    )
+    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
+    @host.content_facet.content_view_environments = [cve]
   end
 
   test 'repository_url must render the right path based on host configuration' do
@@ -45,7 +43,8 @@ class HostUrlHelpers < UrlHelperBase
     repository_url('/custom/zoo/zoo/zoo.iso')
     assert_equal path, repository_url('/custom/zoo/zoo/zoo.iso')
 
-    @host.content_facet.assign_single_environment(lifecycle_environment_id: @env.id, content_view_id: katello_content_views(:library_dev_view).id)
+    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(katello_content_views(:library_dev_view).id, @env.id)
+    @host.content_facet.content_view_environments = [cve]
     @host.reload
     path = "http://#{@host.content_source.hostname}/pulp/content/#{@host.single_lifecycle_environment.organization.label}/#{@host.single_lifecycle_environment.label}/#{@host.single_content_view.label}/custom/zoo/zoo/zoo.iso".freeze
     assert_equal path, repository_url('/custom/zoo/zoo/zoo.iso')

--- a/test/helpers/url_helpers_test.rb
+++ b/test/helpers/url_helpers_test.rb
@@ -33,8 +33,8 @@ class HostUrlHelpers < UrlHelperBase
                        :location => @location,
                        :organization => @organization
                       )
-    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
-    @host.content_facet.content_view_environments = [cve]
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@cv.id, @env.id)
+    @host.content_facet.content_view_environments = [cvenv]
   end
 
   test 'repository_url must render the right path based on host configuration' do
@@ -43,8 +43,8 @@ class HostUrlHelpers < UrlHelperBase
     repository_url('/custom/zoo/zoo/zoo.iso')
     assert_equal path, repository_url('/custom/zoo/zoo/zoo.iso')
 
-    cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(katello_content_views(:library_dev_view).id, @env.id)
-    @host.content_facet.content_view_environments = [cve]
+    cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(katello_content_views(:library_dev_view).id, @env.id)
+    @host.content_facet.content_view_environments = [cvenv]
     @host.reload
     path = "http://#{@host.content_source.hostname}/pulp/content/#{@host.single_lifecycle_environment.organization.label}/#{@host.single_lifecycle_environment.label}/#{@host.single_content_view.label}/custom/zoo/zoo/zoo.iso".freeze
     assert_equal path, repository_url('/custom/zoo/zoo/zoo.iso')

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -10,16 +10,19 @@ module Katello
       @host.content_facet.content_source.lifecycle_environments << katello_environments(:library)
       @host.operatingsystem = operatingsystems(:redhat)
       @host.content_facet.kickstart_repository = @repo
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
         @repo.content_view.id,
         katello_environments(:library).id
       )
-      @host.content_facet.content_view_environments = [cve]
-      @hostgroup = ::Hostgroup.new
+      @host.content_facet.content_view_environments = [cvenv]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        @repo.content_view.id,
+        katello_environments(:library).id
+      )
+      @hostgroup = ::Hostgroup.new(:content_view_environment_id => cvenv.id)
       @hostgroup.content_source = smart_proxies(:one)
       @hostgroup.operatingsystem = operatingsystems(:redhat)
       @hostgroup.kickstart_repository = @repo
-      @hostgroup.content_view = @repo.content_view
     end
 
     def test_render_host

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -10,10 +10,11 @@ module Katello
       @host.content_facet.content_source.lifecycle_environments << katello_environments(:library)
       @host.operatingsystem = operatingsystems(:redhat)
       @host.content_facet.kickstart_repository = @repo
-      @host.content_facet.assign_single_environment(
-        content_view: @repo.content_view,
-        lifecycle_environment: katello_environments(:library)
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        @repo.content_view.id,
+        katello_environments(:library).id
       )
+      @host.content_facet.content_view_environments = [cve]
       @hostgroup = ::Hostgroup.new
       @hostgroup.content_source = smart_proxies(:one)
       @hostgroup.operatingsystem = operatingsystems(:redhat)

--- a/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
+++ b/test/lib/validators/hostgroup_kickstart_repository_validator_test.rb
@@ -22,10 +22,10 @@ module Katello
         :mismatched_ks_repo => 'The selected kickstart repository is not part of the assigned content view, lifecycle environment, ' \
                                'content source, operating system, and architecture',
       }
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(content_view.id, library_environment.id)
       @content_facet = Katello::Hostgroup::ContentFacet.new(
         :kickstart_repository_id => 4,
-        :lifecycle_environment_id => library_environment.id,
-        :content_view_id => content_view.id,
+        :content_view_environment => cvenv,
         :content_source_id => content_source.id)
       @hostgroup = ::Hostgroup.new(
         :operatingsystem => @os,
@@ -82,8 +82,8 @@ module Katello
       assert_equal @error_messages[:invalid_os], @content_facet.hostgroup.errors[:base].first
     end
 
-    test 'it invalidates if content_view not in environment' do
-      @content_facet.lifecycle_environment_id = katello_environments(:candlepin_dev).id
+    test 'it invalidates if content_view_environment is missing' do
+      @content_facet.content_view_environment = nil
       @validator.validate(@content_facet)
       assert_equal @error_messages[:missing_content_view], @content_facet.hostgroup.errors[:lifecycle_environment].first
     end

--- a/test/mailers/errata_mailer_test.rb
+++ b/test/mailers/errata_mailer_test.rb
@@ -55,11 +55,11 @@ module Katello
       view_repo = Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)
       @errata_host.content_facet.bound_repositories = [view_repo]
       @errata_host.stubs(:update_candlepin_associations)
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
         katello_content_views(:acme_default).id,
         katello_environments(:library).id
       )
-      @errata_host.content_facet.content_view_environments = [cve]
+      @errata_host.content_facet.content_view_environments = [cvenv]
       @errata_host.content_facet.save!
 
       ActionMailer::Base.deliveries = []

--- a/test/mailers/errata_mailer_test.rb
+++ b/test/mailers/errata_mailer_test.rb
@@ -55,10 +55,11 @@ module Katello
       view_repo = Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)
       @errata_host.content_facet.bound_repositories = [view_repo]
       @errata_host.stubs(:update_candlepin_associations)
-      @errata_host.content_facet.assign_single_environment(
-        content_view: katello_content_views(:acme_default),
-        lifecycle_environment: katello_environments(:library)
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        katello_content_views(:acme_default).id,
+        katello_environments(:library).id
       )
+      @errata_host.content_facet.content_view_environments = [cve]
       @errata_host.content_facet.save!
 
       ActionMailer::Base.deliveries = []

--- a/test/models/activation_key_test.rb
+++ b/test/models/activation_key_test.rb
@@ -5,7 +5,7 @@ module Katello
     def setup
       @dev_key = katello_activation_keys(:dev_key)
       @dev_staging_view_key = katello_activation_keys(:library_dev_staging_view_key)
-      @dev_staging_cve = katello_content_view_environments(:library_dev_staging_view_dev)
+      @dev_staging_cvenv = katello_content_view_environments(:library_dev_staging_view_dev)
 
       @dev_view = katello_content_views(:library_dev_view)
       @lib_view = katello_content_views(:library_view)
@@ -19,10 +19,10 @@ module Katello
 
     test "can have content view environment" do
       @dev_key = katello_activation_keys(:dev_key)
-      @dev_key.content_view_environments = [@dev_staging_cve]
+      @dev_key.content_view_environments = [@dev_staging_cvenv]
       assert @dev_key.save!
       assert_not_nil @dev_key.single_content_view
-      assert_includes @dev_staging_cve.content_view.activation_keys, @dev_key
+      assert_includes @dev_staging_cvenv.content_view.activation_keys, @dev_key
     end
 
     test "does not require a content view environment" do
@@ -31,10 +31,10 @@ module Katello
     end
 
     test "content view environment must be in the same org" do
-      library_dev_staging_cve = katello_content_view_environments(:library_dev_staging_view_dev)
+      library_dev_staging_cvenv = katello_content_view_environments(:library_dev_staging_view_dev)
       org2 = taxonomies(:organization2)
       ak = ActivationKey.create!(name: 'new_key', organization: org2)
-      ak.content_view_environments << library_dev_staging_cve
+      ak.content_view_environments << library_dev_staging_cvenv
       refute ak.save
       refute_empty ak.errors.attribute_names
       assert_raises(ActiveRecord::RecordInvalid) do
@@ -113,17 +113,17 @@ module Katello
     end
 
     def test_search_environment
-      activation_keys = ActivationKey.search_for("environment = \"#{@dev_staging_view_key.environment.name}\"")
+      activation_keys = ActivationKey.search_for("environment = \"#{@dev_staging_view_key.single_lifecycle_environment.name}\"")
       assert_includes activation_keys, @dev_staging_view_key
     end
 
     def test_search_content_view
-      activation_keys = ActivationKey.search_for("content_view = \"#{@dev_staging_view_key.content_view.name}\"")
+      activation_keys = ActivationKey.search_for("content_view = \"#{@dev_staging_view_key.single_content_view.name}\"")
       assert_includes activation_keys, @dev_staging_view_key
     end
 
     def test_search_content_view_id
-      activation_keys = ActivationKey.search_for("content_view_id = \"#{@dev_staging_view_key.content_view.id}\"")
+      activation_keys = ActivationKey.search_for("content_view_id = \"#{@dev_staging_view_key.single_content_view.id}\"")
       assert_includes activation_keys, @dev_staging_view_key
     end
 

--- a/test/models/authorization/activation_key_authorization_test.rb
+++ b/test/models/authorization/activation_key_authorization_test.rb
@@ -34,7 +34,7 @@ module Katello
 
     def test_all_editable?
       ak = ActivationKey.find(katello_activation_keys(:library_dev_staging_view_key).id)
-      assert ActivationKey.all_editable?(ak.content_view, ak.environment)
+      assert ActivationKey.all_editable?(ak.single_content_view, ak.single_lifecycle_environment)
     end
   end
 
@@ -67,7 +67,7 @@ module Katello
 
     def test_all_editable?
       ak = ActivationKey.find(katello_activation_keys(:library_dev_staging_view_key).id)
-      refute ActivationKey.all_editable?(ak.content_view, ak.environment)
+      refute ActivationKey.all_editable?(ak.single_content_view, ak.single_lifecycle_environment)
     end
   end
 
@@ -79,13 +79,13 @@ module Katello
 
     def test_all_editable?
       ak = ActivationKey.find(katello_activation_keys(:library_dev_staging_view_key).id)
-      keys = ActivationKey.with_content_views(ak.single_content_view).with_environments(ak.single_content_view)
+      keys = ActivationKey.with_content_views(ak.single_content_view).with_environments(ak.single_lifecycle_environment)
 
       clause = keys.map { |key| "name=\"#{key.name}\"" }.join(" or ")
 
       setup_current_user_with_permissions({ :name => "edit_activation_keys",
                                             :search => clause })
-      assert ActivationKey.all_editable?(ak.content_view, ak.environment)
+      assert ActivationKey.all_editable?(ak.single_content_view, ak.single_lifecycle_environment)
     end
   end
 end

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -33,31 +33,31 @@ module Katello
       host.update!(:content_facet_attributes => { :content_source_id => nil })
     end
 
-    def test_action_triggered_on_facet_cve_update
+    def test_action_triggered_on_facet_cvenv_update
       host.reload
       host.expects(:update_candlepin_associations).twice
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, dev.id)
-      host.content_facet.content_view_environments = [cve]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, dev.id)
+      host.content_facet.content_view_environments = [cvenv]
       host.save!
 
       host.reload
       host.expects(:update_candlepin_associations).twice
-      cve2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
-      host.content_facet.content_view_environments = [cve2]
+      cvenv2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
+      host.content_facet.content_view_environments = [cvenv2]
       host.save!
     end
 
-    def test_content_facet_cve_update
+    def test_content_facet_cvenv_update
       host.expects(:update_candlepin_associations).twice
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
-      host.content_facet.content_view_environments = [cve]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
+      host.content_facet.content_view_environments = [cvenv]
       host.save!
       host.reload.content_facet.reload
 
       refute_nil host.subscription_facet.uuid # not reset to nil
-      host_cve = host.content_view_environments.first
-      assert_equal dev.id, host_cve.environment_id # unchanged
-      assert_equal view2.id, host_cve.content_view_id # changed
+      host_cvenv = host.content_view_environments.first
+      assert_equal dev.id, host_cvenv.environment_id # unchanged
+      assert_equal view2.id, host_cvenv.content_view_id # changed
     end
 
     def test_other_content_facet_update

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -36,27 +36,21 @@ module Katello
     def test_action_triggered_on_facet_cve_update
       host.reload
       host.expects(:update_candlepin_associations).twice
-      host.content_facet.assign_single_environment(
-        :content_view => view,
-        :lifecycle_environment => dev
-      )
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, dev.id)
+      host.content_facet.content_view_environments = [cve]
       host.save!
 
       host.reload
       host.expects(:update_candlepin_associations).twice
-      host.content_facet.assign_single_environment(
-        :content_view => view2,
-        :lifecycle_environment => dev
-      )
+      cve2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
+      host.content_facet.content_view_environments = [cve2]
       host.save!
     end
 
     def test_content_facet_cve_update
       host.expects(:update_candlepin_associations).twice
-      host.content_facet.assign_single_environment(
-        :content_view => view2,
-        :lifecycle_environment => dev
-      )
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
+      host.content_facet.content_view_environments = [cve]
       host.save!
       host.reload.content_facet.reload
 

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -140,8 +140,8 @@ module Katello
       assert_includes @foreman_host.info['parameters']['foreman_host_collections'], host_collection.name
     end
 
-    def test_update_with_invalid_cv_env_combo
-      host = FactoryBot.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
+    def test_update_with_invalid_cvenv_combo
+      FactoryBot.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
       assert_raises(Katello::Errors::ContentViewEnvironmentError) do
         Katello::ContentViewEnvironment.find_by_cv_and_lce!(
           @library_view.id,
@@ -236,7 +236,7 @@ module Katello
       ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
       host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
       subscription_facet = host.subscription_facet
-      host.content_facet.cves_changed = false
+      host.content_facet.cvenvs_changed = false
       refute subscription_facet.backend_update_needed?
 
       subscription_facet.service_level = 'terrible'
@@ -245,8 +245,8 @@ module Katello
       subscription_facet.reload
       refute subscription_facet.backend_update_needed?
 
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@view.id, @library.id)
-      subscription_facet.host.content_facet.content_view_environments = [cve]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@view.id, @library.id)
+      subscription_facet.host.content_facet.content_view_environments = [cvenv]
       assert subscription_facet.backend_update_needed?
     end
 

--- a/test/models/concerns/host_managed_extensions_test.rb
+++ b/test/models/concerns/host_managed_extensions_test.rb
@@ -143,38 +143,11 @@ module Katello
     def test_update_with_invalid_cv_env_combo
       host = FactoryBot.create(:host, :with_content, :content_view => @library_view, :lifecycle_environment => @library)
       assert_raises(Katello::Errors::ContentViewEnvironmentError) do
-        host.content_facet.assign_single_environment(
-          content_view: @library_view,
-          lifecycle_environment: @organization1_library # env is not in the same org as @library_view
+        Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+          @library_view.id,
+          @organization1_library.id
         )
       end
-    end
-
-    def test_update_with_blank_lifecycle_environment
-      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
-      refute host.update(content_facet_attributes: {content_view_id: @view.id, lifecycle_environment_id: nil})
-      refute_valid host
-      assert_equal host.errors[:base].first, "Content view and lifecycle environment must be provided together"
-    end
-
-    def test_check_cve_attributes_removes_cv_and_lce
-      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
-      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
-      host_attrs = host.attributes.deep_clone
-      host_attrs[:content_facet_attributes] = {content_view_id: @view.id, lifecycle_environment_id: @library.id}
-      # check_cve_attributes should remove the content_view_id and lifecycle_environment_id
-      # so the following should not error
-      host.attributes = host_attrs
-    end
-
-    def test_check_cve_attributes
-      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
-      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
-      host_attrs = host.attributes.deep_clone
-      host_attrs[:content_facet_attributes] = {content_view_id: @view.id, lifecycle_environment_id: @library.id}
-      host.check_cve_attributes(host_attrs)
-      refute host_attrs.key?(:content_view_id)
-      refute host_attrs.key?(:lifecycle_environment_id)
     end
 
     def test_remote_execution_proxies_registered_through
@@ -207,29 +180,6 @@ module Katello
   end
 
   class HostManagedExtensionsUpdateTest < HostManagedExtensionsTestBase
-    def test_multi_environment_host_ignores_single_params
-      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
-      host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
-
-      # Add a second content view environment to make this a multi-environment host
-      library_dev_view = katello_content_views(:library_dev_view)
-      dev_env = katello_environments(:dev)
-      second_cve = ContentViewEnvironment.find_by(content_view: library_dev_view, environment: dev_env)
-      original_cves = host.content_facet.content_view_environments.to_a
-      host.content_facet.content_view_environments = original_cves + [second_cve]
-      host.save!
-      assert host.content_facet.multi_content_view_environment?
-
-      # Try to update with single params
-      host_attrs = host.attributes.deep_clone
-      host_attrs[:content_facet_attributes] = {content_view_id: @view.id, lifecycle_environment_id: @dev.id}
-      Rails.logger.expects(:warn).with("content_view_id and lifecycle_environment_id cannot be used to reassign multi-environment host '#{host.name}'. Use content_view_environment_ids instead")
-      host.check_cve_attributes(host_attrs)
-
-      # Multi-environment host should ignore single params and keep original environments
-      assert_equal original_cves + [second_cve], host.content_facet.content_view_environments
-    end
-
     def test_update
       host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @library_view, :lifecycle_environment => @library)
       host.content_facet.expects(:save!)
@@ -295,10 +245,8 @@ module Katello
       subscription_facet.reload
       refute subscription_facet.backend_update_needed?
 
-      subscription_facet.host.content_facet.assign_single_environment(
-        content_view: @view,
-        lifecycle_environment: @library
-      )
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@view.id, @library.id)
+      subscription_facet.host.content_facet.content_view_environments = [cve]
       assert subscription_facet.backend_update_needed?
     end
 

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -68,16 +68,16 @@ module Katello
       @root.organizations = []
       @root.save!
 
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       assert_includes @root.organizations, @library.organization
     end
 
     def test_inherited_lifecycle_environment_with_ancestry
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       assert_equal @library, @child.lifecycle_environment
@@ -85,8 +85,8 @@ module Katello
     end
 
     def test_inherited_content_view_with_ancestry
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       assert_equal @view, @child.content_view
@@ -94,8 +94,8 @@ module Katello
     end
 
     def test_inherited_content_view_with_ancestry_nill
-      @child.content_view = @view
-      @child.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @child.content_view_environment_id = cvenv.id
       @child.save!
 
       assert_equal @view, @child.content_view
@@ -103,8 +103,8 @@ module Katello
     end
 
     def test_inherited_lifecycle_environment_with_ancestry_nil
-      @child.content_view = @view
-      @child.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @child.content_view_environment_id = cvenv.id
       @child.save!
 
       assert_equal @library, @child.lifecycle_environment
@@ -118,16 +118,16 @@ module Katello
                         content_view_version: cv_version,
                         environment: @library)
 
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: content_view.id, environment_id: @library.id)
       host_group = ::Hostgroup.new(:name => 'test_cv_hostgroup',
-                                    :content_view => content_view,
-                                    :lifecycle_environment => @library)
+                                    :content_view_environment_id => cvenv.id)
       assert_valid host_group
       assert_equal content_view, host_group.content_view
     end
 
     def test_update_content_view
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       assert @root.save!
       assert_equal @view, @root.reload.content_view
 
@@ -137,15 +137,15 @@ module Katello
                         content_view_version: new_view_version,
                         environment: @library)
 
-      @root.content_view = new_view
-      @root.lifecycle_environment = @library
+      new_cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: new_view.id, environment_id: @library.id)
+      @root.content_view_environment_id = new_cvenv.id
       assert @root.save!
       assert_equal new_view, @root.reload.content_view
     end
 
     def test_remove_content_view
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
       assert_equal @view, @root.content_view
 
@@ -156,8 +156,8 @@ module Katello
     end
 
     def test_content_view_delegation_to_facet
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       assert_equal @view.id, @root.content_view_id
@@ -170,8 +170,8 @@ module Katello
       child = ::Hostgroup.create!(:name => 'child', :parent => parent)
 
       # Set content view on grandparent
-      grandparent.content_view = @view
-      grandparent.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv.id
       grandparent.save!
 
       # Both parent and child should inherit
@@ -180,8 +180,8 @@ module Katello
     end
 
     def test_content_view_override_in_child
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       different_view = FactoryBot.create(:katello_content_view, organization: @org)
@@ -190,8 +190,8 @@ module Katello
                         content_view_version: different_view_version,
                         environment: @library)
 
-      @child.content_view = different_view
-      @child.lifecycle_environment = @library
+      diff_cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: different_view.id, environment_id: @library.id)
+      @child.content_view_environment_id = diff_cvenv.id
       @child.save!
 
       # Parent has its view, child has overridden view
@@ -211,12 +211,12 @@ module Katello
                         content_view_version: parent_view_version,
                         environment: @library)
 
-      grandparent.content_view = grandparent_view
-      grandparent.lifecycle_environment = @library
+      gp_cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: grandparent_view.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = gp_cvenv.id
       grandparent.save!
 
-      parent.content_view = parent_view
-      parent.lifecycle_environment = @library
+      parent_cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: parent_view.id, environment_id: @library.id)
+      parent.content_view_environment_id = parent_cvenv.id
       parent.save!
 
       # Child should inherit from closest ancestor (parent)
@@ -226,7 +226,7 @@ module Katello
     end
 
     def test_lifecycle_environment_auto_adds_organization
-      # When setting CV and LCE together (required by validation),
+      # When setting content_view_environment_id,
       # the lifecycle_environment triggers add_organization_for_environment callback
       org = @view.organization
 
@@ -234,12 +234,11 @@ module Katello
       @root.organizations = []
       @root.save!
 
-      # Set both CV and LCE together (required by validation)
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
-      # With CVEnv model, setting CV and LCE together triggers add_organization_for_environment
+      # Setting content_view_environment_id triggers add_organization_for_environment
       # So organization WILL be auto-added
       @root.reload
       assert_includes @root.organizations, org
@@ -248,8 +247,8 @@ module Katello
     def test_rhsm_organization_label_from_content_view
       # With CVEnv model, both CV and LCE are always set together
       # This test now verifies the logic returns org label when both are present
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       # Should use lifecycle environment's org (same as content_view org in this case)
@@ -257,8 +256,8 @@ module Katello
     end
 
     def test_rhsm_organization_label_prefers_lifecycle_environment
-      @root.lifecycle_environment = @library
-      @root.content_view = @view
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       # Should use lifecycle environment's org if both are set
@@ -274,14 +273,15 @@ module Katello
       hostgroup = ::Hostgroup.create!(:name => 'no_facet')
       assert_nil hostgroup.content_facet
 
-      # Setting content_view should create facet
-      hostgroup.content_view = @view
+      # Setting content_view_environment_id should create facet via safe_content_facet
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      hostgroup.content_view_environment_id = cvenv.id
       assert_not_nil hostgroup.content_facet
     end
 
     def test_inherited_content_view_id
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       # Child should inherit content_view_id
@@ -289,47 +289,31 @@ module Katello
       assert_nil @child.content_view_id
     end
 
-    def test_content_view_with_lifecycle_environment_validation
-      # With CVE model, validation is implicit - CVE must exist to be assigned
-      # Create a content view that is ONLY published to library, not dev
-      library_only_view = FactoryBot.create(:katello_content_view, organization: @org)
-      library_only_version = FactoryBot.create(:katello_content_view_version, content_view: library_only_view)
-      FactoryBot.create(:katello_content_view_environment,
-                        content_view_version: library_only_version,
-                        environment: @library) # Only in library, not dev
-
-      @root.lifecycle_environment = @dev # dev environment
-      @root.content_view = library_only_view # Only published to library, not dev
-
-      # With ContentViewEnvironmentValidator: should reject CV not published to environment
-      refute @root.valid?, "Should be invalid when CV not published to selected environment"
-      # The validator adds the error to the content_facet's base errors
-      assert @root.content_facet.errors[:base].present?, "Should have validation error on content facet"
-    end
+    # Test removed: CV/LCE mismatch is no longer possible with content_view_environment_id
 
     def test_create_with_lifecycle_environment
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
       host_group = ::Hostgroup.new(:name => 'test_le_hostgroup',
-                                    :content_view => @view,
-                                    :lifecycle_environment => @dev)
+                                    :content_view_environment_id => cvenv.id)
       assert_valid host_group
       assert_equal @dev, host_group.lifecycle_environment
     end
 
     def test_update_lifecycle_environment
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv_lib.id
       assert @root.save!
       assert_equal @library, @root.reload.lifecycle_environment
 
-      @root.content_view = @view
-      @root.lifecycle_environment = @dev
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      @root.content_view_environment_id = cvenv_dev.id
       assert @root.save!
       assert_equal @dev, @root.reload.lifecycle_environment
     end
 
     def test_remove_lifecycle_environment
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
       assert_equal @library, @root.lifecycle_environment
 
@@ -340,8 +324,8 @@ module Katello
     end
 
     def test_lifecycle_environment_delegation_to_facet
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       assert_equal @library.id, @root.lifecycle_environment_id
@@ -354,8 +338,8 @@ module Katello
       child = ::Hostgroup.create!(:name => 'c_le', :parent => parent)
 
       # Set lifecycle environment on grandparent
-      grandparent.content_view = @view
-      grandparent.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv.id
       grandparent.save!
 
       # Both parent and child should inherit
@@ -364,12 +348,12 @@ module Katello
     end
 
     def test_lifecycle_environment_override_in_child
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv_lib.id
       @root.save!
 
-      @child.content_view = @view
-      @child.lifecycle_environment = @dev
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      @child.content_view_environment_id = cvenv_dev.id
       @child.save!
 
       # Parent has its env, child has overridden env
@@ -382,12 +366,12 @@ module Katello
       parent = ::Hostgroup.create!(:name => 'p_le2', :parent => grandparent)
       child = ::Hostgroup.create!(:name => 'c_le2', :parent => parent)
 
-      grandparent.content_view = @view
-      grandparent.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv_lib.id
       grandparent.save!
 
-      parent.content_view = @view
-      parent.lifecycle_environment = @dev
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      parent.content_view_environment_id = cvenv_dev.id
       parent.save!
 
       # Child should inherit from closest ancestor (parent)
@@ -402,8 +386,8 @@ module Katello
     end
 
     def test_inherited_lifecycle_environment_id
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       # Child should inherit lifecycle_environment_id
@@ -415,15 +399,16 @@ module Katello
       hostgroup = ::Hostgroup.create!(:name => 'no_facet_le')
       assert_nil hostgroup.content_facet
 
-      # Setting lifecycle_environment should create facet
-      hostgroup.lifecycle_environment = @library
+      # Setting content_view_environment_id should create facet via safe_content_facet
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      hostgroup.content_view_environment_id = cvenv.id
       assert_not_nil hostgroup.content_facet
     end
 
     def test_rhsm_organization_label_from_lifecycle_environment
       # With CVE model, both CV and LE are always set together
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       assert_equal @library.organization.label, @root.rhsm_organization_label
@@ -436,8 +421,8 @@ module Katello
       @root.organizations = []
       @root.save!
 
-      @root.content_view = @view
-      @root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
       @root.save!
 
       # Organization should be added automatically via callback
@@ -448,38 +433,22 @@ module Katello
     def test_lifecycle_environment_with_content_view_same_org
       # CV must be published to LE for validation to pass
       # @view (library_dev_staging_view) IS published to @library
-      @root.lifecycle_environment = @library
-      @root.content_view = @view
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      @root.content_view_environment_id = cvenv.id
 
       assert @root.valid?
       assert @root.save!
     end
 
-    def test_lifecycle_environment_and_content_view_not_published_together
-      # With CVE model, if CV is not published to LE, the CVE doesn't exist
-      # Create a view only published to library
-      library_only_view = FactoryBot.create(:katello_content_view, organization: @org)
-      library_only_version = FactoryBot.create(:katello_content_view_version, content_view: library_only_view)
-      FactoryBot.create(:katello_content_view_environment,
-                        content_view_version: library_only_version,
-                        environment: @library) # Only in library
-
-      @root.lifecycle_environment = @dev # dev environment
-      @root.content_view = library_only_view # Only published to library
-
-      # With ContentViewEnvironmentValidator: should reject CV not published to environment
-      refute @root.valid?, "Should be invalid when CV not published to selected environment"
-      # The validator adds the error to the content_facet's base errors
-      assert @root.content_facet.errors[:base].present?, "Should have validation error on content facet"
-    end
+    # Test removed: CV/LCE mismatch is no longer possible with content_view_environment_id
 
     def test_change_lifecycle_environment_updates_children
       parent = ::Hostgroup.create!(:name => 'parent_le_change')
       child = ::Hostgroup.create!(:name => 'child_le_change', :parent => parent)
       grandchild = ::Hostgroup.create!(:name => 'grandchild_le_change', :parent => child)
 
-      parent.content_view = @view
-      parent.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      parent.content_view_environment_id = cvenv_lib.id
       parent.save!
 
       # All should inherit
@@ -487,8 +456,8 @@ module Katello
       assert_equal @library, grandchild.lifecycle_environment
 
       # Change parent's env
-      parent.content_view = @view
-      parent.lifecycle_environment = @dev
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      parent.content_view_environment_id = cvenv_dev.id
       parent.save!
 
       # Children should now inherit new value
@@ -500,18 +469,18 @@ module Katello
       parent = ::Hostgroup.create!(:name => 'parent_override')
       child = ::Hostgroup.create!(:name => 'child_override', :parent => parent)
 
-      parent.content_view = @view
-      parent.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      parent.content_view_environment_id = cvenv_lib.id
       parent.save!
 
       # Child explicitly sets different env
-      child.content_view = @view
-      child.lifecycle_environment = @dev
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      child.content_view_environment_id = cvenv_dev.id
       child.save!
 
       # Change parent
-      parent.content_view = @view
-      parent.lifecycle_environment = @staging
+      cvenv_staging = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @staging.id)
+      parent.content_view_environment_id = cvenv_staging.id
       parent.save!
 
       # Child should keep its explicit value
@@ -571,8 +540,8 @@ module Katello
       parent = ::Hostgroup.create!(name: 'p_skip', parent: grandparent)
       child = ::Hostgroup.create!(name: 'c_skip', parent: parent)
 
-      grandparent.content_view = @view1
-      grandparent.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv.id
       grandparent.save!
 
       # Parent has no explicit value
@@ -590,8 +559,8 @@ module Katello
       parent = ::Hostgroup.create!(name: 'p_skip_le', parent: grandparent)
       child = ::Hostgroup.create!(name: 'c_skip_le', parent: parent)
 
-      grandparent.content_view = @view1
-      grandparent.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv.id
       grandparent.save!
 
       # Parent has no explicit value
@@ -610,16 +579,16 @@ module Katello
       child3 = ::Hostgroup.create!(name: 'child3', parent: parent)
 
       # Set parent value
-      parent.content_view = @view1
-      parent.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      parent.content_view_environment_id = cvenv.id
       parent.save!
 
       # Child1 inherits
       assert_equal @view1, child1.content_view
 
       # Child2 overrides
-      child2.content_view = @view2
-      child2.lifecycle_environment = @library
+      cvenv2 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view2.id, environment_id: @library.id)
+      child2.content_view_environment_id = cvenv2.id
       child2.save!
 
       # Child3 inherits
@@ -649,13 +618,13 @@ module Katello
       child4 = ::Hostgroup.create!(name: 'c4_branches', parent: parent2)
 
       # Set grandparent
-      grandparent.content_view = @view1
-      grandparent.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv_lib.id
       grandparent.save!
 
       # Override in parent2
-      parent2.content_view = @view1
-      parent2.lifecycle_environment = @dev
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @dev.id)
+      parent2.content_view_environment_id = cvenv_dev.id
       parent2.save!
 
       # Branch 1 (parent1 and children) should inherit from grandparent
@@ -677,8 +646,8 @@ module Katello
       level4 = ::Hostgroup.create!(name: 'mid_level4', parent: level3)
 
       # Set at top
-      level1.content_view = @view1
-      level1.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      level1.content_view_environment_id = cvenv.id
       level1.save!
 
       # All inherit initially
@@ -687,8 +656,8 @@ module Katello
       assert_equal @view1, level4.content_view
 
       # Override at middle level (level2)
-      level2.content_view = @view2
-      level2.lifecycle_environment = @library
+      cvenv2 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view2.id, environment_id: @library.id)
+      level2.content_view_environment_id = cvenv2.id
       level2.save!
 
       # Level1 unchanged
@@ -708,16 +677,16 @@ module Katello
       parent = ::Hostgroup.create!(name: 'p_gc_override', parent: grandparent)
       grandchild = ::Hostgroup.create!(name: 'gc_gc_override', parent: parent)
 
-      grandparent.content_view = @view1
-      grandparent.lifecycle_environment = @library
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv_lib.id
       grandparent.save!
 
       # Parent inherits
       assert_equal @library, parent.lifecycle_environment
 
       # Grandchild sets different value
-      grandchild.content_view = @view1
-      grandchild.lifecycle_environment = @staging
+      cvenv_staging = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @staging.id)
+      grandchild.content_view_environment_id = cvenv_staging.id
       grandchild.save!
 
       # Verify
@@ -733,13 +702,13 @@ module Katello
       child = ::Hostgroup.create!(name: 'c_mixed', parent: parent)
 
       # Set both on grandparent
-      grandparent.content_view = @view1
-      grandparent.lifecycle_environment = @library
+      cvenv1 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv1.id
       grandparent.save!
 
-      # Override only CV at parent level (LE stays inherited)
-      parent.content_view = @view2
-      parent.lifecycle_environment = @library
+      # Override CV at parent level (LE stays the same - library)
+      cvenv2 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view2.id, environment_id: @library.id)
+      parent.content_view_environment_id = cvenv2.id
       parent.save!
 
       # Child should inherit both from parent:
@@ -756,12 +725,12 @@ module Katello
       child = ::Hostgroup.create!(name: 'c_remove', parent: parent)
 
       # Set values
-      grandparent.content_view = @view1
-      grandparent.lifecycle_environment = @library
+      cvenv1 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      grandparent.content_view_environment_id = cvenv1.id
       grandparent.save!
 
-      parent.content_view = @view2
-      parent.lifecycle_environment = @library
+      cvenv2 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view2.id, environment_id: @library.id)
+      parent.content_view_environment_id = cvenv2.id
       parent.save!
 
       # Child inherits from parent
@@ -783,8 +752,8 @@ module Katello
       level3 = ::Hostgroup.create!(name: 'nil_level3', parent: level2)
 
       # Set at level1
-      level1.content_view = @view1
-      level1.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      level1.content_view_environment_id = cvenv.id
       level1.save!
 
       # Explicitly ensure level2 has nil (no facet or nil value)
@@ -812,8 +781,8 @@ module Katello
       b3 = ::Hostgroup.create!(name: 'wide_b3', parent: a2)
 
       # Set at root
-      root.content_view = @view1
-      root.lifecycle_environment = @library
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view1.id, environment_id: @library.id)
+      root.content_view_environment_id = cvenv.id
       root.save!
 
       # All should inherit
@@ -825,8 +794,8 @@ module Katello
       assert_equal @view1, b3.content_view
 
       # Override one branch
-      a2.content_view = @view2
-      a2.lifecycle_environment = @library
+      cvenv2 = Katello::ContentViewEnvironment.find_by!(content_view_id: @view2.id, environment_id: @library.id)
+      a2.content_view_environment_id = cvenv2.id
       a2.save!
 
       # Only a2 and its children should have new value
@@ -864,9 +833,9 @@ module Katello
         architecture: @arch
         )
       facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: hg)
-      facet.content_view = @distro_cv
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
+      facet.content_view_environment_id = cvenv.id
       facet.content_source = @content_source
-      facet.lifecycle_environment = @distro_env
       facet.kickstart_repository = @distro
       assert facet.save
       assert_valid facet
@@ -875,13 +844,13 @@ module Katello
 
     def test_set_kickstart_repository
       @os.stubs(:kickstart_repos).returns([@distro])
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
       hg = ::Hostgroup.new(
         name: 'kickstart_repo',
         operatingsystem: @os,
         content_source: @content_source,
         architecture: @arch,
-        content_view: @distro_cv,
-        lifecycle_environment: @distro_env,
+        content_view_environment_id: cvenv.id,
         kickstart_repository: @distro)
 
       assert_valid hg
@@ -889,13 +858,13 @@ module Katello
     end
 
     def test_set_installation_medium
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
       hg = ::Hostgroup.new(
         name: 'install_media',
         operatingsystem: @os,
         content_source: @content_source,
         architecture: @arch,
-        content_view: @distro_cv,
-        lifecycle_environment: @distro_env,
+        content_view_environment_id: cvenv.id,
         medium: @medium)
 
       assert_valid hg
@@ -904,13 +873,13 @@ module Katello
 
     def test_change_medium_to_kickstart_repository
       @os.stubs(:kickstart_repos).returns([@distro])
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
       hg = ::Hostgroup.new(
         name: 'install_media',
         operatingsystem: @os,
         content_source: @content_source,
         architecture: @arch,
-        content_view: @distro_cv,
-        lifecycle_environment: @distro_env,
+        content_view_environment_id: cvenv.id,
         medium: @medium)
 
       assert hg.save
@@ -922,13 +891,13 @@ module Katello
 
     def test_change_kickstart_repository_to_medium
       @os.stubs(:kickstart_repos).returns([@distro])
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
       hg = ::Hostgroup.new(
         name: 'kickstart_repo',
         operatingsystem: @os,
         content_source: @content_source,
         architecture: @arch,
-        content_view: @distro_cv,
-        lifecycle_environment: @distro_env,
+        content_view_environment_id: cvenv.id,
         kickstart_repository: @distro)
 
       assert hg.save
@@ -941,18 +910,19 @@ module Katello
     def test_change_lifecycle_environment_mismatched_kickstart
       @os = ::Redhat.create_operating_system("GreatOS1", *@dev_distro.distribution_version.split('.'))
 
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
       hg = ::Hostgroup.new(
         name: 'kickstart_repo',
         operatingsystem: @os,
         content_source: @content_source,
         architecture: @arch,
-        content_view: @distro_cv,
-        lifecycle_environment: @distro_env,
+        content_view_environment_id: cvenv.id,
         kickstart_repository: @distro)
 
       # changing the lifecycle environment will trigger
       # code which attempts to reassign the kickstart repo by its label
-      hg.lifecycle_environment = @dev_distro.environment
+      dev_cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @dev_distro.environment.id)
+      hg.content_view_environment_id = dev_cvenv.id
       assert hg.save
       assert_equal hg.kickstart_repository_id, @dev_distro.id
     end
@@ -985,15 +955,11 @@ module Katello
                         content_view_version: @view2_version,
                         environment: @library)
 
-      @hg_with_view1 = ::Hostgroup.create!(name: 'hg_cv1')
-      @hg_with_view1.content_view = @view1
-      @hg_with_view1.lifecycle_environment = @library
-      @hg_with_view1.save!
+      cvenv1 = Katello::ContentViewEnvironment.find_by(content_view_id: @view1.id, environment_id: @library.id)
+      @hg_with_view1 = ::Hostgroup.create!(name: 'hg_cv1', content_view_environment_id: cvenv1.id)
 
-      @hg_with_view2 = ::Hostgroup.create!(name: 'hg_cv2')
-      @hg_with_view2.content_view = @view2
-      @hg_with_view2.lifecycle_environment = @library
-      @hg_with_view2.save!
+      cvenv2 = Katello::ContentViewEnvironment.find_by(content_view_id: @view2.id, environment_id: @library.id)
+      @hg_with_view2 = ::Hostgroup.create!(name: 'hg_cv2', content_view_environment_id: cvenv2.id)
 
       @hg_without_view = ::Hostgroup.create!(name: 'hg_no_cv')
     end
@@ -1038,7 +1004,7 @@ module Katello
       @view = FactoryBot.create(:katello_content_view, organization: @org)
       @view_version = FactoryBot.create(:katello_content_view_version, content_view: @view)
 
-      # Create CVEs for view in each environment
+      # Create content view environments for view in each environment
       FactoryBot.create(:katello_content_view_environment,
                         content_view_version: @view_version,
                         environment: @library)
@@ -1046,15 +1012,11 @@ module Katello
                         content_view_version: @view_version,
                         environment: @dev)
 
-      @hg_with_library = ::Hostgroup.create!(name: 'hg_lib')
-      @hg_with_library.content_view = @view
-      @hg_with_library.lifecycle_environment = @library
-      @hg_with_library.save!
+      cvenv_lib = Katello::ContentViewEnvironment.find_by(content_view_id: @view.id, environment_id: @library.id)
+      @hg_with_library = ::Hostgroup.create!(name: 'hg_lib', content_view_environment_id: cvenv_lib.id)
 
-      @hg_with_dev = ::Hostgroup.create!(name: 'hg_dev')
-      @hg_with_dev.content_view = @view
-      @hg_with_dev.lifecycle_environment = @dev
-      @hg_with_dev.save!
+      cvenv_dev = Katello::ContentViewEnvironment.find_by(content_view_id: @view.id, environment_id: @dev.id)
+      @hg_with_dev = ::Hostgroup.create!(name: 'hg_dev', content_view_environment_id: cvenv_dev.id)
 
       @hg_without_env = ::Hostgroup.create!(name: 'hg_no_env')
     end
@@ -1086,8 +1048,8 @@ module Katello
                         environment: @staging)
 
       parent = ::Hostgroup.create!(name: 'parent_search')
-      parent.content_view = @view
-      parent.lifecycle_environment = @staging
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @staging.id)
+      parent.content_view_environment_id = cvenv.id
       parent.save!
 
       _child = ::Hostgroup.create!(name: 'child_search', parent: parent)
@@ -1155,51 +1117,33 @@ module Katello
                         environment: @library)
     end
 
-    def test_setting_content_view_without_lifecycle_environment_should_fail
+    # Test removed: CV/LCE mismatch is no longer possible with content_view_environment_id
+    # (test_setting_content_view_without_lifecycle_environment_should_fail)
+
+    # Test removed: CV/LCE mismatch is no longer possible with content_view_environment_id
+    # (test_setting_lifecycle_environment_without_content_view_should_fail)
+
+    def test_setting_content_view_environment_should_succeed
       hostgroup = ::Hostgroup.create!(name: 'TestHG')
 
-      # Try to set only CV without LCE
-      hostgroup.content_view_id = @view.id
-      # Don't set lifecycle_environment_id
+      # Set CV and LCE together via content_view_environment_id
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      hostgroup.content_view_environment_id = cvenv.id
 
-      refute hostgroup.valid?, "Hostgroup should be invalid when setting CV without LCE"
-      assert_includes hostgroup.errors.messages.to_s, 'Content view', "Should have validation error about content view"
-    end
-
-    def test_setting_lifecycle_environment_without_content_view_should_fail
-      hostgroup = ::Hostgroup.create!(name: 'TestHG')
-
-      # Try to set only LCE without CV
-      hostgroup.lifecycle_environment_id = @library.id
-      # Don't set content_view_id
-
-      refute hostgroup.valid?, "Hostgroup should be invalid when setting LCE without CV"
-      assert hostgroup.errors.messages.to_s.include?('Content view') || hostgroup.errors.messages.to_s.include?('Lifecycle environment'),
-             "Should have validation error about missing CV or LCE"
-    end
-
-    def test_setting_both_content_view_and_lifecycle_environment_should_succeed
-      hostgroup = ::Hostgroup.create!(name: 'TestHG')
-
-      # Set both CV and LCE together
-      hostgroup.lifecycle_environment_id = @library.id
-      hostgroup.content_view_id = @view.id
-
-      assert hostgroup.valid?, "Hostgroup should be valid when setting both CV and LCE: #{hostgroup.errors.full_messages}"
+      assert hostgroup.valid?, "Hostgroup should be valid when setting content_view_environment_id: #{hostgroup.errors.full_messages}"
       assert hostgroup.save
     end
 
-    def test_removing_both_content_view_and_lifecycle_environment_should_succeed
+    def test_removing_content_view_environment_should_succeed
       hostgroup = ::Hostgroup.create!(name: 'TestHG')
-      hostgroup.lifecycle_environment_id = @library.id
-      hostgroup.content_view_id = @view.id
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      hostgroup.content_view_environment_id = cvenv.id
       hostgroup.save!
 
-      # Remove both together
-      hostgroup.lifecycle_environment_id = nil
-      hostgroup.content_view_id = nil
+      # Remove by clearing the association
+      hostgroup.content_view_environment_id = nil
 
-      assert hostgroup.valid?, "Hostgroup should be valid when removing both CV and LCE: #{hostgroup.errors.full_messages}"
+      assert hostgroup.valid?, "Hostgroup should be valid when removing content_view_environment_id: #{hostgroup.errors.full_messages}"
       assert hostgroup.save
 
       # Verify persistence - reload and check database state
@@ -1209,20 +1153,19 @@ module Katello
       assert_nil hostgroup.content_facet.content_view_environment_id, "ContentViewEnvironment association should be cleared"
     end
 
-    def test_nil_content_view_with_nil_lifecycle_environment_is_valid
+    def test_nil_content_view_environment_is_valid
       hostgroup = ::Hostgroup.create!(name: 'TestHG')
 
-      # Both nil is valid (no content management)
-      hostgroup.lifecycle_environment_id = nil
-      hostgroup.content_view_id = nil
+      # No content_view_environment_id is valid (no content management)
+      hostgroup.content_view_environment_id = nil
 
-      assert hostgroup.valid?, "Hostgroup should be valid with both CV and LCE as nil: #{hostgroup.errors.full_messages}"
+      assert hostgroup.valid?, "Hostgroup should be valid with nil content_view_environment_id: #{hostgroup.errors.full_messages}"
     end
 
-    def test_updating_lifecycle_environment_keeps_content_view_valid
+    def test_updating_content_view_environment_to_different_env
       hostgroup = ::Hostgroup.create!(name: 'TestHG')
-      hostgroup.lifecycle_environment_id = @library.id
-      hostgroup.content_view_id = @view.id
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      hostgroup.content_view_environment_id = cvenv_lib.id
       hostgroup.save!
 
       # Publish view to dev
@@ -1230,17 +1173,18 @@ module Katello
                         content_view_version: @view_version,
                         environment: @dev)
 
-      # Change environment (CV is published to both)
-      hostgroup.lifecycle_environment_id = @dev.id
+      # Change to dev environment (CV is published to both)
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      hostgroup.content_view_environment_id = cvenv_dev.id
 
-      assert hostgroup.valid?, "Hostgroup should be valid when changing LCE to another env where CV is published: #{hostgroup.errors.full_messages}"
+      assert hostgroup.valid?, "Hostgroup should be valid when changing to another CVEnv: #{hostgroup.errors.full_messages}"
       assert hostgroup.save
     end
 
-    def test_child_can_set_partial_cv_lce_when_parent_has_other
+    def test_child_can_set_different_content_view_environment_than_parent
       parent = ::Hostgroup.create!(name: 'ParentHG')
-      parent.lifecycle_environment_id = @library.id
-      parent.content_view_id = @view.id
+      cvenv_lib = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @library.id)
+      parent.content_view_environment_id = cvenv_lib.id
       parent.save!
 
       child = ::Hostgroup.create!(name: 'ChildHG', parent: parent)
@@ -1250,13 +1194,11 @@ module Katello
                         content_view_version: @view_version,
                         environment: @dev)
 
-      # Child must set both CV and LCE explicitly, even when inheriting from parent
-      # Setting only LCE would fail validation because the "both together" rule
-      # checks pending values, not inherited values
-      child.lifecycle_environment_id = @dev.id
-      child.content_view_id = @view.id # Must explicitly set, even though parent has it
+      # Child sets a different content_view_environment_id
+      cvenv_dev = Katello::ContentViewEnvironment.find_by!(content_view_id: @view.id, environment_id: @dev.id)
+      child.content_view_environment_id = cvenv_dev.id
 
-      assert child.valid?, "Child should be valid when setting both CV and LCE explicitly: #{child.errors.full_messages}"
+      assert child.valid?, "Child should be valid when setting its own content_view_environment_id: #{child.errors.full_messages}"
       assert child.save
 
       # Verify the child has explicit CV and LCE values

--- a/test/models/concerns/redhat_extensions_test.rb
+++ b/test/models/concerns/redhat_extensions_test.rb
@@ -95,8 +95,8 @@ module Katello
       hostgroup = ::Hostgroup.find(hostgroups(:common).id)
       hostgroup.operatingsystem = os
       hostgroup.architecture = architectures(:x86_64)
-      hostgroup.lifecycle_environment = @repo_with_distro.environment
-      hostgroup.content_view = @repo_with_distro.content_view
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@repo_with_distro.content_view.id, @repo_with_distro.environment.id)
+      hostgroup.content_view_environment_id = cvenv.id
       hostgroup.save!
       assert_equal @repo_with_distro.distribution_arch, other_repo.distribution_arch
       assert_equal @repo_with_distro.distribution_version, other_repo.distribution_version
@@ -123,9 +123,9 @@ module Katello
       assert_includes repo_list, @repo_with_distro
 
       diff_os = ::Redhat.create_operating_system("RedHat", version[0], "#{version[1]}0")
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@repo_with_distro.content_view.id, @repo_with_distro.environment.id)
       host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => diff_os,
-                        :content_facet_attributes => {:lifecycle_environment_id => @repo_with_distro.environment.id,
-                                                      :content_view_id => @repo_with_distro.content_view.id})
+                        :content_facet_attributes => {:content_view_environment_ids => [cvenv.id]})
       repo_list = diff_os.distribution_repositories(host)
       refute_includes repo_list, @repo_with_distro
     end
@@ -140,15 +140,15 @@ module Katello
       @os.architectures << architectures(:x86_64)
       @content_source = FactoryBot.create(:smart_proxy, :name => "foobar", :url => "http://capsule.com/")
 
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@repo_with_distro.content_view.id, @repo_with_distro.environment.id)
       @host = ::Host.new(:architecture => architectures(:x86_64), :operatingsystem => @os,
-                        :content_facet_attributes => {:lifecycle_environment_id => @repo_with_distro.environment.id,
-                                                      :content_view_id => @repo_with_distro.content_view.id,
+                        :content_facet_attributes => {:content_view_environment_ids => [cvenv.id],
                                                       :content_source => @content_source})
 
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(@repo_with_distro.content_view.id, @repo_with_distro.environment.id)
       @hostgroup = ::Hostgroup.new(:name => "testhg",
         :content_facet_attributes => {
-          :lifecycle_environment_id => @repo_with_distro.environment.id,
-          :content_view_id => @repo_with_distro.content_view.id,
+          :content_view_environment => cvenv,
         }
       )
       @hostgroup.architecture = architectures(:x86_64)

--- a/test/models/content_view_test.rb
+++ b/test/models/content_view_test.rb
@@ -131,15 +131,12 @@ module Katello
       host1 = ::Host::Managed.create!(:name => 'foohost.example.com', :managed => false, :organization_id => org.id)
       host2 = ::Host::Managed.create!(:name => 'barhost.example.com', :managed => false, :organization_id => org.id)
 
-      cve1 = FactoryBot.create(:katello_content_view_environment, content_view: cv, environment: env1)
-      cve2 = FactoryBot.create(:katello_content_view_environment, content_view: cv, environment: env2)
+      cv_version = FactoryBot.create(:katello_content_view_version, content_view: cv)
+      cvenv1 = FactoryBot.create(:katello_content_view_environment, content_view_version: cv_version, environment: env1)
+      cvenv2 = FactoryBot.create(:katello_content_view_environment, content_view_version: cv_version, environment: env2)
 
-      content_facet1 = Katello::Host::ContentFacet.create!(content_view_id: cv.id, lifecycle_environment_id: env1.id, host: host1)
-      content_facet2 = Katello::Host::ContentFacet.create!(content_view_id: cv.id, lifecycle_environment_id: env2.id, host: host2)
-
-      Katello::ContentViewEnvironmentContentFacet.create!(content_view_environment: cve1, content_facet: content_facet1)
-      Katello::ContentViewEnvironmentContentFacet.create!(content_view_environment: cve2, content_facet: content_facet1)
-      Katello::ContentViewEnvironmentContentFacet.create!(content_view_environment: cve2, content_facet: content_facet2)
+      Katello::Host::ContentFacet.create!(content_view_environment_ids: [cvenv1.id, cvenv2.id], host: host1)
+      Katello::Host::ContentFacet.create!(content_view_environment_ids: [cvenv2.id], host: host2)
 
       assert_equal 2, cv.hosts.count
     end
@@ -155,12 +152,12 @@ module Katello
       ak1 = Katello::ActivationKey.create!(name: 'activation_key1', organization: org)
       ak2 = Katello::ActivationKey.create!(name: 'activation_key2', organization: org)
 
-      cve1 = FactoryBot.create(:katello_content_view_environment, content_view: cv, environment: env1)
-      cve2 = FactoryBot.create(:katello_content_view_environment, content_view: cv, environment: env2)
+      cvenv1 = FactoryBot.create(:katello_content_view_environment, content_view: cv, environment: env1)
+      cvenv2 = FactoryBot.create(:katello_content_view_environment, content_view: cv, environment: env2)
 
-      Katello::ContentViewEnvironmentActivationKey.create!(content_view_environment: cve1, activation_key: ak1)
-      Katello::ContentViewEnvironmentActivationKey.create!(content_view_environment: cve2, activation_key: ak1)
-      Katello::ContentViewEnvironmentActivationKey.create!(content_view_environment: cve2, activation_key: ak2)
+      Katello::ContentViewEnvironmentActivationKey.create!(content_view_environment: cvenv1, activation_key: ak1)
+      Katello::ContentViewEnvironmentActivationKey.create!(content_view_environment: cvenv2, activation_key: ak1)
+      Katello::ContentViewEnvironmentActivationKey.create!(content_view_environment: cvenv2, activation_key: ak2)
 
       assert_equal 2, cv.activation_keys.count
     end
@@ -690,8 +687,8 @@ module Katello
       refute_equal facet.host.location, other_location
       assert_nothing_raised do
         Location.as_taxonomy(facet.host.organization, other_location) do
-          facet.content_view_environments.each do |cve|
-            cve.content_view.update_host_statuses(cve.lifecycle_environment)
+          facet.content_view_environments.each do |cvenv|
+            cvenv.content_view.update_host_statuses(cvenv.lifecycle_environment)
           end
         end
       end
@@ -706,8 +703,8 @@ module Katello
 
       assert_nothing_raised do
         Location.as_taxonomy(org, other_location) do
-          facet.content_view_environments.each do |cve|
-            cve.content_view.update_host_statuses(cve.lifecycle_environment)
+          facet.content_view_environments.each do |cvenv|
+            cvenv.content_view.update_host_statuses(cvenv.lifecycle_environment)
           end
         end
       end

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -164,11 +164,11 @@ module Katello
       super
       @host = hosts(:one)
       @host.expects(:update_candlepin_associations)
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
         katello_content_views(:library_dev_view).id,
         katello_environments(:library).id
       )
-      @host.content_facet.content_view_environments = [cve]
+      @host.content_facet.content_view_environments = [cvenv]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!
@@ -223,11 +223,11 @@ module Katello
       @security = katello_errata(:security)
       @host = hosts(:one)
       @host.expects(:update_candlepin_associations)
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
         katello_content_views(:library_dev_view).id,
         katello_environments(:library).id
       )
-      @host.content_facet.content_view_environments = [cve]
+      @host.content_facet.content_view_environments = [cvenv]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -164,10 +164,11 @@ module Katello
       super
       @host = hosts(:one)
       @host.expects(:update_candlepin_associations)
-      @host.content_facet.assign_single_environment(
-        content_view: katello_content_views(:library_dev_view),
-        lifecycle_environment: katello_environments(:library)
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        katello_content_views(:library_dev_view).id,
+        katello_environments(:library).id
       )
+      @host.content_facet.content_view_environments = [cve]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!
@@ -222,10 +223,11 @@ module Katello
       @security = katello_errata(:security)
       @host = hosts(:one)
       @host.expects(:update_candlepin_associations)
-      @host.content_facet.assign_single_environment(
-        content_view: katello_content_views(:library_dev_view),
-        lifecycle_environment: katello_environments(:library)
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        katello_content_views(:library_dev_view).id,
+        katello_environments(:library).id
       )
+      @host.content_facet.content_view_environments = [cve]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -483,10 +483,8 @@ module Katello
     end
 
     def test_save_bound_repos_by_paths
-      content_facet.assign_single_environment(
-        content_view: repo.content_view,
-        lifecycle_environment: repo.environment
-      )
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
+      content_facet.content_view_environments = [cve]
       assert_empty content_facet.bound_repositories
 
       content_facet.update_repositories_by_paths([
@@ -499,10 +497,8 @@ module Katello
     end
 
     def test_save_bound_repos_by_paths_same_path
-      content_facet.assign_single_environment(
-        content_view: repo.content_view,
-        lifecycle_environment: repo.environment
-      )
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
+      content_facet.content_view_environments = [cve]
       content_facet.bound_repositories = [repo]
       ForemanTasks.expects(:async_task).never
 

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -20,7 +20,8 @@ module Katello
 
   class ContentFacetTest < ContentFacetBase
     def test_create
-      empty_host.content_facet = Katello::Host::ContentFacet.create!(:content_view_id => view.id, :lifecycle_environment_id => library.id, :host => empty_host)
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, library.id)
+      empty_host.content_facet = Katello::Host::ContentFacet.create!(:content_view_environment_ids => [cvenv.id], :host => empty_host)
     end
 
     def test_content_view_version
@@ -102,8 +103,8 @@ module Katello
     end
 
     def test_in_content_view_version_environments
-      facet_cve = content_facet.content_view_environments.reload.first
-      first_cvve = {:content_view_version => facet_cve.content_view.version(facet_cve.lifecycle_environment),
+      facet_cvenv = content_facet.content_view_environments.reload.first
+      first_cvve = {:content_view_version => facet_cvenv.content_view.version(facet_cvenv.lifecycle_environment),
                     :environments => [content_facet.single_lifecycle_environment]}
       second_cvve = {:content_view_version => view.version(library), :environments => [dev]} #dummy set
 
@@ -133,8 +134,9 @@ module Katello
     def test_audit_for_content_facet
       org = taxonomies(:empty_organization)
       host1 = ::Host::Managed.create!(:name => 'foohost.example.com', :managed => false, :organization_id => org.id)
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, library.id)
       content_facet1 = Katello::Host::ContentFacet.create!(
-        :content_view_id => view.id, :lifecycle_environment_id => library.id, :host => host1
+        :content_view_environment_ids => [cvenv.id], :host => host1
       )
 
       recent_audit = Audit.where(auditable_id: content_facet1.id).last
@@ -146,38 +148,38 @@ module Katello
       assert content_facet_rec, "No associated audit record for content_facet"
     end
 
-    def test_all_default_or_rolling_returns_nil_when_no_cves
+    def test_all_default_or_rolling_returns_nil_when_no_cvenvs
       content_facet.content_view_environments = []
       assert_nil content_facet.content_view_environments_all_default_or_rolling?
     end
 
     def test_all_default_or_rolling_returns_false_when_non_rolling_non_library
-      non_rolling_cve = katello_content_view_environments(:library_dev_view_dev)
-      content_facet.content_view_environments = [non_rolling_cve]
+      non_rolling_cvenv = katello_content_view_environments(:library_dev_view_dev)
+      content_facet.content_view_environments = [non_rolling_cvenv]
       refute content_facet.content_view_environments_all_default_or_rolling?
     end
 
     def test_all_default_or_rolling_returns_true_when_first_is_library_with_others
-      library_cve = katello_content_view_environments(:library_default_view_environment)
-      non_rolling_cve = katello_content_view_environments(:library_dev_view_dev)
+      library_cvenv = katello_content_view_environments(:library_default_view_environment)
+      non_rolling_cvenv = katello_content_view_environments(:library_dev_view_dev)
       Setting['allow_multiple_content_views'] = true
-      content_facet.content_view_environments = [library_cve, non_rolling_cve]
+      content_facet.content_view_environments = [library_cvenv, non_rolling_cvenv]
       assert content_facet.content_view_environments_all_default_or_rolling?
     end
 
     def test_all_default_or_rolling_returns_false_when_rolling_first_non_rolling_second
-      rolling_cve = katello_content_view_environments(:rolling_view_library)
-      non_rolling_cve = katello_content_view_environments(:library_dev_view_dev)
+      rolling_cvenv = katello_content_view_environments(:rolling_view_library)
+      non_rolling_cvenv = katello_content_view_environments(:library_dev_view_dev)
       Setting['allow_multiple_content_views'] = true
-      content_facet.content_view_environments = [rolling_cve, non_rolling_cve]
+      content_facet.content_view_environments = [rolling_cvenv, non_rolling_cvenv]
       refute content_facet.content_view_environments_all_default_or_rolling?
     end
 
     def test_all_default_or_rolling_returns_true_when_all_rolling_or_library
-      rolling_cve = katello_content_view_environments(:rolling_view_library)
-      library_cve = katello_content_view_environments(:library_default_view_environment)
+      rolling_cvenv = katello_content_view_environments(:rolling_view_library)
+      library_cvenv = katello_content_view_environments(:library_default_view_environment)
       Setting['allow_multiple_content_views'] = true
-      content_facet.content_view_environments = [rolling_cve, library_cve]
+      content_facet.content_view_environments = [rolling_cvenv, library_cvenv]
       assert content_facet.content_view_environments_all_default_or_rolling?
     end
   end
@@ -483,8 +485,8 @@ module Katello
     end
 
     def test_save_bound_repos_by_paths
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
-      content_facet.content_view_environments = [cve]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
+      content_facet.content_view_environments = [cvenv]
       assert_empty content_facet.bound_repositories
 
       content_facet.update_repositories_by_paths([
@@ -497,8 +499,8 @@ module Katello
     end
 
     def test_save_bound_repos_by_paths_same_path
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
-      content_facet.content_view_environments = [cve]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(repo.content_view.id, repo.environment.id)
+      content_facet.content_view_environments = [cvenv]
       content_facet.bound_repositories = [repo]
       ForemanTasks.expects(:async_task).never
 

--- a/test/models/hostgroup/content_facet_test.rb
+++ b/test/models/hostgroup/content_facet_test.rb
@@ -6,117 +6,59 @@ module Katello
       let(:library) { katello_environments(:library) }
       let(:dev) { katello_environments(:dev) }
       let(:view) { katello_content_views(:library_dev_view) }
-      let(:cve) { katello_content_view_environments(:library_dev_view_library) }
+      let(:cvenv) { katello_content_view_environments(:library_dev_view_library) }
       let(:hostgroup) { ::Hostgroup.new(:name => 'test-hg') }
 
       def setup
         @content_facet = Katello::Hostgroup::ContentFacet.new(:hostgroup => hostgroup)
       end
 
-      # Test direct CVE assignment (primary method for UI form)
       def test_content_view_environment_assignment
-        @content_facet.content_view_environment = cve
+        @content_facet.content_view_environment = cvenv
         assert @content_facet.valid?
-        assert_equal cve, @content_facet.content_view_environment
+        assert_equal cvenv, @content_facet.content_view_environment
       end
 
       def test_nil_content_view_environment_succeeds
-        # Nil is valid (inheriting from parent)
         @content_facet.content_view_environment = nil
         assert @content_facet.valid?
       end
 
-      # Test virtual attribute setters (API backwards compatibility)
-      def test_both_content_view_and_lifecycle_environment_succeeds
-        @content_facet.content_view_id = view.id
-        @content_facet.lifecycle_environment_id = library.id
-        assert @content_facet.valid?
-        assert_equal cve, @content_facet.content_view_environment
-      end
-
-      def test_update_with_both_content_view_and_lifecycle_environment_succeeds
-        # Create with valid CVE
-        @content_facet.content_view_environment = cve
-        @content_facet.save!
-
-        # Update using virtual attributes (API backwards compat)
-        new_facet = Katello::Hostgroup::ContentFacet.find(@content_facet.id)
-        new_cv = katello_content_views(:acme_default)
-        new_cve = katello_content_view_environments(:library_default_view_environment)
-
-        new_facet.content_view_id = new_cv.id
-        new_facet.lifecycle_environment_id = library.id
-
-        assert new_facet.valid?
-        assert_equal new_cve, new_facet.content_view_environment
-      end
-
-      # Test object setters
-      def test_content_view_setter
-        @content_facet.content_view = view
+      def test_content_view_id_getter
+        @content_facet.content_view_environment = cvenv
         assert_equal view.id, @content_facet.content_view_id
       end
 
-      def test_lifecycle_environment_setter
-        @content_facet.lifecycle_environment = library
+      def test_lifecycle_environment_id_getter
+        @content_facet.content_view_environment = cvenv
         assert_equal library.id, @content_facet.lifecycle_environment_id
       end
 
-      # Test object getters with pending values (API backwards compat)
-      def test_content_view_getter_with_pending_value
-        @content_facet.content_view_id = view.id
-        @content_facet.lifecycle_environment_id = library.id
+      def test_content_view_getter
+        @content_facet.content_view_environment = cvenv
         assert_equal view, @content_facet.content_view
       end
 
-      def test_lifecycle_environment_getter_with_pending_value
-        @content_facet.content_view_id = view.id
-        @content_facet.lifecycle_environment_id = library.id
+      def test_lifecycle_environment_getter
+        @content_facet.content_view_environment = cvenv
         assert_equal library, @content_facet.lifecycle_environment
       end
 
-      # Test inheritance behavior via virtual attributes (API backwards compatibility)
-      # When using the deprecated virtual attributes, clearing one clears both
-      def test_clearing_content_view_for_inheritance_clears_both
-        # Create with valid CVE
-        @content_facet.content_view_environment = cve
+      def test_getters_nil_when_no_cvenv
+        assert_nil @content_facet.content_view_id
+        assert_nil @content_facet.lifecycle_environment_id
+        assert_nil @content_facet.content_view
+        assert_nil @content_facet.lifecycle_environment
+      end
+
+      def test_clearing_content_view_environment
+        @content_facet.content_view_environment = cvenv
         @content_facet.save!
         assert_not_nil @content_facet.content_view_environment_id
 
-        # Reload and clear only CV using virtual attribute (simulating API call)
         @content_facet.reload
-        @content_facet.content_view_id = nil
+        @content_facet.content_view_environment = nil
 
-        # Both should be cleared for inheritance
-        assert_nil @content_facet.content_view_environment
-        assert @content_facet.valid?
-      end
-
-      def test_clearing_lifecycle_environment_for_inheritance_clears_both
-        # Create with valid CVE
-        @content_facet.content_view_environment = cve
-        @content_facet.save!
-        assert_not_nil @content_facet.content_view_environment_id
-
-        # Reload and clear only LCE using virtual attribute (simulating API call)
-        @content_facet.reload
-        @content_facet.lifecycle_environment_id = nil
-
-        # Both should be cleared for inheritance
-        assert_nil @content_facet.content_view_environment
-        assert @content_facet.valid?
-      end
-
-      def test_clearing_content_view_with_blank_string_clears_both
-        # Create with valid CVE
-        @content_facet.content_view_environment = cve
-        @content_facet.save!
-
-        # Reload and clear with blank string (simulating form submission via API)
-        @content_facet.reload
-        @content_facet.content_view_id = ''
-
-        # Both should be cleared
         assert_nil @content_facet.content_view_environment
         assert @content_facet.valid?
       end

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -678,11 +678,11 @@ module Katello
       # validate that clone repo path for a component view does not include the component view label
       library = KTEnvironment.find(katello_environments(:library).id)
       cv = ContentView.find(katello_content_views(:composite_view).id)
-      cve = ContentViewEnvironment.where(:environment_id => library,
+      cvenv = ContentViewEnvironment.where(:environment_id => library,
                                          :content_view_id => cv).first
-      @fedora_17_x86_64.content_view_version = cve.content_view_version
+      @fedora_17_x86_64.content_view_version = cvenv.content_view_version
 
-      assert_equal "#{cv.organization.label}/#{cve.label}/fedora_17_label", @fedora_17_x86_64.generate_repo_path
+      assert_equal "#{cv.organization.label}/#{cvenv.label}/fedora_17_label", @fedora_17_x86_64.generate_repo_path
 
       @fedora_17_x86_64.content_view_version = katello_content_view_versions(:library_view_version_1)
       @fedora_17_x86_64.environment = nil

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -6,6 +6,7 @@ module Katello
       include VCR::TestCase
     end
 
+    # rubocop:disable Metrics/ClassLength
     class RegistrationManager < RegistrationManagerTestBase
       include FactImporterIsolation
       allow_transactions_for_any_importer
@@ -226,7 +227,7 @@ module Katello
 
       def test_registration_activation_key
         new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @host_collection.organization)
-        cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.content_view, :environment_id => @activation_key.environment).first
+        cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.single_content_view, :environment_id => @activation_key.single_lifecycle_environment).first
 
         ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
 
@@ -239,9 +240,9 @@ module Katello
 
         ::Katello::RegistrationManager.register_host(new_host, rhsm_params, [cvpe], [@activation_key])
 
-        new_host_cve = new_host.content_facet.content_view_environments.first
-        assert_equal @activation_key.environment, new_host_cve.lifecycle_environment
-        assert_equal @activation_key.content_view, new_host_cve.content_view
+        new_host_cvenv = new_host.content_facet.content_view_environments.first
+        assert_equal @activation_key.single_lifecycle_environment, new_host_cvenv.lifecycle_environment
+        assert_equal @activation_key.single_content_view, new_host_cvenv.content_view
 
         assert_includes new_host.host_collections, @host_collection
       end
@@ -250,7 +251,7 @@ module Katello
         @activation_key.host_collections << @one_host_limit_host_collection
         existing_host = ::Host::Managed.create(:name => 'alreadyhere.example.com', :managed => false, :organization => @one_host_limit_host_collection.organization)
         new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @one_host_limit_host_collection.organization)
-        cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.content_view, :environment_id => @activation_key.environment).first
+        cvpe = Katello::ContentViewEnvironment.where(:content_view_id => @activation_key.single_content_view, :environment_id => @activation_key.single_lifecycle_environment).first
         @one_host_limit_host_collection.hosts << existing_host
         assert_equal 1, @one_host_limit_host_collection.hosts.count
         assert_equal 1, @one_host_limit_host_collection.max_hosts
@@ -260,6 +261,22 @@ module Katello
         end
 
         refute_includes new_host.host_collections, @host_collection
+      end
+
+      def test_lookup_content_view_environments_single_cvenv_mode
+        Setting['allow_multiple_content_views'] = false
+        result = ::Katello::RegistrationManager.send(:lookup_content_view_environments, [@activation_key])
+        assert_equal 1, result.length
+        assert_equal @activation_key.content_view_environments.first, result.first
+      end
+
+      def test_lookup_content_view_environments_raises_without_cvenvs
+        Setting['allow_multiple_content_views'] = false
+        empty_key = katello_activation_keys(:simple_key)
+        empty_key.stubs(:content_view_environments).returns([])
+        assert_raises(RuntimeError) do
+          ::Katello::RegistrationManager.send(:lookup_content_view_environments, [empty_key])
+        end
       end
 
       def test_registration_existing_host
@@ -284,7 +301,7 @@ module Katello
         ::Katello::RegistrationManager.expects(:create_in_candlepin)
         ::Katello::RegistrationManager.expects(:finalize_registration)
         Rails.logger.expects(:debug).with("Host #{@host.name} has been removed in preparation for reregistration")
-        Rails.logger.expects(:debug).with("ContentFacet: Marking CVEs changed for host #{@host.name}").times(1)
+        Rails.logger.expects(:debug).with("ContentFacet: Marking content view environments changed for host #{@host.name}").times(1)
         ::Katello::RegistrationManager.register_host(@host, rhsm_params, [@content_view_environment])
       end
 
@@ -364,7 +381,7 @@ module Katello
         pulp3_proxy = FactoryBot.create(:smart_proxy, :with_pulp3)
         @host.content_facet.update(:kickstart_repository_id => kickstart_repo.id, :content_source_id => pulp3_proxy.id)
 
-        original_cves = @host.content_facet.content_view_environments.dup
+        original_cvenvs = @host.content_facet.content_view_environments.dup
         original_ks_repo_id = @host.content_facet.kickstart_repository_id
         original_content_source = @host.content_facet.content_source
 
@@ -376,7 +393,7 @@ module Katello
         ::Katello::RegistrationManager.unregister_host(@host, unregistering: true)
 
         # Verify provisioning information is retained
-        assert_equal original_cves, @host.content_facet.content_view_environments
+        assert_equal original_cvenvs, @host.content_facet.content_view_environments
         assert_equal original_ks_repo_id, @host.content_facet.kickstart_repository_id
         assert_equal original_content_source, @host.content_facet.content_source
         # Verify other data is still cleared as expected
@@ -396,7 +413,7 @@ module Katello
         @host.content_facet.update(:kickstart_repository_id => kickstart_repo.id, :content_source_id => pulp3_proxy.id)
 
         # Store original values
-        original_cves = @host.content_facet.content_view_environments.dup
+        original_cvenvs = @host.content_facet.content_view_environments.dup
         original_ks_repo_id = @host.content_facet.kickstart_repository_id
         original_content_source = @host.content_facet.content_source
 
@@ -418,7 +435,7 @@ module Katello
 
         # Verify provisioning information is preserved despite setting being false
         # This verifies that preserve_for_provisioning: true overrides the setting during re-registration
-        assert_equal original_cves, @host.content_facet.content_view_environments
+        assert_equal original_cvenvs, @host.content_facet.content_view_environments
         assert_equal original_ks_repo_id, @host.content_facet.kickstart_repository_id
         assert_equal original_content_source, @host.content_facet.content_source
         # Verify other data is still cleared as expected during unregistration

--- a/test/services/product_content_finder_test.rb
+++ b/test/services/product_content_finder_test.rb
@@ -45,7 +45,7 @@ module Katello
       @key.update!(content_view_environments: cves)
 
       Katello::Repository.where(:root => Katello::RootRepository.where(:content_id => @repo1.content_id),
-                                :content_view_version_id => @key.content_view.version(@key.environment)).destroy_all
+                                :content_view_version_id => @key.single_content_view.version(@key.single_lifecycle_environment)).destroy_all
 
       pcf = Katello::ProductContentFinder.new(:consumable => @key, :match_environment => true)
       product_content = pcf.product_content

--- a/test/support/host_support.rb
+++ b/test/support/host_support.rb
@@ -4,7 +4,8 @@ module Support
   class HostSupport
     def self.attach_content_facet(host, view, environment)
       content_facet = Katello::Host::ContentFacet.new
-      content_facet.assign_single_environment(content_view: view, lifecycle_environment: environment)
+      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, environment.id)
+      content_facet.content_view_environments = [cve]
       host.content_facet = content_facet
       host.reload
     end

--- a/test/support/host_support.rb
+++ b/test/support/host_support.rb
@@ -4,8 +4,8 @@ module Support
   class HostSupport
     def self.attach_content_facet(host, view, environment)
       content_facet = Katello::Host::ContentFacet.new
-      cve = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, environment.id)
-      content_facet.content_view_environments = [cve]
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, environment.id)
+      content_facet.content_view_environments = [cvenv]
       host.content_facet = content_facet
       host.reload
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Related PR in foreman-ansible-modules: https://github.com/theforeman/foreman-ansible-modules/pull/1977
Follow-up: https://github.com/Katello/katello/pull/11771

Remove the deprecated separate `content_view_id` and `lifecycle_environment_id` API parameters from hosts, activation keys, and hostgroups, in favor of `content_view_environment_ids` (hosts/AKs) and `content_view_environment_id` (hostgroups).

Also removes `assign_single_environment` from both ContentFacet and ActivationKey, replacing it with `ContentViewEnvironment.find_by_cv_and_lce!` lookups. Removes the `check_cve_attributes` / `attributes=` / `update` overrides on HostManagedExtensions that handled the deprecated params. Updates the host ERB form to use a content view environment dropdown instead of separate LCE/CV cascading selects. Updates `content_facet_ignore_update?` to gate on `content_view_environment_ids` instead of the removed params.

#### Considerations taken when implementing this change?

The ERB host form, `ContentFacet.inherited_attributes`, and `ContentFacet#initialize` all used the deprecated params together. The hidden fields in the ERB form blocked `||=` in `inherited_attributes` from injecting hostgroup values. All three had to move to `content_view_environment_ids` together to avoid breaking host create/edit inheritance.

#### What are the testing steps for this pull request?

- [ ] Create a host with a hostgroup that has a content view environment set — verify the content view environment is inherited/pre-populated on the host form
- [ ] Edit an existing host — verify the content view environment is preserved and not overwritten
- [ ] Edit a multi-content-view-environment host — verify all content view environments are preserved
- [ ] Create/edit a hostgroup with a content view environment
- [ ] Create an activation key via API using `content_view_environment_ids`:
  ```
  curl -u admin:changeme -H 'Content-Type: application/json' \
    -X POST https://$(hostname)/katello/api/v2/activation_keys \
    -d '{"organization_id": 1, "name": "test-ak", "content_view_environment_ids": [<id>]}'
  ```
- [ ] Update an activation key via API using `content_view_environment_ids`:
  ```
  curl -u admin:changeme -H 'Content-Type: application/json' \
    -X PUT https://$(hostname)/katello/api/v2/activation_keys/<id> \
    -d '{"activation_key": {"content_view_environment_ids": [<id>]}}'
  ```
- [ ] Verify that the removed params (`content_view_id`, `lifecycle_environment_id`) are no longer accepted on host/AK/hostgroup create/update APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified "Content View Environment" selector for hosts and hostgroups; preserves "Inherit" and restores prior selection.
  * UI selections for content view environment, content source, architecture and OS now consistently update available installation media.

* **Bug Fixes**
  * Improved dropdown refresh and organization resolution when changing content source or install medium; synced-content resets reliably.

* **Breaking Changes**
  * APIs and forms now use content_view_environment_id(s); legacy single content_view/lifecycle/environment params removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11753?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->