### PR TITLE
Replace RestClient with Faraday 2.x for persistent Candlepin connections

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -45,7 +45,7 @@ module Katello
       end
     end
 
-    rescue_from HttpResource::RestClientException do |e|
+    rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
       if request_from_katello_cli?
         render json: { errors: [e.message] }, status: e.code

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -46,7 +46,16 @@ module Katello
     end
 
     rescue_from HttpResource::HttpError do |e|
-      Rails.logger.error(pp_exception(e, with_backtrace: false))
+      if e.code.to_i == 404
+        parsed = JSON.parse(e.response_body.to_s) rescue {}
+        if parsed["errors"]&.any? { |error| error["code"] == "BLOB_UNKNOWN" }
+          Rails.logger.info(pp_exception(e, with_backtrace: false))
+        else
+          Rails.logger.error(pp_exception(e, with_backtrace: false))
+        end
+      else
+        Rails.logger.error(pp_exception(e, with_backtrace: false))
+      end
       body = e.response_body.presence || e.message
       if request_from_katello_cli?
         render json: { errors: [body] }, status: e.code

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -47,10 +47,11 @@ module Katello
 
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
+      body = e.response_body || e.message
       if request_from_katello_cli?
-        render json: { errors: [e.message] }, status: e.code
+        render json: { errors: [body] }, status: e.code
       else
-        render plain: e.message, status: e.code
+        render plain: body, status: e.code
       end
     end
 

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -47,7 +47,7 @@ module Katello
 
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
-      body = e.response_body || e.message
+      body = e.response_body.presence || e.message
       if request_from_katello_cli?
         render json: { errors: [body] }, status: e.code
       else

--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -45,6 +45,15 @@ module Katello
       end
     end
 
+    rescue_from HttpResource::RestClientException do |e|
+      Rails.logger.error(pp_exception(e, with_backtrace: false))
+      if request_from_katello_cli?
+        render json: { errors: [e.message] }, status: e.code
+      else
+        render plain: e.message, status: e.code
+      end
+    end
+
     def authenticate_cert_request
       if cert_present?
         client_cert = ::Cert::RhsmClient.new(cert_from_request)

--- a/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
@@ -61,6 +61,15 @@ module Katello
       end
     end
 
+    rescue_from HttpResource::RestClientException do |e|
+      Rails.logger.error(pp_exception(e, with_backtrace: false))
+      if request_from_katello_cli?
+        render :json => { :errors => [e.message] }, :status => e.code
+      else
+        render :plain => e.message, :status => e.code
+      end
+    end
+
     def authorize_client_or_user
       client_authorized? || authorize
     end

--- a/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
@@ -51,16 +51,6 @@ module Katello
       @host = facet.host
     end
 
-    rescue_from RestClient::Exception do |e|
-      Rails.logger.error(pp_exception(e, with_backtrace: false))
-      Rails.logger.error(e.backtrace.detect { |line| line.match("katello.*controller") })
-      if request_from_katello_cli?
-        render :json => { :errors => [e.http_body] }, :status => e.http_code
-      else
-        render :plain => e.http_body, :status => e.http_code
-      end
-    end
-
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
       body = e.response_body || e.message

--- a/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
@@ -44,7 +44,7 @@ module Katello
       uuid ||= params[:id]
       facet = Katello::Host::SubscriptionFacet.where(:uuid => uuid).first
       if facet.nil?
-        # check with candlepin if consumer is Gone, raises RestClient::Gone
+        # check with candlepin if consumer is Gone, raises HttpError
         User.as_anonymous_admin { Resources::Candlepin::Consumer.get(uuid) }
         fail HttpErrors::NotFound, _("Couldn't find consumer '%s'") % uuid
       end
@@ -63,10 +63,11 @@ module Katello
 
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
+      body = e.response_body || e.message
       if request_from_katello_cli?
-        render :json => { :errors => [e.message] }, :status => e.code
+        render :json => { :errors => [body] }, :status => e.code
       else
-        render :plain => e.message, :status => e.code
+        render :plain => body, :status => e.code
       end
     end
 

--- a/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
@@ -61,7 +61,7 @@ module Katello
       end
     end
 
-    rescue_from HttpResource::RestClientException do |e|
+    rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
       if request_from_katello_cli?
         render :json => { :errors => [e.message] }, :status => e.code

--- a/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_dynflow_proxy_controller.rb
@@ -53,7 +53,7 @@ module Katello
 
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
-      body = e.response_body || e.message
+      body = e.response_body.presence || e.message
       if request_from_katello_cli?
         render :json => { :errors => [body] }, :status => e.code
       else

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -64,6 +64,15 @@ module Katello
       end
     end
 
+    rescue_from HttpResource::RestClientException do |e|
+      Rails.logger.error(pp_exception(e, with_backtrace: false))
+      if request_from_katello_cli?
+        render :json => { :errors => [e.message] }, :status => e.code
+      else
+        render :plain => e.message, :status => e.code
+      end
+    end
+
     def proxy_request_path
       @request_path = drop_api_namespace(@_request.fullpath)
     end

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -56,7 +56,6 @@ module Katello
 
     rescue_from RestClient::Exception do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
-      Rails.logger.error(e.backtrace.detect { |line| line.match("katello.*controller") })
       if request_from_katello_cli?
         render :json => { :errors => [e.http_body] }, :status => e.http_code
       else
@@ -66,10 +65,11 @@ module Katello
 
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
+      body = e.response_body || e.message
       if request_from_katello_cli?
-        render :json => { :errors => [e.message] }, :status => e.code
+        render :json => { :errors => [body] }, :status => e.code
       else
-        render :plain => e.message, :status => e.code
+        render :plain => body, :status => e.code
       end
     end
 
@@ -330,7 +330,7 @@ module Katello
       uuid ||= params[:id]
       facet = Katello::Host::SubscriptionFacet.where(:uuid => uuid).first
       if facet.nil?
-        # check with candlepin if consumer is Gone, raises RestClient::Gone
+        # check with candlepin if consumer is Gone, raises HttpError
         User.as_anonymous_admin { Resources::Candlepin::Consumer.get(uuid) }
       end
       @host = ::Host::Managed.unscoped.find(facet.host_id)

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -64,7 +64,7 @@ module Katello
       end
     end
 
-    rescue_from HttpResource::RestClientException do |e|
+    rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
       if request_from_katello_cli?
         render :json => { :errors => [e.message] }, :status => e.code

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -65,7 +65,7 @@ module Katello
 
     rescue_from HttpResource::HttpError do |e|
       Rails.logger.error(pp_exception(e, with_backtrace: false))
-      body = e.response_body || e.message
+      body = e.response_body.presence || e.message
       if request_from_katello_cli?
         render :json => { :errors => [body] }, :status => e.code
       else

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -85,26 +85,26 @@ module Katello
       end
 
       r = Resources::Candlepin::Proxy.get(@request_path, extra_headers)
-      logger.debug filter_sensitive_data(r)
-      render :json => r, :status => r.code
+      logger.debug filter_sensitive_data(r.body)
+      render :json => r.body, :status => r.status
     end
 
     def delete
       r = Resources::Candlepin::Proxy.delete(@request_path, @request_body.read)
-      logger.debug filter_sensitive_data(r)
-      render :json => r
+      logger.debug filter_sensitive_data(r.body)
+      render :json => r.body, :status => r.status
     end
 
     def post
       r = Resources::Candlepin::Proxy.post(@request_path, @request_body.read)
-      logger.debug filter_sensitive_data(r)
-      render :json => r
+      logger.debug filter_sensitive_data(r.body)
+      render :json => r.body, :status => r.status
     end
 
     def put
       r = Resources::Candlepin::Proxy.put(@request_path, @request_body.read)
-      logger.debug filter_sensitive_data(r)
-      render :json => r
+      logger.debug filter_sensitive_data(r.body)
+      render :json => r.body, :status => r.status
     end
 
     #api :GET, "/consumers/:id", N_("Show a system")

--- a/app/lib/actions/candlepin/consumer/clean_backend_objects.rb
+++ b/app/lib/actions/candlepin/consumer/clean_backend_objects.rb
@@ -66,8 +66,9 @@ module Actions
 
               unregister_options = host_unregister_options(host)
               ::Katello::RegistrationManager.unregister_host(host, unregister_options)
-            rescue RestClient::ResourceNotFound
+            rescue HttpResource::RestClientException => e
               # Ignore if already gone
+              raise unless e.code == '404'
             rescue => e
               output[:results][:errors] << {
                 type: 'unregister_host',
@@ -94,8 +95,9 @@ module Actions
 
               unregister_options = host_unregister_options(host)
               ::Katello::RegistrationManager.unregister_host(host, unregister_options)
-            rescue RestClient::ResourceNotFound
+            rescue HttpResource::RestClientException => e
               # Ignore if already gone
+              raise unless e.code == '404'
             rescue => e
               output[:results][:errors] << {
                 type: 'unregister_host',
@@ -117,8 +119,9 @@ module Actions
               }
 
               ::Katello::Resources::Candlepin::Consumer.destroy(consumer_uuid)
-            rescue RestClient::ResourceNotFound
+            rescue HttpResource::RestClientException => e
               # Ignore if already gone
+              raise unless e.code == '404'
             rescue => e
               output[:results][:errors] << {
                 type: 'destroy_consumer',

--- a/app/lib/actions/candlepin/consumer/clean_backend_objects.rb
+++ b/app/lib/actions/candlepin/consumer/clean_backend_objects.rb
@@ -66,7 +66,7 @@ module Actions
 
               unregister_options = host_unregister_options(host)
               ::Katello::RegistrationManager.unregister_host(host, unregister_options)
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               # Ignore if already gone
               raise unless e.code == '404'
             rescue => e
@@ -95,7 +95,7 @@ module Actions
 
               unregister_options = host_unregister_options(host)
               ::Katello::RegistrationManager.unregister_host(host, unregister_options)
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               # Ignore if already gone
               raise unless e.code == '404'
             rescue => e
@@ -119,7 +119,7 @@ module Actions
               }
 
               ::Katello::Resources::Candlepin::Consumer.destroy(consumer_uuid)
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               # Ignore if already gone
               raise unless e.code == '404'
             rescue => e

--- a/app/lib/actions/candlepin/consumer/clean_backend_objects.rb
+++ b/app/lib/actions/candlepin/consumer/clean_backend_objects.rb
@@ -19,18 +19,20 @@ module Actions
             # Set bulk load size for Candlepin operations
             original_candlepin_page_size = SETTINGS[:katello][:candlepin][:bulk_load_size]
             SETTINGS[:katello][:candlepin][:bulk_load_size] = 125
+            begin
+              # Gather data from Candlepin and Katello
+              candlepin_uuids = fetch_candlepin_uuids
+              katello_candlepin_uuids = fetch_katello_candlepin_uuids
 
-            # Gather data from Candlepin and Katello
-            candlepin_uuids = fetch_candlepin_uuids
-            katello_candlepin_uuids = fetch_katello_candlepin_uuids
+              # Find hosts with issues
+              cleanup_hosts_with_nil_facets
+              cleanup_hosts_with_no_subscriptions(candlepin_uuids)
 
-            # Find hosts with issues
-            cleanup_hosts_with_nil_facets
-            cleanup_hosts_with_no_subscriptions(candlepin_uuids)
-
-            # Clean up orphaned Candlepin consumers
-            cleanup_candlepin_orphans(candlepin_uuids, katello_candlepin_uuids)
-            SETTINGS[:katello][:candlepin][:bulk_load_size] = original_candlepin_page_size
+              # Clean up orphaned Candlepin consumers
+              cleanup_candlepin_orphans(candlepin_uuids, katello_candlepin_uuids)
+            ensure
+              SETTINGS[:katello][:candlepin][:bulk_load_size] = original_candlepin_page_size
+            end
           end
         end
 

--- a/app/lib/actions/candlepin/environment/add_content_to_environment.rb
+++ b/app/lib/actions/candlepin/environment/add_content_to_environment.rb
@@ -9,7 +9,8 @@ module Actions
 
         def run
           output[:add_response] = ::Katello::Resources::Candlepin::Environment.add_content(input[:view_env_cp_id], [input[:content_id]])
-        rescue RestClient::Conflict
+        rescue HttpResource::RestClientException => e
+          raise unless e.code == '409'
           Rails.logger.info("attempted to add content ID #{input[:content_id]} to environment, but content ID already exists.")
         end
       end

--- a/app/lib/actions/candlepin/environment/add_content_to_environment.rb
+++ b/app/lib/actions/candlepin/environment/add_content_to_environment.rb
@@ -9,7 +9,7 @@ module Actions
 
         def run
           output[:add_response] = ::Katello::Resources::Candlepin::Environment.add_content(input[:view_env_cp_id], [input[:content_id]])
-        rescue HttpResource::RestClientException => e
+        rescue HttpResource::HttpError => e
           raise unless e.code == '409'
           Rails.logger.info("attempted to add content ID #{input[:content_id]} to environment, but content ID already exists.")
         end

--- a/app/lib/actions/candlepin/environment/set_content.rb
+++ b/app/lib/actions/candlepin/environment/set_content.rb
@@ -31,12 +31,13 @@ module Actions
               output[:add_response] = ::Katello::Resources::Candlepin::Environment.add_content(input[:cp_environment_id], output[:add_ids])
               break
             rescue HttpResource::HttpError => e
-              if e.code == '409'
+              case e.code
+              when '409'
                 # Candlepin raises a 409 in case it gets a duplicate content id add to an environment.
                 # Refresh the existing ids list and try again.
                 raise e if ((retries += 1) == max_retries)
                 output[:add_ids] = content_ids - existing_ids
-              elsif e.code == '404'
+              when '404'
                 # Set a higher limit for retries just in case the missing content is not being parsed correctly.
                 # If the content is not found after the retries, assume it is gone and continue.
                 raise e if ((retries += 1) == 1_000)

--- a/app/lib/actions/candlepin/environment/set_content.rb
+++ b/app/lib/actions/candlepin/environment/set_content.rb
@@ -30,20 +30,22 @@ module Actions
             begin
               output[:add_response] = ::Katello::Resources::Candlepin::Environment.add_content(input[:cp_environment_id], output[:add_ids])
               break
-            rescue RestClient::Conflict => e
-              raise e if ((retries += 1) == max_retries)
-              # Candlepin raises a 409 in case it gets a duplicate content id add to an environment
-              # Since its a dup id refresh the existing ids list (which hopefully will not have the duplicate content)
-              # and try again.
-              output[:add_ids] = content_ids - existing_ids
-            rescue RestClient::ResourceNotFound, RestClient::NotFound => e
-              # Set a higher limit for retries just in case the missing content is not being parsed from the error body correctly.
-              # If the content is not found after the retries, assume it is gone and continue.
-              raise e if ((retries += 1) == 1_000)
-              # Parse the missing content from the Candlepin response and remove it from the add_ids list.
-              missing_content = JSON.parse(e.response.body)['displayMessage'].split(' ')[-1].gsub(/[".]/, '')
-              Rails.logger.debug "Content #{missing_content} not found in the environment. Removing it from the add_ids list."
-              output[:add_ids].delete(missing_content)
+            rescue HttpResource::RestClientException => e
+              if e.code == '409'
+                # Candlepin raises a 409 in case it gets a duplicate content id add to an environment.
+                # Refresh the existing ids list and try again.
+                raise e if ((retries += 1) == max_retries)
+                output[:add_ids] = content_ids - existing_ids
+              elsif e.code == '404'
+                # Set a higher limit for retries just in case the missing content is not being parsed correctly.
+                # If the content is not found after the retries, assume it is gone and continue.
+                raise e if ((retries += 1) == 1_000)
+                missing_content = e.message.split(' ')[-1].gsub(/[".]/, '')
+                Rails.logger.debug "Content #{missing_content} not found in the environment. Removing it from the add_ids list."
+                output[:add_ids].delete(missing_content)
+              else
+                raise
+              end
             end
           end
           retries = 0
@@ -51,12 +53,12 @@ module Actions
             begin
               output[:delete_response] = ::Katello::Resources::Candlepin::Environment.delete_content(input[:cp_environment_id], output[:delete_ids])
               break
-            rescue RestClient::ResourceNotFound
-              # If the content is not found after the retries, assume it is gone and continue.
-              break if ((retries += 1) == max_retries)
+            rescue HttpResource::RestClientException => e
+              raise unless e.code == '404'
               # Candlepin raises a 404 in case a content id is not found in this environment
               # If thats the case lets just refresh the existing ids list (which hopefully will not have the 404'd content)
               # and try again.
+              break if ((retries += 1) == max_retries)
               output[:delete_ids] = existing_ids - content_ids
             end
           end

--- a/app/lib/actions/candlepin/environment/set_content.rb
+++ b/app/lib/actions/candlepin/environment/set_content.rb
@@ -30,7 +30,7 @@ module Actions
             begin
               output[:add_response] = ::Katello::Resources::Candlepin::Environment.add_content(input[:cp_environment_id], output[:add_ids])
               break
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               if e.code == '409'
                 # Candlepin raises a 409 in case it gets a duplicate content id add to an environment.
                 # Refresh the existing ids list and try again.
@@ -53,7 +53,7 @@ module Actions
             begin
               output[:delete_response] = ::Katello::Resources::Candlepin::Environment.delete_content(input[:cp_environment_id], output[:delete_ids])
               break
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               raise unless e.code == '404'
               # Candlepin raises a 404 in case a content id is not found in this environment
               # If thats the case lets just refresh the existing ids list (which hopefully will not have the 404'd content)

--- a/app/lib/actions/katello/organization/manifest_delete.rb
+++ b/app/lib/actions/katello/organization/manifest_delete.rb
@@ -44,6 +44,7 @@ module Actions
 
         def finalize
           subject_organization.audit_manifest_action(_('Manifest deleted'))
+          ::Katello::Resources::Candlepin::UpstreamCandlepinResource.reset_connection!
         end
       end
     end

--- a/app/lib/actions/katello/organization/manifest_import.rb
+++ b/app/lib/actions/katello/organization/manifest_import.rb
@@ -58,6 +58,7 @@ module Actions
         def finalize
           subject_organization.clear_manifest_expired_notifications
           subject_organization.audit_manifest_action(_('Manifest imported'))
+          ::Katello::Resources::Candlepin::UpstreamCandlepinResource.reset_connection!
         end
       end
     end

--- a/app/lib/actions/katello/organization/manifest_refresh.rb
+++ b/app/lib/actions/katello/organization/manifest_refresh.rb
@@ -98,6 +98,7 @@ module Actions
           org = ::Organization.find(input[:organization_id])
           org.clear_manifest_expired_notifications
           subject_organization.audit_manifest_action(_('Manifest refreshed'))
+          ::Katello::Resources::Candlepin::UpstreamCandlepinResource.reset_connection!
         end
       end
     end

--- a/app/lib/actions/middleware/propagate_candlepin_errors.rb
+++ b/app/lib/actions/middleware/propagate_candlepin_errors.rb
@@ -17,7 +17,7 @@ module Actions
 
       def propagate_candlepin_errors
         yield
-      rescue HttpResource::RestClientException => e
+      rescue HttpResource::HttpError => e
         raise(::Katello::Errors::CandlepinError.new(e.message) || e)
       end
     end

--- a/app/lib/actions/middleware/propagate_candlepin_errors.rb
+++ b/app/lib/actions/middleware/propagate_candlepin_errors.rb
@@ -17,6 +17,8 @@ module Actions
 
       def propagate_candlepin_errors
         yield
+      rescue ::Katello::Errors::CandlepinError
+        raise
       rescue HttpResource::HttpError => e
         display_message = e.message
         if e.response_body.present?

--- a/app/lib/actions/middleware/propagate_candlepin_errors.rb
+++ b/app/lib/actions/middleware/propagate_candlepin_errors.rb
@@ -17,13 +17,8 @@ module Actions
 
       def propagate_candlepin_errors
         yield
-      rescue RestClient::ExceptionWithResponse => e
-        error_class = if e.response.request.url.include?('/candlepin')
-                        ::Katello::Errors::CandlepinError
-                      else
-                        ::Katello::Errors::UpstreamCandlepinError
-                      end
-        raise(error_class.from_exception(e) || e)
+      rescue HttpResource::RestClientException => e
+        raise(::Katello::Errors::CandlepinError.new(e.message) || e)
       end
     end
   end

--- a/app/lib/actions/middleware/propagate_candlepin_errors.rb
+++ b/app/lib/actions/middleware/propagate_candlepin_errors.rb
@@ -18,7 +18,12 @@ module Actions
       def propagate_candlepin_errors
         yield
       rescue HttpResource::HttpError => e
-        raise(::Katello::Errors::CandlepinError.new(e.message) || e)
+        display_message = e.message
+        if e.response_body.present?
+          parsed = JSON.parse(e.response_body) rescue {}
+          display_message = parsed['displayMessage'] || display_message
+        end
+        raise ::Katello::Errors::CandlepinError, display_message
       end
     end
   end

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -10,7 +10,7 @@ module Katello
           rescue_from HttpErrors::WrappedError, :with => :rescue_from_wrapped_error
 
           rescue_from RestClient::ExceptionWithResponse, :with => :rescue_from_exception_with_response
-          rescue_from HttpResource::RestClientException, :with => :rescue_from_exception_with_response
+          rescue_from HttpResource::HttpError, :with => :rescue_from_exception_with_response
           rescue_from ActiveRecord::RecordInvalid, :with => :rescue_from_record_invalid
           rescue_from ActiveRecord::RecordNotFound, :with => :rescue_from_record_not_found
 

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -58,11 +58,12 @@ module Katello
 
         def rescue_from_exception_with_response(exception)
           logger.error "exception when talking to a remote client: #{exception.message} " << pp_exception(exception)
+          code = exception.respond_to?(:code) ? exception.code.to_i : 0
+          status = (code > 0) ? code : :bad_request
           if request_from_katello_cli?
-            # TODO: why not use http_code from the exception???
-            render :json => format_subsys_exception_hash(exception), :status => :bad_request
+            render :json => format_subsys_exception_hash(exception), :status => status
           else
-            respond_for_exception(exception, :status => :bad_request)
+            respond_for_exception(exception, :status => status)
           end
         end
 
@@ -150,16 +151,26 @@ module Katello
           message = ""
           message << "#{exception.class}: " if options[:with_class]
           message << "#{exception.message}\n"
-          message << "Body: #{exception.http_body}\n" if options[:with_body] && exception.respond_to?(:http_body)
+          body = if exception.respond_to?(:http_body)
+                   exception.http_body
+                 elsif exception.respond_to?(:response_body)
+                   exception.response_body
+                 end
+          message << "Body: #{body}\n" if options[:with_body] && body
           message << exception.backtrace.join("\n") if options[:with_backtrace]
           message
         end
 
         def format_subsys_exception_hash(exception)
-          orig_hash = JSON.parse(exception.response).with_indifferent_access rescue {}
+          raw_body = if exception.respond_to?(:response)
+                       exception.response
+                     elsif exception.respond_to?(:response_body)
+                       exception.response_body
+                     end
+          orig_hash = JSON.parse(raw_body).with_indifferent_access rescue {}
 
           orig_hash[:message] = orig_hash.delete(:displayMessage) || orig_hash[:message]
-          orig_hash[:message] = exception.response.to_s.gsub(/^"|"$/, "") if orig_hash[:message].nil? && exception.respond_to?(:response)
+          orig_hash[:message] = raw_body.to_s.gsub(/^"|"$/, "") if orig_hash[:message].nil? && raw_body
           orig_hash[:message] = exception.message if orig_hash[:message].blank?
           orig_hash[:errors] = [orig_hash[:message]] if orig_hash[:errors].nil?
           orig_hash

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -10,6 +10,7 @@ module Katello
           rescue_from HttpErrors::WrappedError, :with => :rescue_from_wrapped_error
 
           rescue_from RestClient::ExceptionWithResponse, :with => :rescue_from_exception_with_response
+          rescue_from HttpResource::RestClientException, :with => :rescue_from_exception_with_response
           rescue_from ActiveRecord::RecordInvalid, :with => :rescue_from_record_invalid
           rescue_from ActiveRecord::RecordNotFound, :with => :rescue_from_record_not_found
 

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -59,7 +59,7 @@ module Katello
         def rescue_from_exception_with_response(exception)
           logger.error "exception when talking to a remote client: #{exception.message} " << pp_exception(exception)
           code = exception.respond_to?(:code) ? exception.code.to_i : 0
-          status = code > 0 ? code : :bad_request
+          status = (code > 0) ? code : :bad_request
           if request_from_katello_cli?
             render :json => format_subsys_exception_hash(exception), :status => status
           else

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -59,7 +59,7 @@ module Katello
         def rescue_from_exception_with_response(exception)
           logger.error "exception when talking to a remote client: #{exception.message} " << pp_exception(exception)
           code = exception.respond_to?(:code) ? exception.code.to_i : 0
-          status = (code > 0) ? code : :bad_request
+          status = code > 0 ? code : :bad_request
           if request_from_katello_cli?
             render :json => format_subsys_exception_hash(exception), :status => status
           else

--- a/app/lib/katello/concerns/oauth_request_signing.rb
+++ b/app/lib/katello/concerns/oauth_request_signing.rb
@@ -28,7 +28,7 @@ module Katello
             :request_token_path => "",
             :authorize_path => "",
             :access_token_path => "",
-            :ca_file => self.ssl_ca_file
+            :ca_file => self.ssl_ca_file,
           )
         end
 

--- a/app/lib/katello/concerns/oauth_request_signing.rb
+++ b/app/lib/katello/concerns/oauth_request_signing.rb
@@ -10,12 +10,12 @@ module Katello
         post: Net::HTTP::Post,
         put: Net::HTTP::Put,
         patch: Net::HTTP::Patch,
-        delete: Net::HTTP::Delete
-      }
+        delete: Net::HTTP::Delete,
+      }.freeze
 
       class_methods do
         def sign_request(req, url, method)
-          raise "#{name}: OAuth consumer_key and consumer_secret required" unless self.consumer_key && self.consumer_secret
+          fail "#{name}: OAuth consumer_key and consumer_secret required" unless self.consumer_key && self.consumer_secret
           req.headers['Authorization'] = build_oauth_header(url, method)
         end
 

--- a/app/lib/katello/concerns/oauth_request_signing.rb
+++ b/app/lib/katello/concerns/oauth_request_signing.rb
@@ -1,0 +1,43 @@
+require 'oauth'
+
+module Katello
+  module Concerns
+    module OauthRequestSigning
+      extend ActiveSupport::Concern
+
+      HTTP_CLASSES = {
+        get: Net::HTTP::Get,
+        post: Net::HTTP::Post,
+        put: Net::HTTP::Put,
+        patch: Net::HTTP::Patch,
+        delete: Net::HTTP::Delete
+      }
+
+      class_methods do
+        def sign_request(req, url, method)
+          raise "#{name}: OAuth consumer_key and consumer_secret required" unless self.consumer_key && self.consumer_secret
+          req.headers['Authorization'] = build_oauth_header(url, method)
+        end
+
+        private
+
+        def oauth_consumer
+          @oauth_consumer ||= OAuth::Consumer.new(
+            self.consumer_key, self.consumer_secret,
+            :site => self.site,
+            :request_token_path => "",
+            :authorize_path => "",
+            :access_token_path => "",
+            :ca_file => self.ssl_ca_file
+          )
+        end
+
+        def build_oauth_header(url, method)
+          request = HTTP_CLASSES.fetch(method).new(url)
+          oauth_consumer.sign!(request)
+          request['Authorization']
+        end
+      end
+    end
+  end
+end

--- a/app/lib/katello/concerns/oauth_request_signing.rb
+++ b/app/lib/katello/concerns/oauth_request_signing.rb
@@ -15,7 +15,7 @@ module Katello
 
       class_methods do
         def sign_request(req, url, method)
-          fail "#{name}: OAuth consumer_key and consumer_secret required" unless self.consumer_key && self.consumer_secret
+          fail "#{name}: OAuth consumer_key and consumer_secret required" if self.consumer_key.blank? || self.consumer_secret.blank?
           req.headers['Authorization'] = build_oauth_header(url, method)
         end
 
@@ -28,7 +28,7 @@ module Katello
             :request_token_path => "",
             :authorize_path => "",
             :access_token_path => "",
-            :ca_file => self.ssl_ca_file,
+            :ca_file => self.ssl_ca_file
           )
         end
 

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -37,14 +37,15 @@ module Katello
     end
 
     class << self
-      [:get, :post, :put, :patch, :delete].each do |method|
-        define_method(method) do |*args|
-          issue_request(
-            method: method,
-            path: args.first,
-            headers: args.length > 1 ? args.last : nil,
-            payload: args.length > 2 ? args[1] : nil
-          )
+      [:get, :delete].each do |method|
+        define_method(method) do |path, headers: nil, params: nil|
+          issue_request(method: method, path: path, headers: headers, params: params)
+        end
+      end
+
+      [:post, :put, :patch].each do |method|
+        define_method(method) do |path, payload = nil, headers: nil, params: nil|
+          issue_request(method: method, path: path, headers: headers, payload: payload, params: params)
         end
       end
 

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -80,7 +80,7 @@ module Katello
         (headers || {}).transform_keys(&:to_s).transform_values(&:to_s)
       end
 
-      def issue_request(method:, path:, headers: {}, payload: nil, params: nil)
+      def issue_request(method:, path:, headers: {}, payload: nil, params: nil, process: true)
         path = "#{path}#{query_string(params)}" if params
         headers = stringify_headers(headers)
         logger.debug("Resource #{method.upcase} request: #{path}")
@@ -98,7 +98,7 @@ module Katello
           req.body = payload if payload
         end
 
-        process_response(response)
+        process ? process_response(response) : response
       rescue Faraday::ConnectionFailed
         service = path.split("/").second
         raise Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -67,12 +67,8 @@ module Katello
           service_code = parsed["code"] if parsed["code"]
         rescue => error
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
-          if %w(404 500 502 503 504).member? resp.status.to_s
-            logger.error "Remote server status code " << resp.status.to_s
-            fail HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
-          else
-            fail NetworkException, [resp.status.to_s, resp.body].reject { |s| s.blank? }.join(' ')
-          end
+          logger.error "Remote server status code " << resp.status.to_s
+          fail HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
         end
         fail HttpError, {:message => message, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
       end

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -84,15 +84,15 @@ module Katello
       def issue_request(method:, path:, headers: {}, payload: nil, params: nil, process: true, connection: nil)
         path = "#{path}#{query_string(params)}" if params
         headers = stringify_headers(headers)
-        logger.debug("Resource #{method.upcase} request: #{path}")
+        conn = connection || faraday_connection
+        url = connection ? "#{conn.url_prefix}#{path}" : path
+        logger.debug("Resource #{method.upcase} request: #{url}")
         logger.debug "Headers: #{headers.to_json}"
         begin
           logger.debug "Body: #{filter_sensitive_data(payload.to_json)}"
         rescue JSON::GeneratorError, Encoding::UndefinedConversionError
           logger.debug "Body: Error: could not render payload as json"
         end
-
-        conn = connection || faraday_connection
         response = conn.send(method, path) do |req|
           sign_request(req, self.site + path, method)
           req.headers.merge!(headers) if headers

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -93,8 +93,9 @@ module Katello
         rescue JSON::GeneratorError, Encoding::UndefinedConversionError
           logger.debug "Body: Error: could not render payload as json"
         end
+        sign_url = connection ? "#{conn.url_prefix}#{path}" : self.site + path
         response = conn.send(method, path) do |req|
-          sign_request(req, self.site + path, method)
+          sign_request(req, sign_url, method)
           req.headers.merge!(headers) if headers
           req.body = payload if payload
         end

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -68,9 +68,9 @@ module Katello
         rescue => error
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
           logger.error "Remote server status code " << resp.status.to_s
-          raise HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
+          raise_http_error(message: resp.body.presence || error.to_s, status_code: status_code, response_body: resp.body, service_code: service_code)
         end
-        fail HttpError, {:message => message, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
+        raise_http_error(message: message, status_code: status_code, response_body: resp.body, service_code: service_code)
       end
 
       def stringify_headers(headers)
@@ -101,7 +101,25 @@ module Katello
 
       def raise_faraday_exception(e, a_path, http_method)
         msg = "#{name}: #{e.message} (#{http_method} #{a_path})"
-        fail HttpError, { message: msg, service_code: '', code: e.response&.dig(:status).to_s, response_body: e.response&.dig(:body) }
+        status_code = e.response&.dig(:status)
+        if status_code.present?
+          raise_http_error(message: msg, status_code: status_code.to_s, response_body: e.response&.dig(:body))
+        else
+          raise_network_error(msg)
+        end
+      end
+
+      def raise_http_error(message:, status_code:, response_body:, service_code: '')
+        fail HttpError, {
+          message: message,
+          service_code: service_code,
+          code: status_code,
+          response_body: response_body,
+        }
+      end
+
+      def raise_network_error(message)
+        fail NetworkException, message
       end
 
       def join_path(*args)

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -69,9 +69,9 @@ module Katello
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
           if %w(404 500 502 503 504).member? resp.status.to_s
             logger.error "Remote server status code " << resp.status.to_s
-            raise HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
+            fail HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
           else
-            raise NetworkException, [resp.status.to_s, resp.body].reject { |s| s.blank? }.join(' ')
+            fail NetworkException, [resp.status.to_s, resp.body].reject { |s| s.blank? }.join(' ')
           end
         end
         fail HttpError, {:message => message, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
@@ -98,14 +98,14 @@ module Katello
         process ? process_response(response) : response
       rescue Faraday::ConnectionFailed
         service = path.split("/").second
-        raise Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
+        fail Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
       rescue Faraday::Error => e
         raise_faraday_exception e, path, method.upcase
       end
 
       def raise_faraday_exception(e, a_path, http_method)
         msg = "#{name}: #{e.message} (#{http_method} #{a_path})"
-        raise HttpError, { message: msg, service_code: '', code: e.response&.dig(:status).to_s, response_body: e.response&.dig(:body) }
+        fail HttpError, { message: msg, service_code: '', code: e.response&.dig(:status).to_s, response_body: e.response&.dig(:body) }
       end
 
       def join_path(*args)

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -1,5 +1,6 @@
-require 'oauth'
 require 'cgi'
+require 'faraday'
+require 'faraday/net_http_persistent'
 
 module Katello
   class HttpResource
@@ -35,22 +36,14 @@ module Katello
       @json[key] = value
     end
 
-    REQUEST_MAP = {
-      get: Net::HTTP::Get,
-      post: Net::HTTP::Post,
-      put: Net::HTTP::Put,
-      patch: Net::HTTP::Patch,
-      delete: Net::HTTP::Delete,
-    }.freeze
-
     class << self
-      REQUEST_MAP.keys.each do |key|
-        define_method(key) do |*args|
+      [:get, :post, :put, :patch, :delete].each do |method|
+        define_method(method) do |*args|
           issue_request(
-            method: key,
+            method: method,
             path: args.first,
             headers: args.length > 1 ? args.last : nil,
-            payload: args.length > 2 ? args[1] : nil # non-GET method signatures use payload as the second argument, keeping headers as the last element
+            payload: args.length > 2 ? args[1] : nil
           )
         end
       end
@@ -60,30 +53,35 @@ module Katello
       end
 
       def process_response(resp)
-        logger.debug "Processing response: #{resp.code}"
+        logger.debug "Processing response: #{resp.status}"
         logger.debug filter_sensitive_data(resp.body)
-        return resp unless resp.code.to_i >= 400
+        return resp unless resp.status >= 400
         parsed = {}
         message = "Rest exception while processing the call"
         service_code = ""
-        status_code = resp.code.to_s
+        status_code = resp.status.to_s
         begin
           parsed = JSON.parse resp.body
           message = parsed["displayMessage"] if parsed["displayMessage"]
           service_code = parsed["code"] if parsed["code"]
         rescue => error
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
-          if %w(404 500 502 503 504).member? resp.code.to_s
-            logger.error "Remote server status code " << resp.code.to_s
+          if %w(404 500 502 503 504).member? resp.status.to_s
+            logger.error "Remote server status code " << resp.status.to_s
             raise RestClientException, {:message => error.to_s, :service_code => service_code, :code => status_code}, caller
           else
-            raise NetworkException, [resp.code.to_s, resp.body].reject { |s| s.blank? }.join(' ')
+            raise NetworkException, [resp.status.to_s, resp.body].reject { |s| s.blank? }.join(' ')
           end
         end
         fail RestClientException, {:message => message, :service_code => service_code, :code => status_code}, caller
       end
 
+      def stringify_headers(headers)
+        (headers || {}).transform_keys(&:to_s).transform_values(&:to_s)
+      end
+
       def issue_request(method:, path:, headers: {}, payload: nil)
+        headers = stringify_headers(headers)
         logger.debug("Resource #{method.upcase} request: #{path}")
         logger.debug "Headers: #{headers.to_json}"
         begin
@@ -92,22 +90,24 @@ module Katello
           logger.debug "Body: Error: could not render payload as json"
         end
 
-        client = rest_client(REQUEST_MAP[method], method, path)
-        args = [method, payload, headers].compact
+        conn = faraday_connection
+        response = conn.send(method, path) do |req|
+          sign_request(req, self.site + path, method)
+          req.headers.merge!(headers) if headers
+          req.body = payload if payload
+        end
 
-        process_response(client.send(*args))
-      rescue RestClient::Exception => e
-        raise_rest_client_exception e, path, method.upcase
-      rescue Errno::ECONNREFUSED
+        process_response(response)
+      rescue Faraday::ConnectionFailed
         service = path.split("/").second
         raise Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
+      rescue Faraday::Error => e
+        raise_faraday_exception e, path, method.upcase
       end
 
-      # re-raise the same exception with nicer error message
-      def raise_rest_client_exception(e, a_path, http_method)
-        msg = "#{name}: #{e.message} #{e.http_body} (#{http_method} #{a_path})"
-        e.message = msg
-        fail e
+      def raise_faraday_exception(e, a_path, http_method)
+        msg = "#{name}: #{e.message} (#{http_method} #{a_path})"
+        raise RestClientException, { message: msg, service_code: '', code: e.response&.dig(:status).to_s }
       end
 
       def join_path(*args)
@@ -117,41 +117,21 @@ module Katello
         end
       end
 
-      # Creates a RestClient::Resource class with a signed OAuth style
-      # Authentication header added to the request headers.
-      def rest_client(http_type, method, path)
-        # Need full path to properly generate the signature
-        url = self.site + path
-        params = { :site => self.site,
-                   :http_method => method,
-                   :request_token_path => "",
-                   :authorize_path => "",
-                   :access_token_path => ""}
+      def faraday_connection
+        @faraday_connection ||= begin
+          timeout = SETTINGS[:katello][:rest_client_timeout]
+          Faraday.new(url: self.site) do |f|
+            f.options.open_timeout = timeout
+            f.options.timeout = timeout
+            f.ssl.ca_file = self.ssl_ca_file if self.ssl_ca_file
+            f.ssl.client_cert = self.ssl_client_cert if self.ssl_client_cert
+            f.ssl.client_key = self.ssl_client_key if self.ssl_client_key
+            f.adapter :net_http_persistent
+          end
+        end
+      end
 
-        params[:ca_file] = self.ssl_ca_file unless self.ssl_ca_file.nil?
-        # New OAuth consumer to setup signing the request
-        consumer = OAuth::Consumer.new(self.consumer_key,
-                            self.consumer_secret,
-                            params)
-
-        # The type is passed in, GET/POST/PUT/DELETE
-        request = http_type.new(url)
-
-        # Sign the request with OAuth
-        consumer.sign!(request)
-        # Extract the header and add it to the RestClient
-        added_header = {'Authorization' => request['Authorization']}
-
-        options = {
-          :headers => added_header,
-          :open_timeout => SETTINGS[:katello][:rest_client_timeout],
-          :timeout => SETTINGS[:katello][:rest_client_timeout],
-        }
-        options[:ssl_ca_file] = self.ssl_ca_file unless self.ssl_ca_file.nil?
-        options[:ssl_client_cert] = self.ssl_client_cert unless self.ssl_client_cert.nil?
-        options[:ssl_client_key] = self.ssl_client_key unless self.ssl_client_key.nil?
-
-        RestClient::Resource.new(url, options)
+      def sign_request(_req, _url, _method)
       end
 
       def hash_to_query(query_parameters)

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -8,12 +8,13 @@ module Katello
     end
 
     class HttpError < StandardError
-      attr_reader :service_code, :code
+      attr_reader :service_code, :code, :response_body
 
       def initialize(params)
         super params[:message]
         @service_code = params[:service_code]
         @code = params[:code]
+        @response_body = params[:response_body]
       end
     end
 
@@ -68,12 +69,12 @@ module Katello
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
           if %w(404 500 502 503 504).member? resp.status.to_s
             logger.error "Remote server status code " << resp.status.to_s
-            raise HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code}, caller
+            raise HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
           else
             raise NetworkException, [resp.status.to_s, resp.body].reject { |s| s.blank? }.join(' ')
           end
         end
-        fail HttpError, {:message => message, :service_code => service_code, :code => status_code}, caller
+        fail HttpError, {:message => message, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
       end
 
       def stringify_headers(headers)
@@ -107,7 +108,7 @@ module Katello
 
       def raise_faraday_exception(e, a_path, http_method)
         msg = "#{name}: #{e.message} (#{http_method} #{a_path})"
-        raise HttpError, { message: msg, service_code: '', code: e.response&.dig(:status).to_s }
+        raise HttpError, { message: msg, service_code: '', code: e.response&.dig(:status).to_s, response_body: e.response&.dig(:body) }
       end
 
       def join_path(*args)

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -81,7 +81,7 @@ module Katello
         (headers || {}).transform_keys(&:to_s).transform_values(&:to_s)
       end
 
-      def issue_request(method:, path:, headers: {}, payload: nil, params: nil, process: true)
+      def issue_request(method:, path:, headers: {}, payload: nil, params: nil, process: true, connection: nil)
         path = "#{path}#{query_string(params)}" if params
         headers = stringify_headers(headers)
         logger.debug("Resource #{method.upcase} request: #{path}")
@@ -92,7 +92,7 @@ module Katello
           logger.debug "Body: Error: could not render payload as json"
         end
 
-        conn = faraday_connection
+        conn = connection || faraday_connection
         response = conn.send(method, path) do |req|
           sign_request(req, self.site + path, method)
           req.headers.merge!(headers) if headers

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -81,7 +81,8 @@ module Katello
         (headers || {}).transform_keys(&:to_s).transform_values(&:to_s)
       end
 
-      def issue_request(method:, path:, headers: {}, payload: nil)
+      def issue_request(method:, path:, headers: {}, payload: nil, params: nil)
+        path = "#{path}#{query_string(params)}" if params
         headers = stringify_headers(headers)
         logger.debug("Resource #{method.upcase} request: #{path}")
         logger.debug "Headers: #{headers.to_json}"
@@ -135,9 +136,12 @@ module Katello
       def sign_request(_req, _url, _method)
       end
 
-      def hash_to_query(query_parameters)
-        "?#{URI.encode_www_form(query_parameters)}"
+      def query_string(params)
+        return '' if params.nil? || (params.respond_to?(:empty?) && params.empty?)
+        "?#{URI.encode_www_form(params)}"
       end
+
+      alias_method :hash_to_query, :query_string
     end
   end
 end

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -54,8 +54,8 @@ module Katello
       end
 
       def process_response(resp)
-        logger.debug "Processing response: #{resp.status}"
-        logger.debug filter_sensitive_data(resp.body)
+        logger.debug { "Processing response: #{resp.status}" }
+        logger.debug { filter_sensitive_data(resp.body) }
         return resp unless resp.status >= 400
         parsed = {}
         message = "HTTP error while processing the call"
@@ -85,17 +85,12 @@ module Katello
         path = "#{path}#{query_string(params)}" if params
         headers = stringify_headers(headers)
         conn = connection || faraday_connection
-        url = connection ? "#{conn.url_prefix}#{path}" : path
-        logger.debug("Resource #{method.upcase} request: #{url}")
-        logger.debug "Headers: #{headers.to_json}"
-        begin
-          logger.debug "Body: #{filter_sensitive_data(payload.to_json)}"
-        rescue JSON::GeneratorError, Encoding::UndefinedConversionError
-          logger.debug "Body: Error: could not render payload as json"
-        end
-        sign_url = connection ? "#{conn.url_prefix}#{path}" : self.site + path
+        full_url = connection ? "#{conn.url_prefix}#{path}" : self.site + path
+        logger.debug { "Resource #{method.upcase} request: #{full_url}" }
+        logger.debug { "Headers: #{headers.to_json}" }
+        logger.debug { "Body: #{filter_sensitive_data(payload.to_json)}" } if payload
         response = conn.send(method, path) do |req|
-          sign_request(req, sign_url, method)
+          sign_request(req, full_url, method)
           req.headers.merge!(headers) if headers
           req.body = payload if payload
         end

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -68,7 +68,7 @@ module Katello
         rescue => error
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
           logger.error "Remote server status code " << resp.status.to_s
-          fail HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
+          raise HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
         end
         fail HttpError, {:message => message, :service_code => service_code, :code => status_code, :response_body => resp.body}, caller
       end
@@ -94,7 +94,7 @@ module Katello
         process ? process_response(response) : response
       rescue Faraday::ConnectionFailed
         service = path.split("/").second
-        fail Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
+        raise Errors::ConnectionRefusedException, _("A backend service [ %s ] is unreachable") % service.capitalize
       rescue Faraday::Error => e
         raise_faraday_exception e, path, method.upcase
       end

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -7,7 +7,7 @@ module Katello
     class NetworkException < StandardError
     end
 
-    class RestClientException < StandardError
+    class HttpError < StandardError
       attr_reader :service_code, :code
 
       def initialize(params)
@@ -68,12 +68,12 @@ module Katello
           logger.error "Error parsing the body: " << error.backtrace.join("\n")
           if %w(404 500 502 503 504).member? resp.status.to_s
             logger.error "Remote server status code " << resp.status.to_s
-            raise RestClientException, {:message => error.to_s, :service_code => service_code, :code => status_code}, caller
+            raise HttpError, {:message => error.to_s, :service_code => service_code, :code => status_code}, caller
           else
             raise NetworkException, [resp.status.to_s, resp.body].reject { |s| s.blank? }.join(' ')
           end
         end
-        fail RestClientException, {:message => message, :service_code => service_code, :code => status_code}, caller
+        fail HttpError, {:message => message, :service_code => service_code, :code => status_code}, caller
       end
 
       def stringify_headers(headers)
@@ -107,7 +107,7 @@ module Katello
 
       def raise_faraday_exception(e, a_path, http_method)
         msg = "#{name}: #{e.message} (#{http_method} #{a_path})"
-        raise RestClientException, { message: msg, service_code: '', code: e.response&.dig(:status).to_s }
+        raise HttpError, { message: msg, service_code: '', code: e.response&.dig(:status).to_s }
       end
 
       def join_path(*args)

--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -1,4 +1,3 @@
-require 'cgi'
 require 'faraday'
 require 'faraday/net_http_persistent'
 
@@ -58,7 +57,7 @@ module Katello
         logger.debug filter_sensitive_data(resp.body)
         return resp unless resp.status >= 400
         parsed = {}
-        message = "Rest exception while processing the call"
+        message = "HTTP error while processing the call"
         service_code = ""
         status_code = resp.status.to_s
         begin

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -64,6 +64,50 @@ module Katello
           included.map { |value| "include=#{value}" }.join('&')
         end
 
+        def self.build_path(base, params: {}, includes: [], page: nil, page_size: nil)
+          parts = []
+          query = hash_to_query(params)
+          parts << included_list(includes) unless includes.empty?
+          parts << "per_page=#{page_size}&page=#{page}" if page && page_size
+          extra = parts.reject(&:blank?).join('&')
+          return base + query if extra.empty?
+          separator = query.empty? ? '?' : '&'
+          base + query + separator + extra
+        end
+
+        def self.parse_json(response, array: false)
+          parsed = JSON.parse(response.body)
+          array ? ::Katello::Util::Data.array_with_indifferent_access(parsed) : parsed.with_indifferent_access
+        end
+
+        def self.update_content_overrides_for(resource_path, id, content_overrides)
+          return [] if content_overrides.empty?
+
+          attrs_to_delete = []
+          attrs_to_update = []
+          content_overrides.each do |override|
+            if override[:value]
+              attrs_to_update << override
+            else
+              attrs_to_delete << override
+            end
+          end
+
+          if attrs_to_update.present?
+            result = Candlepin::CandlepinResource.put(join_path(resource_path, 'content_overrides'),
+                                                      attrs_to_update.to_json, headers: default_headers)
+          end
+          if attrs_to_delete.present?
+            result = Candlepin::CandlepinResource.issue_request(
+              method: :delete,
+              path: join_path(resource_path, 'content_overrides'),
+              headers: default_headers,
+              payload: attrs_to_delete.to_json
+            )
+          end
+          ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result.body))
+        end
+
         def self.fetch_paged(page_size = -1)
           if page_size == -1
             page_size = SETTINGS[:katello][:candlepin][:bulk_load_size]

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -127,12 +127,15 @@ module Katello
           end
 
           def faraday_connection(_path = '')
-            @faraday_connection ||= resource(url: self.site + self.path, client_cert: client_cert, client_key: client_key, ca_file: nil)
+            org_id = Organization.current&.id
+            @faraday_connections ||= {}
+            @faraday_connections[org_id] ||= resource(url: self.site + self.path, client_cert: client_cert, client_key: client_key, ca_file: nil)
           end
 
           def reset_connection!
-            @faraday_connection = nil
-            @upstream_owner_id = nil
+            org_id = Organization.current&.id
+            @faraday_connections&.delete(org_id)
+            @upstream_owner_ids&.delete(org_id)
           end
 
           def client_cert
@@ -160,7 +163,9 @@ module Katello
           end
 
           def upstream_owner_id
-            @upstream_owner_id ||= begin
+            org_id = Organization.current&.id
+            @upstream_owner_ids ||= {}
+            @upstream_owner_ids[org_id] ||= begin
               response = Katello::Resources::Candlepin::UpstreamConsumer.issue_request(
                 method: :get,
                 path: Katello::Resources::Candlepin::UpstreamConsumer.path,

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -241,13 +241,13 @@ module Katello
 
       module ConsumerResource
         def path(id = nil)
-          "#{self.prefix}/consumers/#{id}"
+          id ? "#{self.prefix}/consumers/#{id}" : "#{self.prefix}/consumers"
         end
       end
 
       module OwnerResource
         def path(id = nil)
-          "#{self.prefix}/owners/#{id}"
+          id ? "#{self.prefix}/owners/#{id}" : "#{self.prefix}/owners"
         end
       end
 

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -123,7 +123,7 @@ module Katello
           end
 
           def faraday_connection(_path = '')
-            resource(url: self.site + self.path, client_cert: client_cert, client_key: client_key, ca_file: nil)
+            @faraday_connection ||= resource(url: self.site + self.path, client_cert: client_cert, client_key: client_key, ca_file: nil)
           end
 
           def client_cert

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -1,9 +1,11 @@
 module Katello
   module Resources
     module Candlepin
-      TOTAL_COUNT_HEADER = :x_total_count # as parsed by rest_client
+      TOTAL_COUNT_HEADER = 'x-total-count'
 
       class CandlepinResource < HttpResource
+        include Katello::Concerns::OauthRequestSigning
+
         cfg = SETTINGS[:katello][:candlepin]
         url = cfg[:url]
         uri = URI.parse(url)
@@ -15,15 +17,13 @@ module Katello
 
         class << self
           def process_response(response)
-            debug_level = response.code >= 400 ? :error : :debug
-            logger.send(debug_level, "Candlepin request #{response.headers[:x_candlepin_request_uuid]} returned with code #{response.code}")
+            debug_level = response.status >= 400 ? :error : :debug
+            logger.send(debug_level, "Candlepin request #{response.headers['x-candlepin-request-uuid']} returned with code #{response.status}")
             super
           end
 
-          def raise_rest_client_exception(error, path, http_method)
-            # this differentiates between Tomcat returning a 404 (candlepin is down or not deployed)
-            # vs a 404 from Candlepin itself
-            unless error&.response&.headers&.dig(:x_version)
+          def raise_faraday_exception(error, path, http_method)
+            unless error.response && error.response[:headers]&.key?('x-version')
               fail ::Katello::Errors::CandlepinNotRunning
             end
 
@@ -86,42 +86,44 @@ module Katello
         self.prefix = '/subscription'
 
         class << self
-          delegate :[], to: :json_resource
+          def sign_request(_req, _url, _method)
+          end
 
           def default_headers(uuid = nil)
             super(uuid).except('cp-user', 'cp-consumer')
           end
 
-          def resource(options = {}, url: self.site + self.path, client_cert: self.client_cert, client_key: self.client_key, ca_file: nil)
-            cert_store = OpenSSL::X509::Store.new
-            cert_store.add_file(ca_file) if ca_file
+          def resource(url: self.site + self.path, client_cert: self.client_cert, client_key: self.client_key, ca_file: nil)
+            timeout = Setting[:manifest_refresh_timeout]
 
-            if proxy&.cacert&.present?
-              Foreman::Util.add_ca_bundle_to_store(proxy.cacert, cert_store)
+            Faraday.new(url: url) do |f|
+              f.options.open_timeout = timeout
+              f.options.timeout = timeout
+              f.headers = self.default_headers
+
+              f.ssl.client_cert = OpenSSL::X509::Certificate.new(client_cert)
+              f.ssl.client_key = OpenSSL::PKey::RSA.new(client_key)
+              if ca_file
+                f.ssl.ca_file = ca_file
+                f.ssl.verify = true
+              else
+                f.ssl.verify = false
+              end
+
+              if proxy&.cacert&.present?
+                cert_store = OpenSSL::X509::Store.new
+                Foreman::Util.add_ca_bundle_to_store(proxy.cacert, cert_store)
+                f.ssl.cert_store = cert_store
+              end
+
+              f.proxy = self.proxy_uri if self.proxy_uri
+
+              f.adapter :net_http_persistent
             end
-            RestClient::Resource.new(url,
-                                     :ssl_client_cert => OpenSSL::X509::Certificate.new(client_cert),
-                                     :ssl_client_key => OpenSSL::PKey::RSA.new(client_key),
-                                     :ssl_cert_store => cert_store,
-                                     :verify_ssl => ca_file ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
-                                     :open_timeout => Setting[:manifest_refresh_timeout],
-                                     :timeout => Setting[:manifest_refresh_timeout],
-                                     :proxy => self.proxy_uri,
-                                     **options
-                                    )
           end
 
-          def json_resource(options = {}, url: self.site + self.path, client_cert: self.client_cert, client_key: self.client_key, ca_file: nil)
-            options.deep_merge!(headers: self.default_headers)
-            resource(options, url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
-          end
-
-          def rest_client(_http_type = nil, method = :get, path = self.path)
-            # No oauth upstream
-            self.consumer_secret = nil
-            self.consumer_key = nil
-
-            resource({ http_method: method }, url: self.site + path, client_cert: client_cert, client_key: client_key, ca_file: nil)
+          def faraday_connection(_path = '')
+            resource(url: self.site + self.path, client_cert: client_cert, client_key: client_key, ca_file: nil)
           end
 
           def client_cert
@@ -149,8 +151,10 @@ module Katello
           end
 
           def upstream_owner_id
-            JSON.parse(Katello::Resources::Candlepin::UpstreamConsumer.resource.get.body)['owner']['key']
-          rescue RestClient::Exception => e
+            conn = Katello::Resources::Candlepin::UpstreamConsumer.resource
+            response = conn.get(Katello::Resources::Candlepin::UpstreamConsumer.path)
+            JSON.parse(response.body)['owner']['key']
+          rescue Faraday::Error => e
             Rails.logger.error "Unable to find upstream owner for consumer"
             raise e
           end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -75,8 +75,10 @@ module Katello
           base + query + separator + extra
         end
 
-        def self.parse_json(response, array: false)
-          parsed = JSON.parse(response.body)
+        def self.parse_json(response, array: false, default: nil)
+          body = response&.body
+          body = default if default && body.blank?
+          parsed = JSON.parse(body)
           array ? ::Katello::Util::Data.array_with_indifferent_access(parsed) : parsed.with_indifferent_access
         end
 
@@ -105,7 +107,7 @@ module Katello
               payload: attrs_to_delete.to_json
             )
           end
-          ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result.body))
+          parse_json(result, array: true, default: '[]')
         end
 
         def self.fetch_paged(page_size = -1)
@@ -191,7 +193,9 @@ module Katello
           end
 
           def site
-            "#{upstream_api_uri.scheme}://#{upstream_api_uri.host}"
+            default_port = upstream_api_uri.scheme == 'https' ? 443 : 80
+            site = "#{upstream_api_uri.scheme}://#{upstream_api_uri.host}"
+            upstream_api_uri.port == default_port ? site : "#{site}:#{upstream_api_uri.port}"
           end
 
           def upstream_id_cert

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -17,7 +17,7 @@ module Katello
 
         class << self
           def process_response(response)
-            debug_level = response.status >= 400 ? :error : :debug
+            debug_level = (response.status >= 400) ? :error : :debug
             logger.send(debug_level, "Candlepin request #{response.headers['x-candlepin-request-uuid']} returned with code #{response.status}")
             super
           end
@@ -102,7 +102,7 @@ module Katello
               method: :delete,
               path: join_path(resource_path, 'content_overrides'),
               headers: default_headers,
-              payload: attrs_to_delete.to_json,
+              payload: attrs_to_delete.to_json
             )
           end
           ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result.body))
@@ -151,18 +151,15 @@ module Katello
 
               f.ssl.client_cert = OpenSSL::X509::Certificate.new(client_cert)
               f.ssl.client_key = OpenSSL::PKey::RSA.new(client_key)
-              if ca_file
-                f.ssl.ca_file = ca_file
-                f.ssl.verify = true
-              else
-                f.ssl.verify = false
-              end
+              f.ssl.ca_file = ca_file if ca_file
 
               if proxy&.cacert&.present?
                 cert_store = OpenSSL::X509::Store.new
                 Foreman::Util.add_ca_bundle_to_store(proxy.cacert, cert_store)
                 f.ssl.cert_store = cert_store
               end
+
+              f.ssl.verify = ca_file.present? || proxy&.cacert.present?
 
               f.proxy = self.proxy_uri if self.proxy_uri
 
@@ -212,8 +209,7 @@ module Katello
               response = Katello::Resources::Candlepin::UpstreamConsumer.issue_request(
                 method: :get,
                 path: Katello::Resources::Candlepin::UpstreamConsumer.path,
-                headers: default_headers,
-                process: false
+                headers: default_headers
               )
               JSON.parse(response.body)['owner']['key']
             end
@@ -253,10 +249,9 @@ module Katello
 
       module PoolResource
         def path(id = nil, owner_label = nil)
-          case
-          when owner_label && id
+          if owner_label && id
             "#{prefix}/owners/#{owner_label}/pools/#{id}"
-          when owner_label
+          elsif owner_label
             "#{prefix}/owners/#{owner_label}/pools/"
           else
             "#{prefix}/pools/#{id}"

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -1,7 +1,7 @@
 module Katello
   module Resources
     module Candlepin
-      TOTAL_COUNT_HEADER = 'x-total-count'
+      TOTAL_COUNT_HEADER = 'x-total-count'.freeze
 
       class CandlepinResource < HttpResource
         include Katello::Concerns::OauthRequestSigning
@@ -80,7 +80,7 @@ module Katello
           array ? ::Katello::Util::Data.array_with_indifferent_access(parsed) : parsed.with_indifferent_access
         end
 
-        def self.update_content_overrides_for(resource_path, id, content_overrides)
+        def self.update_content_overrides_for(resource_path, _id, content_overrides)
           return [] if content_overrides.empty?
 
           attrs_to_delete = []
@@ -253,9 +253,10 @@ module Katello
 
       module PoolResource
         def path(id = nil, owner_label = nil)
-          if owner_label && id
+          case
+          when owner_label && id
             "#{prefix}/owners/#{owner_label}/pools/#{id}"
-          elsif owner_label
+          when owner_label
             "#{prefix}/owners/#{owner_label}/pools/"
           else
             "#{prefix}/pools/#{id}"

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -130,6 +130,11 @@ module Katello
             @faraday_connection ||= resource(url: self.site + self.path, client_cert: client_cert, client_key: client_key, ca_file: nil)
           end
 
+          def reset_connection!
+            @faraday_connection = nil
+            @upstream_owner_id = nil
+          end
+
           def client_cert
             upstream_id_cert['cert']
           end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -93,6 +93,10 @@ module Katello
             super(uuid).except('cp-user', 'cp-consumer')
           end
 
+          # Creates a new Faraday connection with client cert auth for upstream
+          # Candlepin (Red Hat CDN). Use for calls with custom URL/certs (export,
+          # update, regenerate). For default upstream calls, use faraday_connection
+          # which memoizes the connection for reuse.
           def resource(url: self.site + self.path, client_cert: self.client_cert, client_key: self.client_key, ca_file: nil)
             timeout = Setting[:manifest_refresh_timeout]
 
@@ -151,12 +155,13 @@ module Katello
           end
 
           def upstream_owner_id
-            conn = Katello::Resources::Candlepin::UpstreamConsumer.resource
-            response = conn.get(Katello::Resources::Candlepin::UpstreamConsumer.path)
+            response = Katello::Resources::Candlepin::UpstreamConsumer.issue_request(
+              method: :get,
+              path: Katello::Resources::Candlepin::UpstreamConsumer.path,
+              headers: default_headers,
+              process: false
+            )
             JSON.parse(response.body)['owner']['key']
-          rescue Faraday::Error => e
-            Rails.logger.error "Unable to find upstream owner for consumer"
-            raise e
           end
 
           def upstream_consumer_id

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -155,7 +155,7 @@ module Katello
               f.ssl.client_key = OpenSSL::PKey::RSA.new(client_key)
               f.ssl.ca_file = ca_file if ca_file
 
-              if proxy&.cacert&.present?
+              if proxy&.cacert.present?
                 cert_store = OpenSSL::X509::Store.new
                 Foreman::Util.add_ca_bundle_to_store(proxy.cacert, cert_store)
                 f.ssl.cert_store = cert_store
@@ -193,9 +193,9 @@ module Katello
           end
 
           def site
-            default_port = upstream_api_uri.scheme == 'https' ? 443 : 80
+            default_port = (upstream_api_uri.scheme == 'https') ? 443 : 80
             site = "#{upstream_api_uri.scheme}://#{upstream_api_uri.host}"
-            upstream_api_uri.port == default_port ? site : "#{site}:#{upstream_api_uri.port}"
+            (upstream_api_uri.port == default_port) ? site : "#{site}:#{upstream_api_uri.port}"
           end
 
           def upstream_id_cert

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -133,9 +133,8 @@ module Katello
           end
 
           def reset_connection!
-            org_id = Organization.current&.id
-            @faraday_connections&.delete(org_id)
-            @upstream_owner_ids&.delete(org_id)
+            @faraday_connections = nil
+            @upstream_owner_ids = nil
           end
 
           def client_cert

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -155,13 +155,15 @@ module Katello
           end
 
           def upstream_owner_id
-            response = Katello::Resources::Candlepin::UpstreamConsumer.issue_request(
-              method: :get,
-              path: Katello::Resources::Candlepin::UpstreamConsumer.path,
-              headers: default_headers,
-              process: false
-            )
-            JSON.parse(response.body)['owner']['key']
+            @upstream_owner_id ||= begin
+              response = Katello::Resources::Candlepin::UpstreamConsumer.issue_request(
+                method: :get,
+                path: Katello::Resources::Candlepin::UpstreamConsumer.path,
+                headers: default_headers,
+                process: false
+              )
+              JSON.parse(response.body)['owner']['key']
+            end
           end
 
           def upstream_consumer_id

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -102,7 +102,7 @@ module Katello
               method: :delete,
               path: join_path(resource_path, 'content_overrides'),
               headers: default_headers,
-              payload: attrs_to_delete.to_json
+              payload: attrs_to_delete.to_json,
             )
           end
           ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result.body))

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -30,7 +30,7 @@ module Katello
 
           def destroy(id)
             fail(ArgumentError, "activation key id has to be specified") unless id
-            self.delete(path(id), self.default_headers).code.to_i
+            self.delete(path(id), self.default_headers).status
           end
 
           def content_overrides(id)
@@ -57,10 +57,13 @@ module Katello
                                                         attrs_to_update.to_json, self.default_headers)
             end
             if attrs_to_delete.present?
-              client = Candlepin::CandlepinResource.rest_client(Net::HTTP::Delete, :delete,
-                                                                join_path(path(id), 'content_overrides'))
-              client.options[:payload] = attrs_to_delete.to_json
-              result = client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
+              override_path = join_path(path(id), 'content_overrides')
+              conn = Candlepin::CandlepinResource.faraday_connection
+              result = conn.delete(override_path) do |req|
+                CandlepinResource.sign_request(req, CandlepinResource.site + override_path, :delete)
+                req.headers.merge!(HttpResource.stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
+                req.body = attrs_to_delete.to_json
+              end
             end
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result || '{}'))
           end

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -42,31 +42,7 @@ module Katello
           # id : ID of the Activation Key
           # content_overrides => Array of content override hashes
           def update_content_overrides(id, content_overrides)
-            return [] if content_overrides.empty?
-
-            attrs_to_delete = []
-            attrs_to_update = []
-            content_overrides.each do |content_override|
-              if content_override[:value]
-                attrs_to_update << content_override
-              else
-                attrs_to_delete << content_override
-              end
-            end
-
-            if attrs_to_update.present?
-              result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
-                                                        attrs_to_update.to_json, headers: self.default_headers)
-            end
-            if attrs_to_delete.present?
-              result = Candlepin::CandlepinResource.issue_request(
-                method: :delete,
-                path: join_path(path(id), 'content_overrides'),
-                headers: self.default_headers,
-                payload: attrs_to_delete.to_json
-              )
-            end
-            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result&.body || '{}'))
+            update_content_overrides_for(path(id), id, content_overrides)
           end
 
           def path(id = nil, owner_id = nil)

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -4,7 +4,7 @@ module Katello
       class ActivationKey < CandlepinResource
         class << self
           def get(id = nil, params = '', owner = nil)
-            akeys_json = super(path(id, owner) + params, self.default_headers).body
+            akeys_json = super(path(id, owner) + params, headers: self.default_headers).body
             akeys = JSON.parse(akeys_json)
             akeys = [akeys] unless id.nil?
             ::Katello::Util::Data.array_with_indifferent_access akeys
@@ -19,22 +19,22 @@ module Katello
               role: purpose_role,
               usage: purpose_usage,
             }
-            response = self.post(url, params.to_json, self.default_headers)
+            response = self.post(url, params.to_json, headers: self.default_headers)
             JSON.parse(response.body).with_indifferent_access
           end
 
           def update(id, release_version, service_level, purpose_role, purpose_usage)
             attrs = { :releaseVer => release_version, :serviceLevel => service_level, :role => purpose_role, :usage => purpose_usage }.delete_if { |_k, v| v.nil? }
-            JSON.parse(self.put(path(id), attrs.to_json, self.default_headers).body).with_indifferent_access
+            JSON.parse(self.put(path(id), attrs.to_json, headers: self.default_headers).body).with_indifferent_access
           end
 
           def destroy(id)
             fail(ArgumentError, "activation key id has to be specified") unless id
-            self.delete(path(id), self.default_headers).status
+            self.delete(path(id), headers: self.default_headers).status
           end
 
           def content_overrides(id)
-            result = Candlepin::CandlepinResource.get(join_path(path(id), 'content_overrides'), self.default_headers).body
+            result = Candlepin::CandlepinResource.get(join_path(path(id), 'content_overrides'), headers: self.default_headers).body
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
           end
 
@@ -54,7 +54,7 @@ module Katello
 
             if attrs_to_update.present?
               result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
-                                                        attrs_to_update.to_json, self.default_headers)
+                                                        attrs_to_update.to_json, headers: self.default_headers)
             end
             if attrs_to_delete.present?
               override_path = join_path(path(id), 'content_overrides')

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -57,13 +57,12 @@ module Katello
                                                         attrs_to_update.to_json, headers: self.default_headers)
             end
             if attrs_to_delete.present?
-              override_path = join_path(path(id), 'content_overrides')
-              conn = Candlepin::CandlepinResource.faraday_connection
-              result = conn.delete(override_path) do |req|
-                CandlepinResource.sign_request(req, CandlepinResource.site + override_path, :delete)
-                req.headers.merge!(HttpResource.stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
-                req.body = attrs_to_delete.to_json
-              end
+              result = Candlepin::CandlepinResource.issue_request(
+                method: :delete,
+                path: join_path(path(id), 'content_overrides'),
+                headers: self.default_headers,
+                payload: attrs_to_delete.to_json
+              )
             end
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result || '{}'))
           end

--- a/app/lib/katello/resources/candlepin/activation_key.rb
+++ b/app/lib/katello/resources/candlepin/activation_key.rb
@@ -42,6 +42,8 @@ module Katello
           # id : ID of the Activation Key
           # content_overrides => Array of content override hashes
           def update_content_overrides(id, content_overrides)
+            return [] if content_overrides.empty?
+
             attrs_to_delete = []
             attrs_to_update = []
             content_overrides.each do |content_override|
@@ -64,7 +66,7 @@ module Katello
                 payload: attrs_to_delete.to_json
               )
             end
-            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result || '{}'))
+            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result&.body || '{}'))
           end
 
           def path(id = nil, owner_id = nil)

--- a/app/lib/katello/resources/candlepin/c_p_user.rb
+++ b/app/lib/katello/resources/candlepin/c_p_user.rb
@@ -4,7 +4,7 @@ module Katello
       class CPUser < CandlepinResource
         class << self
           def create(attrs)
-            JSON.parse(self.post(path, JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+            JSON.parse(self.post(path, JSON.generate(attrs), headers: self.default_headers).body).with_indifferent_access
           end
 
           def path(id = nil)

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -80,7 +80,7 @@ module Katello
           end
 
           def destroy(uuid)
-            self.delete(path(uuid), User.cp_oauth_header).code.to_i
+            self.delete(path(uuid), User.cp_oauth_header).status
           end
 
           def serials(uuid)
@@ -101,7 +101,7 @@ module Katello
           def virtual_guests(uuid)
             response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), self.default_headers).body
             ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
-          rescue RestClient::Exception
+          rescue HttpResource::RestClientException
             return []
           end
 
@@ -112,7 +112,7 @@ module Katello
             else
               return nil
             end
-          rescue RestClient::Exception
+          rescue HttpResource::RestClientException
             return nil
           end
 
@@ -140,10 +140,13 @@ module Katello
                                                         attrs_to_update.to_json, self.default_headers)
             end
             if attrs_to_delete.present?
-              client = Candlepin::CandlepinResource.rest_client(Net::HTTP::Delete, :delete,
-                                                                join_path(path(id), 'content_overrides'))
-              client.options[:payload] = attrs_to_delete.to_json
-              result = client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
+              override_path = join_path(path(id), 'content_overrides')
+              conn = Candlepin::CandlepinResource.faraday_connection
+              result = conn.delete(override_path) do |req|
+                CandlepinResource.sign_request(req, CandlepinResource.site + override_path, :delete)
+                req.headers.merge!(HttpResource.stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
+                req.body = attrs_to_delete.to_json
+              end
             end
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
           end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -140,13 +140,12 @@ module Katello
                                                         attrs_to_update.to_json, headers: self.default_headers)
             end
             if attrs_to_delete.present?
-              override_path = join_path(path(id), 'content_overrides')
-              conn = Candlepin::CandlepinResource.faraday_connection
-              result = conn.delete(override_path) do |req|
-                CandlepinResource.sign_request(req, CandlepinResource.site + override_path, :delete)
-                req.headers.merge!(HttpResource.stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
-                req.body = attrs_to_delete.to_json
-              end
+              result = Candlepin::CandlepinResource.issue_request(
+                method: :delete,
+                path: join_path(path(id), 'content_overrides'),
+                headers: self.default_headers,
+                payload: attrs_to_delete.to_json
+              )
             end
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
           end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -15,11 +15,11 @@ module Katello
 
           def get(params)
             if params.is_a?(String)
-              JSON.parse(super(path(params), self.default_headers).body).with_indifferent_access
+              JSON.parse(super(path(params), headers: self.default_headers).body).with_indifferent_access
             else
               includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
               fetch_paged do |page_add|
-                response = super(path + hash_to_query(params) + includes + "&#{page_add}", self.default_headers).body
+                response = super(path + hash_to_query(params) + includes + "&#{page_add}", headers: self.default_headers).body
                 JSON.parse(response).map(&:with_indifferent_access)
               end
             end
@@ -40,7 +40,7 @@ module Katello
             url = "/candlepin/consumers/?owner=#{org.label}"
             url += "&activation_keys=" + activation_key_cp_ids.join(",") if activation_key_cp_ids.length > 0
 
-            response = self.post(url, parameters.to_json, self.default_headers).body
+            response = self.post(url, parameters.to_json, headers: self.default_headers).body
             JSON.parse(response).with_indifferent_access
           end
 
@@ -48,13 +48,13 @@ module Katello
             url = "/candlepin/hypervisors/#{owner}?reporter_id=#{reporter_id}"
             headers = self.default_headers
             headers['content-type'] = 'text/plain'
-            response = self.post(url, raw_json, headers)
+            response = self.post(url, raw_json, headers: headers)
             JSON.parse(response).with_indifferent_access
           end
 
           def hypervisors_heartbeat(owner:, reporter_id:)
             url = "/candlepin/hypervisors/#{owner}/heartbeat?reporter_id=#{reporter_id}"
-            response = self.put(url, {}.to_json, self.default_headers).body
+            response = self.put(url, {}.to_json, headers: self.default_headers).body
             JSON.parse(response).with_indifferent_access
           end
 
@@ -62,7 +62,7 @@ module Katello
             url = "/candlepin/hypervisors"
             url << "?owner=#{params[:owner]}&env=#{params[:env]}"
             attrs = params.except(:owner, :env)
-            response = self.post(url, attrs.to_json, self.default_headers).body
+            response = self.post(url, attrs.to_json, headers: self.default_headers).body
             JSON.parse(response).with_indifferent_access
           end
 
@@ -73,14 +73,14 @@ module Katello
               if params.key?(:environment) && params[:environment].key?(:id)
                 params[:environments] = [{"id": params[:environment][:id]}]
               end
-              self.put(path(uuid), params.to_json, self.default_headers).body
+              self.put(path(uuid), params.to_json, headers: self.default_headers).body
             end
             # consumer update doesn't return any data atm
             # JSON.parse(response).with_indifferent_access
           end
 
           def destroy(uuid)
-            self.delete(path(uuid), User.cp_oauth_header).status
+            self.delete(path(uuid), headers: User.cp_oauth_header).status
           end
 
           def serials(uuid)
@@ -90,23 +90,23 @@ module Katello
 
           def checkin(uuid, checkin_date)
             checkin_date ||= Time.now
-            self.put(path(uuid), {:lastCheckin => checkin_date}.to_json, self.default_headers).body
+            self.put(path(uuid), {:lastCheckin => checkin_date}.to_json, headers: self.default_headers).body
           end
 
           def regenerate_identity_certificates(uuid)
-            response = self.post(path(uuid), {}, self.default_headers).body
+            response = self.post(path(uuid), {}, headers: self.default_headers).body
             JSON.parse(response).with_indifferent_access
           end
 
           def virtual_guests(uuid)
-            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), self.default_headers).body
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), headers: self.default_headers).body
             ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
           rescue HttpResource::HttpError
             return []
           end
 
           def virtual_host(uuid)
-            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'host'), self.default_headers).body
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'host'), headers: self.default_headers).body
             if response.present?
               JSON.parse(response).with_indifferent_access
             else
@@ -117,7 +117,7 @@ module Katello
           end
 
           def content_overrides(id)
-            result = Candlepin::CandlepinResource.get(join_path(path(id), 'content_overrides'), self.default_headers).body
+            result = Candlepin::CandlepinResource.get(join_path(path(id), 'content_overrides'), headers: self.default_headers).body
             ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
           end
 
@@ -137,7 +137,7 @@ module Katello
 
             if attrs_to_update.present?
               result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
-                                                        attrs_to_update.to_json, self.default_headers)
+                                                        attrs_to_update.to_json, headers: self.default_headers)
             end
             if attrs_to_delete.present?
               override_path = join_path(path(id), 'content_overrides')

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -101,7 +101,7 @@ module Katello
           def virtual_guests(uuid)
             response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'guests'), self.default_headers).body
             ::Katello::Util::Data.array_with_indifferent_access JSON.parse(response)
-          rescue HttpResource::RestClientException
+          rescue HttpResource::HttpError
             return []
           end
 
@@ -112,7 +112,7 @@ module Katello
             else
               return nil
             end
-          rescue HttpResource::RestClientException
+          rescue HttpResource::HttpError
             return nil
           end
 

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -17,9 +17,13 @@ module Katello
             if params.is_a?(String)
               JSON.parse(super(path(params), headers: self.default_headers).body).with_indifferent_access
             else
-              includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
+              includes = params.key?(:include_only) ? included_list(params.delete(:include_only)) : ""
               fetch_paged do |page_add|
-                response = super(path + hash_to_query(params) + includes + "&#{page_add}", headers: self.default_headers).body
+                query = hash_to_query(params)
+                parts = [includes, page_add].reject(&:blank?)
+                separator = query.empty? ? "?" : "&"
+                full_path = parts.empty? ? path + query : path + query + separator + parts.join("&")
+                response = super(full_path, headers: self.default_headers).body
                 JSON.parse(response).map(&:with_indifferent_access)
               end
             end
@@ -49,7 +53,7 @@ module Katello
             headers = self.default_headers
             headers['content-type'] = 'text/plain'
             response = self.post(url, raw_json, headers: headers)
-            JSON.parse(response).with_indifferent_access
+            JSON.parse(response.body).with_indifferent_access
           end
 
           def hypervisors_heartbeat(owner:, reporter_id:)
@@ -125,6 +129,8 @@ module Katello
           # id : UUID of the consumer
           # content_overrides => Array of entitlement hashes objects
           def update_content_overrides(id, content_overrides)
+            return [] if content_overrides.empty?
+
             attrs_to_delete = []
             attrs_to_update = []
             content_overrides.each do |content_override|
@@ -147,7 +153,7 @@ module Katello
                 payload: attrs_to_delete.to_json
               )
             end
-            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result))
+            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result.body))
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/consumer.rb
+++ b/app/lib/katello/resources/candlepin/consumer.rb
@@ -15,17 +15,22 @@ module Katello
 
           def get(params)
             if params.is_a?(String)
-              JSON.parse(super(path(params), headers: self.default_headers).body).with_indifferent_access
+              parse_json(super(path(params), headers: self.default_headers))
             else
-              includes = params.key?(:include_only) ? included_list(params.delete(:include_only)) : ""
-              fetch_paged do |page_add|
-                query = hash_to_query(params)
-                parts = [includes, page_add].reject(&:blank?)
-                separator = query.empty? ? "?" : "&"
-                full_path = parts.empty? ? path + query : path + query + separator + parts.join("&")
+              params = params.dup
+              includes = params.delete(:include_only) || []
+              page_size = SETTINGS[:katello][:candlepin][:bulk_load_size]
+              page = 0
+              content = []
+              loop do
+                page += 1
+                full_path = build_path(path, params: params, includes: includes, page: page, page_size: page_size)
                 response = super(full_path, headers: self.default_headers).body
-                JSON.parse(response).map(&:with_indifferent_access)
+                data = JSON.parse(response).map(&:with_indifferent_access)
+                content.concat(data)
+                break if data.size < page_size
               end
+              content
             end
           end
 
@@ -129,31 +134,7 @@ module Katello
           # id : UUID of the consumer
           # content_overrides => Array of entitlement hashes objects
           def update_content_overrides(id, content_overrides)
-            return [] if content_overrides.empty?
-
-            attrs_to_delete = []
-            attrs_to_update = []
-            content_overrides.each do |content_override|
-              if content_override[:value]
-                attrs_to_update << content_override
-              else
-                attrs_to_delete << content_override
-              end
-            end
-
-            if attrs_to_update.present?
-              result = Candlepin::CandlepinResource.put(join_path(path(id), 'content_overrides'),
-                                                        attrs_to_update.to_json, headers: self.default_headers)
-            end
-            if attrs_to_delete.present?
-              result = Candlepin::CandlepinResource.issue_request(
-                method: :delete,
-                path: join_path(path(id), 'content_overrides'),
-                headers: self.default_headers,
-                payload: attrs_to_delete.to_json
-              )
-            end
-            ::Katello::Util::Data.array_with_indifferent_access(JSON.parse(result.body))
+            update_content_overrides_for(path(id), id, content_overrides)
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/content.rb
+++ b/app/lib/katello/resources/candlepin/content.rb
@@ -23,7 +23,7 @@ module Katello
 
             begin
               self.delete(path(owner_label, id), self.default_headers).status
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               raise e unless e.code == '404'
               # this is OK
               :content_gone

--- a/app/lib/katello/resources/candlepin/content.rb
+++ b/app/lib/katello/resources/candlepin/content.rb
@@ -22,8 +22,9 @@ module Katello
             fail ArgumentError, "content id has to be specified" unless id
 
             begin
-              self.delete(path(owner_label, id), self.default_headers).code.to_i
-            rescue RestClient::NotFound
+              self.delete(path(owner_label, id), self.default_headers).status
+            rescue HttpResource::RestClientException => e
+              raise e unless e.code == '404'
               # this is OK
               :content_gone
             end

--- a/app/lib/katello/resources/candlepin/content.rb
+++ b/app/lib/katello/resources/candlepin/content.rb
@@ -4,17 +4,17 @@ module Katello
       class Content < CandlepinResource
         class << self
           def create(owner_label, attrs)
-            JSON.parse(self.post(path(owner_label), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+            JSON.parse(self.post(path(owner_label), JSON.generate(attrs), headers: self.default_headers).body).with_indifferent_access
           end
 
           def get(owner_label, id)
-            content_json = super(path(owner_label, id), self.default_headers).body
+            content_json = super(path(owner_label, id), headers: self.default_headers).body
             JSON.parse(content_json).with_indifferent_access
           end
 
           def all(owner_label, include_only: nil)
             includes = include_only ? "?#{included_list(include_only)}" : ""
-            content_json = Candlepin::CandlepinResource.get(path(owner_label) + includes, self.default_headers).body
+            content_json = Candlepin::CandlepinResource.get(path(owner_label) + includes, headers: self.default_headers).body
             JSON.parse(content_json)
           end
 
@@ -22,7 +22,7 @@ module Katello
             fail ArgumentError, "content id has to be specified" unless id
 
             begin
-              self.delete(path(owner_label, id), self.default_headers).status
+              self.delete(path(owner_label, id), headers: self.default_headers).status
             rescue HttpResource::HttpError => e
               raise e unless e.code == '404'
               # this is OK
@@ -31,7 +31,7 @@ module Katello
           end
 
           def update(owner_label, attrs)
-            JSON.parse(self.put(path(owner_label, attrs[:id] || attrs['id']), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+            JSON.parse(self.put(path(owner_label, attrs[:id] || attrs['id']), JSON.generate(attrs), headers: self.default_headers).body).with_indifferent_access
           end
 
           def path(owner_label, id = nil)

--- a/app/lib/katello/resources/candlepin/environment.rb
+++ b/app/lib/katello/resources/candlepin/environment.rb
@@ -19,9 +19,10 @@ module Katello
           end
 
           def destroy(id)
-            self.delete(path(id), User.cp_oauth_header).code.to_i
-          rescue RestClient::NotFound => e
-            raise ::Katello::Errors::CandlepinEnvironmentGone, e.message
+            self.delete(path(id), User.cp_oauth_header).status
+          rescue HttpResource::RestClientException => e
+            raise ::Katello::Errors::CandlepinEnvironmentGone, e.message if e.code == '404'
+            raise e
           end
 
           def path(id = '')
@@ -37,7 +38,7 @@ module Katello
           def delete_content(env_id, content_ids)
             path = self.path(env_id) + "/content"
             params = content_ids.map { |content_id| {:content => content_id}.to_param }.join("&")
-            self.delete("#{path}?#{params}", self.default_headers).code.to_i
+            self.delete("#{path}?#{params}", self.default_headers).status
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/environment.rb
+++ b/app/lib/katello/resources/candlepin/environment.rb
@@ -20,7 +20,7 @@ module Katello
 
           def destroy(id)
             self.delete(path(id), User.cp_oauth_header).status
-          rescue HttpResource::RestClientException => e
+          rescue HttpResource::HttpError => e
             raise ::Katello::Errors::CandlepinEnvironmentGone, e.message if e.code == '404'
             raise e
           end

--- a/app/lib/katello/resources/candlepin/environment.rb
+++ b/app/lib/katello/resources/candlepin/environment.rb
@@ -4,22 +4,22 @@ module Katello
       class Environment < CandlepinResource
         class << self
           def find(id)
-            JSON.parse(self.get(path(id), self.default_headers).body).with_indifferent_access
+            JSON.parse(self.get(path(id), headers: self.default_headers).body).with_indifferent_access
           end
 
           def all
-            JSON.parse(self.get(path, self.default_headers).body).collect { |a| a.with_indifferent_access }
+            JSON.parse(self.get(path, headers: self.default_headers).body).collect { |a| a.with_indifferent_access }
           end
 
           def create(owner_id, id, name, description)
             attrs = {:id => id, :name => name, :description => description}
             path = "/candlepin/owners/#{owner_id}/environments"
-            environment_json = self.post(path, attrs.to_json, self.default_headers).body
+            environment_json = self.post(path, attrs.to_json, headers: self.default_headers).body
             JSON.parse(environment_json).with_indifferent_access
           end
 
           def destroy(id)
-            self.delete(path(id), User.cp_oauth_header).status
+            self.delete(path(id), headers: User.cp_oauth_header).status
           rescue HttpResource::HttpError => e
             raise ::Katello::Errors::CandlepinEnvironmentGone, e.message if e.code == '404'
             raise e
@@ -32,13 +32,13 @@ module Katello
           def add_content(env_id, content_ids)
             path = self.path(env_id) + "/content"
             params = content_ids.map { |content_id| {:contentId => content_id} }
-            JSON.parse(self.post(path, params.to_json, self.default_headers).body).with_indifferent_access
+            JSON.parse(self.post(path, params.to_json, headers: self.default_headers).body).with_indifferent_access
           end
 
           def delete_content(env_id, content_ids)
             path = self.path(env_id) + "/content"
             params = content_ids.map { |content_id| {:content => content_id}.to_param }.join("&")
-            self.delete("#{path}?#{params}", self.default_headers).status
+            self.delete("#{path}?#{params}", headers: self.default_headers).status
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/job.rb
+++ b/app/lib/katello/resources/candlepin/job.rb
@@ -10,7 +10,7 @@ module Katello
           end
 
           def get(id, params = {})
-            job_json = super(path(id) + hash_to_query(params), self.default_headers).body
+            job_json = super(path(id) + hash_to_query(params), headers: self.default_headers).body
             job = JSON.parse(job_json)
             job.with_indifferent_access
           end

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -6,7 +6,7 @@ module Katello
 
         class << self
           def all
-            response = self.get(path, default_headers)
+            response = self.get(path, headers: default_headers)
             JSON.parse(response.body)
           end
 
@@ -20,7 +20,7 @@ module Katello
               :contentAccessMode => 'org_environment',
               :contentAccessModeList => 'org_environment',
             }
-            owner_json = self.post(path, attrs.to_json, self.default_headers).body
+            owner_json = self.post(path, attrs.to_json, headers: self.default_headers).body
             JSON.parse(owner_json).with_indifferent_access
           end
 
@@ -31,11 +31,11 @@ module Katello
           end
 
           def destroy(key)
-            self.delete(path(key), User.cp_oauth_header).status
+            self.delete(path(key), headers: User.cp_oauth_header).status
           end
 
           def find(key)
-            owner_json = self.get(path(key), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+            owner_json = self.get(path(key), headers: {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
             JSON.parse(owner_json).with_indifferent_access
           end
 
@@ -46,7 +46,7 @@ module Katello
               :contentAccessMode => 'org_environment',
               :contentAccessModeList => 'org_environment'
             )
-            self.put(path(key), JSON.generate(owner), self.default_headers).body
+            self.put(path(key), JSON.generate(owner), headers: self.default_headers).body
           end
 
           def import(organization_name, path_to_file, options)
@@ -75,12 +75,12 @@ module Katello
           end
 
           def destroy_imports(organization_name, wait_until_complete: false)
-            response_json = self.delete(join_path(path(organization_name), 'imports'), self.default_headers)
+            response_json = self.delete(join_path(path(organization_name), 'imports'), headers: self.default_headers)
             response = JSON.parse(response_json).with_indifferent_access
             if wait_until_complete && response['state'] == 'CREATED'
               while !response['state'].nil? && response['state'] != 'FINISHED' && response['state'] != 'ERROR'
                 path = join_path('candlepin', response['statusPath'][1..])
-                response_json = self.get(path, self.default_headers)
+                response_json = self.get(path, headers: self.default_headers)
                 response = JSON.parse(response_json).with_indifferent_access
               end
             end
@@ -89,7 +89,7 @@ module Katello
           end
 
           def imports(organization_name)
-            imports_json = self.get(join_path(path(organization_name), 'imports'), self.default_headers)
+            imports_json = self.get(join_path(path(organization_name), 'imports'), headers: self.default_headers)
             ::Katello::Util::Data.array_with_indifferent_access JSON.parse(imports_json)
           end
 
@@ -99,25 +99,25 @@ module Katello
             if owner_label
               # hash_to_query escapes the ":!" to "%3A%21" which candlepin rejects
               params += '&attribute=unmapped_guests_only:!true'
-              json_str = self.get(join_path(path(owner_label), 'pools') + params, self.default_headers).body
+              json_str = self.get(join_path(path(owner_label), 'pools') + params, headers: self.default_headers).body
             else
-              json_str = self.get(join_path('candlepin', 'pools') + params, self.default_headers).body
+              json_str = self.get(join_path('candlepin', 'pools') + params, headers: self.default_headers).body
             end
             ::Katello::Util::Data.array_with_indifferent_access JSON.parse(json_str)
           end
 
           def statistics(key)
-            json_str = self.get(join_path(path(key), 'statistics'), self.default_headers).body
+            json_str = self.get(join_path(path(key), 'statistics'), headers: self.default_headers).body
             ::Katello::Util::Data.array_with_indifferent_access JSON.parse(json_str)
           end
 
           def generate_ueber_cert(key)
-            ueber_cert_json = self.post(join_path(path(key), "uebercert"), {}.to_json, self.default_headers).body
+            ueber_cert_json = self.post(join_path(path(key), "uebercert"), {}.to_json, headers: self.default_headers).body
             JSON.parse(ueber_cert_json).with_indifferent_access
           end
 
           def get_ueber_cert(key)
-            ueber_cert_json = self.get(join_path(path(key), "uebercert"), {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
+            ueber_cert_json = self.get(join_path(path(key), "uebercert"), headers: {'accept' => 'application/json'}.merge(User.cp_oauth_header)).body
             JSON.parse(ueber_cert_json).with_indifferent_access
           end
 
@@ -129,7 +129,7 @@ module Katello
           end
 
           def service_levels(uuid)
-            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'servicelevels'), self.default_headers).body
+            response = Candlepin::CandlepinResource.get(join_path(path(uuid), 'servicelevels'), headers: self.default_headers).body
             if response.empty?
               return []
             else
@@ -138,7 +138,7 @@ module Katello
           end
 
           def system_purpose(key)
-            response = Candlepin::CandlepinResource.get(join_path(path(key), 'system_purpose'), self.default_headers).body
+            response = Candlepin::CandlepinResource.get(join_path(path(key), 'system_purpose'), headers: self.default_headers).body
             if response.empty?
               return []
             else

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -49,6 +49,8 @@ module Katello
             self.put(path(key), JSON.generate(owner), headers: self.default_headers).body
           end
 
+          # Multipart upload — uses its own Faraday connection with f.request :multipart
+          # instead of issue_request, which only handles string/JSON payloads.
           def import(organization_name, path_to_file, options)
             path = join_path(path(organization_name), 'imports/async')
             if options[:force] || SETTINGS[:katello].key?(:force_manifest_import)

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -59,6 +59,7 @@ module Katello
 
             conn = Faraday.new(url: self.site) do |f|
               f.request :multipart
+              f.options.open_timeout = SETTINGS[:katello][:rest_client_timeout]
               f.options.timeout = SETTINGS[:katello][:rest_client_timeout]
               f.ssl.ca_file = self.ssl_ca_file if self.ssl_ca_file
               f.adapter :net_http_persistent
@@ -77,13 +78,11 @@ module Katello
           end
 
           def destroy_imports(organization_name, wait_until_complete: false)
-            response_json = self.delete(join_path(path(organization_name), 'imports'), headers: self.default_headers)
-            response = JSON.parse(response_json).with_indifferent_access
+            response = JSON.parse(self.delete(join_path(path(organization_name), 'imports'), headers: self.default_headers).body).with_indifferent_access
             if wait_until_complete && response['state'] == 'CREATED'
               while !response['state'].nil? && response['state'] != 'FINISHED' && response['state'] != 'ERROR'
                 path = join_path('candlepin', response['statusPath'][1..])
-                response_json = self.get(path, headers: self.default_headers)
-                response = JSON.parse(response_json).with_indifferent_access
+                response = JSON.parse(self.get(path, headers: self.default_headers).body).with_indifferent_access
               end
             end
 
@@ -91,8 +90,7 @@ module Katello
           end
 
           def imports(organization_name)
-            imports_json = self.get(join_path(path(organization_name), 'imports'), headers: self.default_headers)
-            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(imports_json)
+            ::Katello::Util::Data.array_with_indifferent_access JSON.parse(self.get(join_path(path(organization_name), 'imports'), headers: self.default_headers).body)
           end
 
           def pools(owner_label, filter = {})

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -31,7 +31,7 @@ module Katello
           end
 
           def destroy(key)
-            self.delete(path(key), User.cp_oauth_header).code.to_i
+            self.delete(path(key), User.cp_oauth_header).status
           end
 
           def find(key)
@@ -55,8 +55,19 @@ module Katello
               path += "?force=#{SETTINGS[:katello][:force_manifest_import]}"
             end
 
-            response = self.post(path, {:import => File.new(path_to_file, 'rb')}, self.default_headers.except('content-type'))
-            JSON.parse(response)
+            conn = Faraday.new(url: self.site) do |f|
+              f.request :multipart
+              f.options.timeout = SETTINGS[:katello][:rest_client_timeout]
+              f.ssl.ca_file = self.ssl_ca_file if self.ssl_ca_file
+              f.adapter :net_http_persistent
+            end
+            payload = { :import => Faraday::Multipart::FilePart.new(path_to_file, 'application/zip') }
+            headers = self.default_headers.except('content-type')
+            response = conn.post(path, payload) do |req|
+              sign_request(req, self.site + path, :post)
+              req.headers.merge!(headers)
+            end
+            JSON.parse(response.body)
           end
 
           def product_content(organization_name)

--- a/app/lib/katello/resources/candlepin/pool.rb
+++ b/app/lib/katello/resources/candlepin/pool.rb
@@ -19,8 +19,9 @@ module Katello
           def find(pool_id)
             begin
               pool_json = self.get(path(pool_id), self.default_headers).body
-            rescue RestClient::ResourceNotFound
-              raise Katello::Errors::CandlepinPoolGone
+            rescue HttpResource::RestClientException => e
+              raise Katello::Errors::CandlepinPoolGone if e.code == '404'
+              raise e
             end
 
             JSON.parse(pool_json).with_indifferent_access
@@ -28,7 +29,7 @@ module Katello
 
           def destroy(id)
             fail ArgumentError, "pool id has to be specified" unless id
-            self.delete(path(id), self.default_headers).code.to_i
+            self.delete(path(id), self.default_headers).status
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/pool.rb
+++ b/app/lib/katello/resources/candlepin/pool.rb
@@ -8,17 +8,17 @@ module Katello
           def get_for_owner(owner_key, include_temporary_guests = false)
             url = "#{prefix}/owners/#{owner_key}/pools?add_future=true"
             url += "&attribute=unmapped_guests_only:!true" if include_temporary_guests
-            pools_json = self.get(url, self.default_headers).body
+            pools_json = self.get(url, headers: self.default_headers).body
             JSON.parse(pools_json)
           end
 
           def create(owner_key, attrs)
-            self.post("/candlepin/owners/#{owner_key}/pools", attrs.to_json, self.default_headers).body
+            self.post("/candlepin/owners/#{owner_key}/pools", attrs.to_json, headers: self.default_headers).body
           end
 
           def find(pool_id)
             begin
-              pool_json = self.get(path(pool_id), self.default_headers).body
+              pool_json = self.get(path(pool_id), headers: self.default_headers).body
             rescue HttpResource::HttpError => e
               raise Katello::Errors::CandlepinPoolGone if e.code == '404'
               raise e
@@ -29,7 +29,7 @@ module Katello
 
           def destroy(id)
             fail ArgumentError, "pool id has to be specified" unless id
-            self.delete(path(id), self.default_headers).status
+            self.delete(path(id), headers: self.default_headers).status
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/pool.rb
+++ b/app/lib/katello/resources/candlepin/pool.rb
@@ -19,7 +19,7 @@ module Katello
           def find(pool_id)
             begin
               pool_json = self.get(path(pool_id), self.default_headers).body
-            rescue HttpResource::RestClientException => e
+            rescue HttpResource::HttpError => e
               raise Katello::Errors::CandlepinPoolGone if e.code == '404'
               raise e
             end

--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -5,7 +5,7 @@ module Katello
         class << self
           def all(owner_label, included = [])
             url = path(owner_label) + "?active=include" + "&#{included_list(included)}"
-            products = JSON.parse(Candlepin::CandlepinResource.get(url, self.default_headers).body)
+            products = JSON.parse(Candlepin::CandlepinResource.get(url, headers: self.default_headers).body)
             ::Katello::Util::Data.array_with_indifferent_access products
           end
 
@@ -19,11 +19,11 @@ module Katello
           end
 
           def create(owner_label, attr)
-            JSON.parse(self.post(path(owner_label), attr.to_json, self.default_headers).body).with_indifferent_access
+            JSON.parse(self.post(path(owner_label), attr.to_json, headers: self.default_headers).body).with_indifferent_access
           end
 
           def get(owner_label, id = nil, included = [])
-            products_json = super(path(owner_label, id + "/?#{included_list(included)}"), self.default_headers).body
+            products_json = super(path(owner_label, id + "/?#{included_list(included)}"), headers: self.default_headers).body
             products = JSON.parse(products_json)
             products = [products] unless id.nil?
             ::Katello::Util::Data.array_with_indifferent_access products
@@ -34,7 +34,7 @@ module Katello
                           derivedProvidedProducts.id startDate)
             subscriptions_json = Candlepin::CandlepinResource.get(
               "/candlepin/owners/#{owner}/subscriptions?#{included_list(included)}",
-              self.default_headers
+              headers: self.default_headers
             ).body
             subscriptions = JSON.parse(subscriptions_json)
 
@@ -60,11 +60,11 @@ module Katello
 
           def destroy(owner_label, product_id)
             fail ArgumentError, "product id has to be specified" unless product_id
-            self.delete(path(owner_label, product_id), self.default_headers).status
+            self.delete(path(owner_label, product_id), headers: self.default_headers).status
           end
 
           def add_content(owner_label, product_id, content_id, enabled)
-            self.post(join_path(path(owner_label, product_id), "content/#{content_id}?enabled=#{enabled}"), nil, self.default_headers).status
+            self.post(join_path(path(owner_label, product_id), "content/#{content_id}?enabled=#{enabled}"), nil, headers: self.default_headers).status
           end
 
           def remove_content(owner_label, product_id, content_id)
@@ -117,7 +117,7 @@ module Katello
           end
 
           def update(owner_label, attrs)
-            JSON.parse(self.put(path(owner_label, attrs[:id] || attrs['id']), JSON.generate(attrs), self.default_headers).body).with_indifferent_access
+            JSON.parse(self.put(path(owner_label, attrs[:id] || attrs['id']), JSON.generate(attrs), headers: self.default_headers).body).with_indifferent_access
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -68,7 +68,7 @@ module Katello
           end
 
           def remove_content(owner_label, product_id, content_id)
-            self.delete(join_path(path(owner_label, product_id), "content/#{content_id}"), self.default_headers).status
+            self.delete(join_path(path(owner_label, product_id), "content/#{content_id}"), headers: self.default_headers).status
           end
 
           def create_unlimited_subscription(owner_key, product_id, start_date)

--- a/app/lib/katello/resources/candlepin/product.rb
+++ b/app/lib/katello/resources/candlepin/product.rb
@@ -60,15 +60,15 @@ module Katello
 
           def destroy(owner_label, product_id)
             fail ArgumentError, "product id has to be specified" unless product_id
-            self.delete(path(owner_label, product_id), self.default_headers).code.to_i
+            self.delete(path(owner_label, product_id), self.default_headers).status
           end
 
           def add_content(owner_label, product_id, content_id, enabled)
-            self.post(join_path(path(owner_label, product_id), "content/#{content_id}?enabled=#{enabled}"), nil, self.default_headers).code.to_i
+            self.post(join_path(path(owner_label, product_id), "content/#{content_id}?enabled=#{enabled}"), nil, self.default_headers).status
           end
 
           def remove_content(owner_label, product_id, content_id)
-            self.delete(join_path(path(owner_label, product_id), "content/#{content_id}"), self.default_headers).code.to_i
+            self.delete(join_path(path(owner_label, product_id), "content/#{content_id}"), self.default_headers).status
           end
 
           def create_unlimited_subscription(owner_key, product_id, start_date)

--- a/app/lib/katello/resources/candlepin/proxy.rb
+++ b/app/lib/katello/resources/candlepin/proxy.rb
@@ -2,37 +2,44 @@ module Katello
   module Resources
     module Candlepin
       class Proxy
-        def self.logger
-          ::Foreman::Logging.logger('katello/cp_proxy')
-        end
+        class << self
+          def get(path, extra_headers = {})
+            CandlepinResource.issue_request(
+              method: :get,
+              path: CandlepinResource.prefix + path,
+              headers: CandlepinResource.default_headers.merge(extra_headers),
+              process: false
+            )
+          end
 
-        def self.get(path, extra_headers = {})
-          proxy_request(:get, path, headers: extra_headers)
-        end
+          def post(path, body)
+            CandlepinResource.issue_request(
+              method: :post,
+              path: CandlepinResource.prefix + path,
+              headers: CandlepinResource.default_headers,
+              payload: body,
+              process: false
+            )
+          end
 
-        def self.post(path, body)
-          proxy_request(:post, path, body: body)
-        end
+          def put(path, body)
+            CandlepinResource.issue_request(
+              method: :put,
+              path: CandlepinResource.prefix + path,
+              headers: CandlepinResource.default_headers,
+              payload: body,
+              process: false
+            )
+          end
 
-        def self.put(path, body)
-          proxy_request(:put, path, body: body)
-        end
-
-        def self.delete(path, body = nil)
-          proxy_request(:delete, path, body: body)
-        end
-
-        def self.proxy_request(method, path, body: nil, headers: {})
-          logger.debug "Sending #{method.upcase} request to Candlepin: #{path}"
-          full_path = CandlepinResource.prefix + path
-          headers = HttpResource.stringify_headers(
-            CandlepinResource.default_headers.merge(headers)
-          )
-
-          CandlepinResource.faraday_connection.send(method, full_path) do |req|
-            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, method)
-            req.headers.merge!(headers)
-            req.body = body if body
+          def delete(path, body = nil)
+            CandlepinResource.issue_request(
+              method: :delete,
+              path: CandlepinResource.prefix + path,
+              headers: CandlepinResource.default_headers,
+              payload: body,
+              process: false
+            )
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/proxy.rb
+++ b/app/lib/katello/resources/candlepin/proxy.rb
@@ -4,40 +4,29 @@ module Katello
       class Proxy
         class << self
           def get(path, extra_headers = {})
-            CandlepinResource.issue_request(
-              method: :get,
-              path: CandlepinResource.prefix + path,
-              headers: CandlepinResource.default_headers.merge(extra_headers),
-              process: false
-            )
+            issue_proxy(:get, path, headers: extra_headers)
           end
 
           def post(path, body)
-            CandlepinResource.issue_request(
-              method: :post,
-              path: CandlepinResource.prefix + path,
-              headers: CandlepinResource.default_headers,
-              payload: body,
-              process: false
-            )
+            issue_proxy(:post, path, payload: body)
           end
 
           def put(path, body)
-            CandlepinResource.issue_request(
-              method: :put,
-              path: CandlepinResource.prefix + path,
-              headers: CandlepinResource.default_headers,
-              payload: body,
-              process: false
-            )
+            issue_proxy(:put, path, payload: body)
           end
 
           def delete(path, body = nil)
+            issue_proxy(:delete, path, payload: body)
+          end
+
+          private
+
+          def issue_proxy(method, path, payload: nil, headers: {})
             CandlepinResource.issue_request(
-              method: :delete,
+              method: method,
               path: CandlepinResource.prefix + path,
-              headers: CandlepinResource.default_headers,
-              payload: body,
+              headers: CandlepinResource.default_headers.merge(headers),
+              payload: payload,
               process: false
             )
           end

--- a/app/lib/katello/resources/candlepin/proxy.rb
+++ b/app/lib/katello/resources/candlepin/proxy.rb
@@ -8,30 +8,45 @@ module Katello
 
         def self.post(path, body)
           logger.debug "Sending POST request to Candlepin: #{path}"
-          client = CandlepinResource.rest_client(Net::HTTP::Post, :post, path_with_cp_prefix(path))
-          client.post body, {:accept => :json, :content_type => :json}.merge(User.cp_oauth_header)
+          conn = CandlepinResource.faraday_connection
+          full_path = path_with_cp_prefix(path)
+          conn.post(full_path) do |req|
+            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :post)
+            req.headers.merge!(stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
+            req.body = body
+          end
         end
 
         def self.delete(path, body = nil)
           logger.debug "Sending DELETE request to Candlepin: #{path}"
-          client = CandlepinResource.rest_client(Net::HTTP::Delete, :delete, path_with_cp_prefix(path))
-          # Some candlepin calls will set the body in DELETE requests.
-          client.options[:payload] = body unless body.nil?
-          client.delete({:accept => :json, :content_type => :json}.merge(User.cp_oauth_header))
+          conn = CandlepinResource.faraday_connection
+          full_path = path_with_cp_prefix(path)
+          conn.delete(full_path) do |req|
+            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :delete)
+            req.headers.merge!(stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
+            req.body = body unless body.nil?
+          end
         end
 
         def self.get(path, extra_headers = {})
           logger.debug "Sending GET request to Candlepin: #{path}"
-          client = CandlepinResource.rest_client(Net::HTTP::Get, :get, path_with_cp_prefix(path))
-          client.get(extra_headers.merge!(default_request_headers))
-        rescue RestClient::NotModified => e
-          e.response
+          conn = CandlepinResource.faraday_connection
+          full_path = path_with_cp_prefix(path)
+          conn.get(full_path) do |req|
+            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :get)
+            req.headers.merge!(stringify_headers(extra_headers.merge!(default_request_headers)))
+          end
         end
 
         def self.put(path, body)
           logger.debug "Sending PUT request to Candlepin: #{path}"
-          client = CandlepinResource.rest_client(Net::HTTP::Put, :put, path_with_cp_prefix(path))
-          client.put body, {:accept => :json, :content_type => :json}.merge(User.cp_oauth_header)
+          conn = CandlepinResource.faraday_connection
+          full_path = path_with_cp_prefix(path)
+          conn.put(full_path) do |req|
+            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :put)
+            req.headers.merge!(stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
+            req.body = body
+          end
         end
 
         def self.path_with_cp_prefix(path)
@@ -39,7 +54,11 @@ module Katello
         end
 
         def self.default_request_headers
-          @default_request_headers ||= User.cp_oauth_header.merge(accept: :json)
+          User.cp_oauth_header.merge('accept' => 'application/json')
+        end
+
+        def self.stringify_headers(headers)
+          HttpResource.stringify_headers(headers)
         end
       end
     end

--- a/app/lib/katello/resources/candlepin/proxy.rb
+++ b/app/lib/katello/resources/candlepin/proxy.rb
@@ -26,9 +26,8 @@ module Katello
           logger.debug "Sending #{method.upcase} request to Candlepin: #{path}"
           full_path = CandlepinResource.prefix + path
           headers = HttpResource.stringify_headers(
-            headers.merge('accept' => 'application/json').merge(User.cp_oauth_header)
+            CandlepinResource.default_headers.merge(headers)
           )
-          headers['content-type'] = 'application/json' unless method == :get
 
           CandlepinResource.faraday_connection.send(method, full_path) do |req|
             CandlepinResource.sign_request(req, CandlepinResource.site + full_path, method)

--- a/app/lib/katello/resources/candlepin/proxy.rb
+++ b/app/lib/katello/resources/candlepin/proxy.rb
@@ -6,59 +6,35 @@ module Katello
           ::Foreman::Logging.logger('katello/cp_proxy')
         end
 
-        def self.post(path, body)
-          logger.debug "Sending POST request to Candlepin: #{path}"
-          conn = CandlepinResource.faraday_connection
-          full_path = path_with_cp_prefix(path)
-          conn.post(full_path) do |req|
-            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :post)
-            req.headers.merge!(stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
-            req.body = body
-          end
-        end
-
-        def self.delete(path, body = nil)
-          logger.debug "Sending DELETE request to Candlepin: #{path}"
-          conn = CandlepinResource.faraday_connection
-          full_path = path_with_cp_prefix(path)
-          conn.delete(full_path) do |req|
-            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :delete)
-            req.headers.merge!(stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
-            req.body = body unless body.nil?
-          end
-        end
-
         def self.get(path, extra_headers = {})
-          logger.debug "Sending GET request to Candlepin: #{path}"
-          conn = CandlepinResource.faraday_connection
-          full_path = path_with_cp_prefix(path)
-          conn.get(full_path) do |req|
-            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :get)
-            req.headers.merge!(stringify_headers(extra_headers.merge!(default_request_headers)))
-          end
+          proxy_request(:get, path, headers: extra_headers)
+        end
+
+        def self.post(path, body)
+          proxy_request(:post, path, body: body)
         end
 
         def self.put(path, body)
-          logger.debug "Sending PUT request to Candlepin: #{path}"
-          conn = CandlepinResource.faraday_connection
-          full_path = path_with_cp_prefix(path)
-          conn.put(full_path) do |req|
-            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, :put)
-            req.headers.merge!(stringify_headers({'accept' => 'application/json', 'content-type' => 'application/json'}.merge(User.cp_oauth_header)))
-            req.body = body
+          proxy_request(:put, path, body: body)
+        end
+
+        def self.delete(path, body = nil)
+          proxy_request(:delete, path, body: body)
+        end
+
+        def self.proxy_request(method, path, body: nil, headers: {})
+          logger.debug "Sending #{method.upcase} request to Candlepin: #{path}"
+          full_path = CandlepinResource.prefix + path
+          headers = HttpResource.stringify_headers(
+            headers.merge('accept' => 'application/json').merge(User.cp_oauth_header)
+          )
+          headers['content-type'] = 'application/json' unless method == :get
+
+          CandlepinResource.faraday_connection.send(method, full_path) do |req|
+            CandlepinResource.sign_request(req, CandlepinResource.site + full_path, method)
+            req.headers.merge!(headers)
+            req.body = body if body
           end
-        end
-
-        def self.path_with_cp_prefix(path)
-          CandlepinResource.prefix + path
-        end
-
-        def self.default_request_headers
-          User.cp_oauth_header.merge('accept' => 'application/json')
-        end
-
-        def self.stringify_headers(headers)
-          HttpResource.stringify_headers(headers)
         end
       end
     end

--- a/app/lib/katello/resources/candlepin/subscription.rb
+++ b/app/lib/katello/resources/candlepin/subscription.rb
@@ -5,18 +5,18 @@ module Katello
         class << self
           def destroy(subscription_id)
             fail ArgumentError, "subscription id has to be specified" unless subscription_id
-            self.delete(path(subscription_id), self.default_headers).status
+            self.delete(path(subscription_id), headers: self.default_headers).status
           end
 
           def get(id = nil)
-            content_json = super(path(id), self.default_headers).body
+            content_json = super(path(id), headers: self.default_headers).body
             JSON.parse(content_json)
           end
 
           def get_for_owner(owner_key, included = [])
             content_json = Candlepin::CandlepinResource.get(
               "/candlepin/owners/#{owner_key}/subscriptions?#{included_list(included)}",
-              self.default_headers
+              headers: self.default_headers
             ).body
             JSON.parse(content_json)
           end

--- a/app/lib/katello/resources/candlepin/subscription.rb
+++ b/app/lib/katello/resources/candlepin/subscription.rb
@@ -5,7 +5,7 @@ module Katello
         class << self
           def destroy(subscription_id)
             fail ArgumentError, "subscription id has to be specified" unless subscription_id
-            self.delete(path(subscription_id), self.default_headers).code.to_i
+            self.delete(path(subscription_id), self.default_headers).status
           end
 
           def get(id = nil)

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -11,8 +11,8 @@ module Katello
 
           def ping
             response = issue_request(method: :head, path: path, headers: default_headers, process: false)
-            raise ::Katello::Errors::UpstreamConsumerGone if [401, 410].include?(response.status)
-            raise ::Katello::Errors::UpstreamConsumerNotFound if response.status == 404
+            fail ::Katello::Errors::UpstreamConsumerGone if [401, 410].include?(response.status)
+            fail ::Katello::Errors::UpstreamConsumerNotFound if response.status == 404
             response
           end
 
@@ -22,16 +22,16 @@ module Katello
             full_path = build_path(path, params: params, includes: includes)
             JSON.parse(super(full_path, headers: self.default_headers).body)
           rescue HttpResource::HttpError => e
-            raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
-            raise e
+            fail ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
+            fail e
           end
 
           def remove_entitlement(entitlement_id)
             fail ArgumentError, "No entitlement ID given to remove." if entitlement_id.blank?
             self.delete(join_path(path, "entitlements/#{entitlement_id}"), headers: self.default_headers)
           rescue HttpResource::HttpError => e
-            raise ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
-            raise e
+            fail ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
+            fail e
           end
 
           def start_upstream_export(url, client_cert, client_key, ca_file)

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -20,7 +20,7 @@ module Katello
 
           def get(params)
             includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
-            JSON.parse(super(path + hash_to_query(params) + includes, self.default_headers).body)
+            JSON.parse(super(path + hash_to_query(params) + includes, headers: self.default_headers).body)
           rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
             raise e
@@ -63,7 +63,7 @@ module Katello
 
           def bind_entitlement(**pool)
             entitlements_path = join_path(path, 'entitlements') + hash_to_query(pool)
-            response = self.post(entitlements_path, nil, self.default_headers)
+            response = self.post(entitlements_path, nil, headers: self.default_headers)
             JSON.parse(response.body)
           end
         end

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -12,7 +12,7 @@ module Katello
           def ping
             conn = resource
             conn.head(path)
-          rescue HttpResource::RestClientException => e
+          rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamConsumerGone if %w(401 410).include?(e.code)
             raise ::Katello::Errors::UpstreamConsumerNotFound if e.code == '404'
             raise e
@@ -21,7 +21,7 @@ module Katello
           def get(params)
             includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
             JSON.parse(super(path + hash_to_query(params) + includes, self.default_headers).body)
-          rescue HttpResource::RestClientException => e
+          rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
             raise e
           end
@@ -29,7 +29,7 @@ module Katello
           def remove_entitlement(entitlement_id)
             fail ArgumentError, "No entitlement ID given to remove." if entitlement_id.blank?
             self.delete(join_path(path, "entitlements/#{entitlement_id}"), self.default_headers)
-          rescue HttpResource::RestClientException => e
+          rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
             raise e
           end

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -22,16 +22,16 @@ module Katello
             full_path = build_path(path, params: params, includes: includes)
             JSON.parse(super(full_path, headers: self.default_headers).body)
           rescue HttpResource::HttpError => e
-            fail ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
-            fail e
+            raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
+            raise e
           end
 
           def remove_entitlement(entitlement_id)
             fail ArgumentError, "No entitlement ID given to remove." if entitlement_id.blank?
             self.delete(join_path(path, "entitlements/#{entitlement_id}"), headers: self.default_headers)
           rescue HttpResource::HttpError => e
-            fail ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
-            fail e
+            raise ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
+            raise e
           end
 
           def start_upstream_export(url, client_cert, client_key, ca_file)

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -34,30 +34,20 @@ module Katello
           end
 
           def start_upstream_export(url, client_cert, client_key, ca_file)
-            logger.debug "Sending GET request to upstream Candlepin: #{url}"
             conn = resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
-            conn.get(URI.parse(url).request_uri)
+            issue_request(method: :get, path: URI.parse(url).request_uri, headers: default_headers, connection: conn, process: false)
           end
 
           alias_method :retrieve_upstream_export, :start_upstream_export
 
           def update(url, client_cert, client_key, ca_file, attributes)
-            logger.debug "Sending PUT request to upstream Candlepin: #{url} #{attributes.to_json}"
             conn = resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
-            conn.put(URI.parse(url).request_uri) do |req|
-              req.headers.merge!(HttpResource.stringify_headers(
-                'accept' => 'application/json',
-                'accept-language' => I18n.locale,
-                'content-type' => 'application/json'
-              ))
-              req.body = attributes.to_json
-            end
+            issue_request(method: :put, path: URI.parse(url).request_uri, headers: default_headers, payload: attributes.to_json, connection: conn, process: false)
           end
 
           def regenerate_upstream_identity(url, client_cert, client_key, ca_file)
-            logger.debug "Sending POST request to upstream Candlepin: #{url}"
             conn = resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
-            conn.post(URI.parse(url).request_uri)
+            issue_request(method: :post, path: URI.parse(url).request_uri, headers: default_headers, connection: conn, process: false)
           end
 
           def bind_entitlement(**pool)

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -10,59 +10,61 @@ module Katello
           end
 
           def ping
-            resource.head
-          rescue RestClient::Unauthorized, RestClient::Gone
-            raise ::Katello::Errors::UpstreamConsumerGone
-          rescue RestClient::NotFound
-            raise ::Katello::Errors::UpstreamConsumerNotFound
+            conn = resource
+            conn.head(path)
+          rescue HttpResource::RestClientException => e
+            raise ::Katello::Errors::UpstreamConsumerGone if %w(401 410).include?(e.code)
+            raise ::Katello::Errors::UpstreamConsumerNotFound if e.code == '404'
+            raise e
           end
 
-          # Overrides the HttpResource get method to check if the upstream
-          # consumer exists.
           def get(params)
             includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
             JSON.parse(super(path + hash_to_query(params) + includes, self.default_headers).body)
-          rescue RestClient::Gone
-            raise ::Katello::Errors::UpstreamConsumerGone
+          rescue HttpResource::RestClientException => e
+            raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
+            raise e
           end
 
           def remove_entitlement(entitlement_id)
             fail ArgumentError, "No entitlement ID given to remove." if entitlement_id.blank?
-
-            self["entitlements/#{entitlement_id}"].delete
-          rescue RestClient::NotFound
-            raise ::Katello::Errors::UpstreamEntitlementGone
+            self.delete(join_path(path, "entitlements/#{entitlement_id}"), self.default_headers)
+          rescue HttpResource::RestClientException => e
+            raise ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
+            raise e
           end
 
           def start_upstream_export(url, client_cert, client_key, ca_file)
             logger.debug "Sending GET request to upstream Candlepin: #{url}"
-            resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).get
-          rescue RestClient::Exception => e
-            raise e
+            conn = resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
+            conn.get(URI.parse(url).request_uri)
           end
 
           alias_method :retrieve_upstream_export, :start_upstream_export
 
           def update(url, client_cert, client_key, ca_file, attributes)
             logger.debug "Sending PUT request to upstream Candlepin: #{url} #{attributes.to_json}"
-            resource(
-              url: url,
-              client_cert: client_cert,
-              client_key: client_key,
-              ca_file: ca_file).put(
-                attributes.to_json,
+            conn = resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
+            conn.put(URI.parse(url).request_uri) do |req|
+              req.headers.merge!(HttpResource.stringify_headers(
                 'accept' => 'application/json',
                 'accept-language' => I18n.locale,
-                'content-type' => 'application/json')
+                'content-type' => 'application/json'
+              ))
+              req.body = attributes.to_json
+            end
           end
 
           def regenerate_upstream_identity(url, client_cert, client_key, ca_file)
             logger.debug "Sending POST request to upstream Candlepin: #{url}"
-            resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file).post(nil)
+            conn = resource(url: url, client_cert: client_cert, client_key: client_key, ca_file: ca_file)
+            conn.post(URI.parse(url).request_uri)
           end
 
           def bind_entitlement(**pool)
-            JSON.parse(self['entitlements'].post(nil, params: pool))
+            entitlements_path = join_path(path, 'entitlements') + hash_to_query(pool)
+            response = self.post(entitlements_path, nil, self.default_headers)
+            JSON.parse(response.body)
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -17,10 +17,9 @@ module Katello
           end
 
           def get(params)
-            includes = params.key?(:include_only) ? included_list(params.delete(:include_only)) : ""
-            query = hash_to_query(params)
-            separator = query.empty? ? "?" : "&"
-            full_path = includes.empty? ? path + query : path + query + separator + includes
+            params = params.dup
+            includes = params.delete(:include_only) || []
+            full_path = build_path(path, params: params, includes: includes)
             JSON.parse(super(full_path, headers: self.default_headers).body)
           rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -10,8 +10,7 @@ module Katello
           end
 
           def ping
-            conn = resource
-            conn.head(path)
+            issue_request(method: :head, path: path, headers: default_headers, process: false)
           rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamConsumerGone if %w(401 410).include?(e.code)
             raise ::Katello::Errors::UpstreamConsumerNotFound if e.code == '404'

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -28,7 +28,7 @@ module Katello
 
           def remove_entitlement(entitlement_id)
             fail ArgumentError, "No entitlement ID given to remove." if entitlement_id.blank?
-            self.delete(join_path(path, "entitlements/#{entitlement_id}"), self.default_headers)
+            self.delete(join_path(path, "entitlements/#{entitlement_id}"), headers: self.default_headers)
           rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamEntitlementGone if e.code == '404'
             raise e

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -17,8 +17,11 @@ module Katello
           end
 
           def get(params)
-            includes = params.key?(:include_only) ? "&" + included_list(params.delete(:include_only)) : ""
-            JSON.parse(super(path + hash_to_query(params) + includes, headers: self.default_headers).body)
+            includes = params.key?(:include_only) ? included_list(params.delete(:include_only)) : ""
+            query = hash_to_query(params)
+            separator = query.empty? ? "?" : "&"
+            full_path = includes.empty? ? path + query : path + query + separator + includes
+            JSON.parse(super(full_path, headers: self.default_headers).body)
           rescue HttpResource::HttpError => e
             raise ::Katello::Errors::UpstreamConsumerGone if e.code == '410'
             raise e

--- a/app/lib/katello/resources/candlepin/upstream_consumer.rb
+++ b/app/lib/katello/resources/candlepin/upstream_consumer.rb
@@ -10,11 +10,10 @@ module Katello
           end
 
           def ping
-            issue_request(method: :head, path: path, headers: default_headers, process: false)
-          rescue HttpResource::HttpError => e
-            raise ::Katello::Errors::UpstreamConsumerGone if %w(401 410).include?(e.code)
-            raise ::Katello::Errors::UpstreamConsumerNotFound if e.code == '404'
-            raise e
+            response = issue_request(method: :head, path: path, headers: default_headers, process: false)
+            raise ::Katello::Errors::UpstreamConsumerGone if [401, 410].include?(response.status)
+            raise ::Katello::Errors::UpstreamConsumerNotFound if response.status == 404
+            response
           end
 
           def get(params)

--- a/app/lib/katello/resources/candlepin/upstream_entitlement.rb
+++ b/app/lib/katello/resources/candlepin/upstream_entitlement.rb
@@ -8,12 +8,13 @@ module Katello
           end
 
           def update(entitlement_id, quantity)
-            body = {quantity: quantity}.to_json
-            conn = resource
-            conn.put(path(entitlement_id)) do |req|
-              req.headers.merge!(HttpResource.stringify_headers(self.default_headers))
-              req.body = body
-            end
+            issue_request(
+              method: :put,
+              path: path(entitlement_id),
+              headers: default_headers,
+              payload: {quantity: quantity}.to_json,
+              process: false
+            )
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/upstream_entitlement.rb
+++ b/app/lib/katello/resources/candlepin/upstream_entitlement.rb
@@ -9,8 +9,11 @@ module Katello
 
           def update(entitlement_id, quantity)
             body = {quantity: quantity}.to_json
-
-            self[entitlement_id].put(body)
+            conn = resource
+            conn.put(path(entitlement_id)) do |req|
+              req.headers.merge!(HttpResource.stringify_headers(self.default_headers))
+              req.body = body
+            end
           end
         end
       end

--- a/app/lib/katello/resources/candlepin/upstream_job.rb
+++ b/app/lib/katello/resources/candlepin/upstream_job.rb
@@ -15,7 +15,7 @@ module Katello
             url = subscription_path(ENV['REDHAT_RHSM_API_URL']) || subscription_path(upstream['apiUrl']) || API_URL
             response = Resources::Candlepin::UpstreamConsumer.start_upstream_export("#{url}#{path(id)}", upstream['idCert']['cert'],
               upstream['idCert']['key'], nil)
-            job = JSON.parse(response)
+            job = JSON.parse(response.body)
             job.with_indifferent_access
           end
 

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -13,8 +13,13 @@ module Katello
               params: params,
               process: false
             )
-            raise Katello::Errors::UpstreamConsumerGone if response.status == 410
-            response
+            if response.status.between?(200, 299)
+              response
+            elsif [401, 410].include?(response.status)
+              fail Katello::Errors::UpstreamConsumerGone
+            else
+              process_response(response)
+            end
           end
 
           def path(id = nil, owner_label = nil)

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -7,8 +7,7 @@ module Katello
         class << self
           def get(params = [])
             conn = resource
-            query = params.empty? ? '' : "?#{URI.encode_www_form(params)}"
-            response = conn.get(path + query)
+            response = conn.get(path + query_string(params))
             raise Katello::Errors::UpstreamConsumerGone if response.status == 410
             response
           end

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -6,9 +6,10 @@ module Katello
 
         class << self
           def get(*args)
-            resource.get(*args)
-          rescue RestClient::Gone
-            raise Katello::Errors::UpstreamConsumerGone
+            conn = resource
+            response = conn.get(path, *args)
+            raise Katello::Errors::UpstreamConsumerGone if response.status == 410
+            response
           end
 
           def path(id = nil, owner_label = nil)

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -6,8 +6,13 @@ module Katello
 
         class << self
           def get(params = [])
-            conn = resource
-            response = conn.get(path + query_string(params))
+            response = issue_request(
+              method: :get,
+              path: path,
+              headers: default_headers,
+              params: params,
+              process: false
+            )
             raise Katello::Errors::UpstreamConsumerGone if response.status == 410
             response
           end

--- a/app/lib/katello/resources/candlepin/upstream_pool.rb
+++ b/app/lib/katello/resources/candlepin/upstream_pool.rb
@@ -5,9 +5,10 @@ module Katello
         extend PoolResource
 
         class << self
-          def get(*args)
+          def get(params = [])
             conn = resource
-            response = conn.get(path, *args)
+            query = params.empty? ? '' : "?#{URI.encode_www_form(params)}"
+            response = conn.get(path + query)
             raise Katello::Errors::UpstreamConsumerGone if response.status == 410
             response
           end

--- a/app/lib/katello/util/candlepin_repository_checker.rb
+++ b/app/lib/katello/util/candlepin_repository_checker.rb
@@ -37,7 +37,8 @@ module Katello
 
         ::Katello::Resources::Candlepin::Content.get(repository.organization.label, repository.content_id)
         true
-      rescue RestClient::NotFound
+      rescue HttpResource::RestClientException => e
+        raise unless e.code == '404'
         false
       end
 

--- a/app/lib/katello/util/candlepin_repository_checker.rb
+++ b/app/lib/katello/util/candlepin_repository_checker.rb
@@ -37,7 +37,7 @@ module Katello
 
         ::Katello::Resources::Candlepin::Content.get(repository.organization.label, repository.content_id)
         true
-      rescue HttpResource::RestClientException => e
+      rescue HttpResource::HttpError => e
         raise unless e.code == '404'
         false
       end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -402,7 +402,7 @@ module Katello
         when :excon
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert_filename
           config.ssl_client_key = ::Cert::Certs.ssl_client_key_filename
-        when :net_http
+        when :net_http, :net_http_persistent
           config.ssl_client_cert = ::Cert::Certs.ssl_client_cert
           config.ssl_client_key = ::Cert::Certs.ssl_client_key
         else

--- a/app/models/katello/glue/candlepin/environment.rb
+++ b/app/models/katello/glue/candlepin/environment.rb
@@ -12,7 +12,7 @@ module Katello
       def exists_in_candlepin?
         candlepin_info
         true
-      rescue HttpResource::RestClientException => e
+      rescue HttpResource::HttpError => e
         raise unless e.code == '404'
         false
       end

--- a/app/models/katello/glue/candlepin/environment.rb
+++ b/app/models/katello/glue/candlepin/environment.rb
@@ -12,7 +12,8 @@ module Katello
       def exists_in_candlepin?
         candlepin_info
         true
-      rescue RestClient::NotFound
+      rescue HttpResource::RestClientException => e
+        raise unless e.code == '404'
         false
       end
 

--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -23,7 +23,8 @@ module Katello
       def candlepin_owner_exists?
         find_owner
         true
-      rescue RestClient::ResourceNotFound
+      rescue HttpResource::RestClientException => e
+        raise unless e.code == '404'
         false
       end
 
@@ -47,7 +48,8 @@ module Katello
 
       def load_debug_cert
         return Resources::Candlepin::Owner.get_ueber_cert(label)
-      rescue RestClient::ResourceNotFound
+      rescue HttpResource::RestClientException => e
+        raise unless e.code == '404'
         return generate_debug_cert
       end
 

--- a/app/models/katello/glue/candlepin/owner.rb
+++ b/app/models/katello/glue/candlepin/owner.rb
@@ -23,7 +23,7 @@ module Katello
       def candlepin_owner_exists?
         find_owner
         true
-      rescue HttpResource::RestClientException => e
+      rescue HttpResource::HttpError => e
         raise unless e.code == '404'
         false
       end
@@ -48,7 +48,7 @@ module Katello
 
       def load_debug_cert
         return Resources::Candlepin::Owner.get_ueber_cert(label)
-      rescue HttpResource::RestClientException => e
+      rescue HttpResource::HttpError => e
         raise unless e.code == '404'
         return generate_debug_cert
       end

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -13,7 +13,7 @@ module Katello
           included_fields: included_field_params(quantities_only)
         )
 
-        upstream_response = CP_POOL.get(params: cp_params)
+        upstream_response = CP_POOL.get(cp_params)
         pools = response_to_pools(upstream_response, pool_id_map: pool_id_map)
         total = upstream_response.headers[total_count_header] || pools.count
 
@@ -42,7 +42,7 @@ module Katello
       end
 
       def response_to_pools(response, pool_id_map: {})
-        pools = JSON.parse(response)
+        pools = JSON.parse(response.body)
         if pool_id_map.empty?
           pool_id_map = Katello::Candlepin::PoolService.map_upstream_pools_to_local(pools)
         end
@@ -87,7 +87,7 @@ module Katello
         # use extra_params when you have duplicate keys
         # i.e. [[:michael, "bolton"], [:michael, "jordan"]]
         included_fields.map! { |field| [:include, field] }
-        RestClient::ParamsArray.new(base_params.to_a + extra_params + included_fields)
+        base_params.to_a + extra_params + included_fields
       end
 
       def pool_id_params(pool_ids)

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -108,7 +108,7 @@ module Katello
     private def content_exists?(org, content)
       Resources::Candlepin::Content.get(org.label, content.cp_content_id)
       true
-    rescue HttpResource::RestClientException => e
+    rescue HttpResource::HttpError => e
       raise unless e.code == '404'
       false
     end

--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -108,7 +108,8 @@ module Katello
     private def content_exists?(org, content)
       Resources::Candlepin::Content.get(org.label, content.cp_content_id)
       true
-    rescue RestClient::NotFound
+    rescue HttpResource::RestClientException => e
+      raise unless e.code == '404'
       false
     end
 

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -294,9 +294,10 @@ module Katello
       def candlepin_consumer_destroy(host_uuid)
         ::Katello::Resources::Candlepin::Consumer.destroy(host_uuid)
       rescue HttpResource::HttpError => e
-        if e.code == '404'
+        case e.code
+        when '404'
           Rails.logger.warn(_("Attempted to destroy consumer %s from candlepin, but consumer does not exist in candlepin") % host_uuid)
-        elsif e.code == '410'
+        when '410'
           Rails.logger.warn(_("Candlepin consumer %s has already been removed") % host_uuid)
         else
           raise

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -160,7 +160,8 @@ module Katello
           # provisioning information (including kickstart repository) is preserved
           begin
             unregister_host(host, :unregistering => true, :preserve_for_provisioning => true)
-          rescue RestClient::Gone
+          rescue HttpResource::RestClientException => e
+            raise unless e.code == '410'
             Rails.logger.debug("Host %s has been removed in preparation for reregistration" % host&.name)
           end
           host.reload
@@ -292,10 +293,14 @@ module Katello
 
       def candlepin_consumer_destroy(host_uuid)
         ::Katello::Resources::Candlepin::Consumer.destroy(host_uuid)
-      rescue RestClient::ResourceNotFound
-        Rails.logger.warn(_("Attempted to destroy consumer %s from candlepin, but consumer does not exist in candlepin") % host_uuid)
-      rescue RestClient::Gone
-        Rails.logger.warn(_("Candlepin consumer %s has already been removed") % host_uuid)
+      rescue HttpResource::RestClientException => e
+        if e.code == '404'
+          Rails.logger.warn(_("Attempted to destroy consumer %s from candlepin, but consumer does not exist in candlepin") % host_uuid)
+        elsif e.code == '410'
+          Rails.logger.warn(_("Candlepin consumer %s has already been removed") % host_uuid)
+        else
+          raise
+        end
       end
 
       def populate_content_facet(host, content_view_environments)

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -160,7 +160,7 @@ module Katello
           # provisioning information (including kickstart repository) is preserved
           begin
             unregister_host(host, :unregistering => true, :preserve_for_provisioning => true)
-          rescue HttpResource::RestClientException => e
+          rescue HttpResource::HttpError => e
             raise unless e.code == '410'
             Rails.logger.debug("Host %s has been removed in preparation for reregistration" % host&.name)
           end
@@ -293,7 +293,7 @@ module Katello
 
       def candlepin_consumer_destroy(host_uuid)
         ::Katello::Resources::Candlepin::Consumer.destroy(host_uuid)
-      rescue HttpResource::RestClientException => e
+      rescue HttpResource::HttpError => e
         if e.code == '404'
           Rails.logger.warn(_("Attempted to destroy consumer %s from candlepin, but consumer does not exist in candlepin") % host_uuid)
         elsif e.code == '410'

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "spidr"
 
   # Pulp dependencies
-  gem.add_dependency "faraday", ">= 2.0.0", "< 3.0.0"
+  gem.add_dependency "faraday", "~> 2.0"
   gem.add_dependency "faraday-net_http_persistent", "~> 2.0"
   gem.add_dependency "faraday-multipart", "~> 1.0"
   gem.add_dependency "pulpcore_client", ">= 3.105.0", "< 3.106.0"

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -49,8 +49,9 @@ Gem::Specification.new do |gem|
   gem.add_dependency "spidr"
 
   # Pulp dependencies
-  # faraday pin for compatibility with foreman_azure_rm
-  gem.add_dependency "faraday", ">= 1.10.2", "< 1.11.0"
+  gem.add_dependency "faraday", ">= 2.0.0", "< 3.0.0"
+  gem.add_dependency "faraday-net_http_persistent", "~> 2.0"
+  gem.add_dependency "faraday-multipart", "~> 1.0"
   gem.add_dependency "pulpcore_client", ">= 3.105.0", "< 3.106.0"
   gem.add_dependency "pulp_file_client", ">= 3.105.0", "< 3.106.0"
   gem.add_dependency "pulp_ansible_client", ">= 0.29.0", "< 0.30.0"

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -421,7 +421,7 @@ module Katello
       end
 
       it "should return Candlepin error when backend is down" do
-        ::Katello::RegistrationManager.expects(:unregister_host).raises(RestClient::ServiceUnavailable.new(nil, 503))
+        ::Katello::RegistrationManager.expects(:unregister_host).raises(HttpResource::HttpError.new(message: 'Service Unavailable', code: '503', service_code: ''))
         delete :consumer_destroy, params: { :id => @host.subscription_facet.uuid }
         assert_response 503
       end
@@ -509,7 +509,7 @@ module Katello
 
       it "does not cache on Candlepin error" do
         Rails.cache.delete(::Katello::Resources::Candlepin::CandlepinPing::CACHE_KEY)
-        Resources::Candlepin::CandlepinPing.stubs(:ping).raises(RestClient::ServiceUnavailable.new(nil, 503))
+        Resources::Candlepin::CandlepinPing.stubs(:ping).raises(HttpResource::HttpError.new(message: 'Service Unavailable', code: '503', service_code: ''))
 
         2.times do
           get :server_status

--- a/test/lib/access_permissions_test.rb
+++ b/test/lib/access_permissions_test.rb
@@ -19,6 +19,8 @@ module Katello
     KATELLO_SUB_MAN_AUTH = [
       'katello/api/rhsm/candlepin_proxies/upload_tracer_profile',
       'katello/api/rhsm/candlepin_proxies/consumer_destroy',
+      'katello/api/rhsm/candlepin_proxies/consumer_compliance',
+      'katello/api/rhsm/candlepin_proxies/consumer_purpose_compliance',
       'katello/api/rhsm/candlepin_proxies/enabled_repos',
       'katello/api/rhsm/candlepin_proxies/checkin',
       'katello/api/rhsm/candlepin_proxies/facts',

--- a/test/lib/access_permissions_test.rb
+++ b/test/lib/access_permissions_test.rb
@@ -19,8 +19,6 @@ module Katello
     KATELLO_SUB_MAN_AUTH = [
       'katello/api/rhsm/candlepin_proxies/upload_tracer_profile',
       'katello/api/rhsm/candlepin_proxies/consumer_destroy',
-      'katello/api/rhsm/candlepin_proxies/consumer_compliance',
-      'katello/api/rhsm/candlepin_proxies/consumer_purpose_compliance',
       'katello/api/rhsm/candlepin_proxies/enabled_repos',
       'katello/api/rhsm/candlepin_proxies/checkin',
       'katello/api/rhsm/candlepin_proxies/facts',

--- a/test/lib/http_resource_test.rb
+++ b/test/lib/http_resource_test.rb
@@ -9,64 +9,88 @@ module Katello
       end
     end
 
-    def test_hash_to_query_empty
-      params = {}
-
-      result = TestHttpResource.hash_to_query(params)
-
-      assert_equal "?", result
+    def setup
+      @mock_response = stub(status: 200, body: '', headers: {})
+      @mock_conn = stub
+      TestHttpResource.stubs(:faraday_connection).returns(@mock_conn)
     end
 
-    def test_hash_to_query
-      params = {
-        foo: 'fru',
-        bar: 'bru',
-        too: 'tru',
-        arr: [
-          :arr_one,
-          :arr_two,
-        ],
-      }
+    def test_query_string_empty_hash
+      assert_equal '', TestHttpResource.query_string({})
+    end
 
-      result = TestHttpResource.hash_to_query(params)
+    def test_query_string_empty_array
+      assert_equal '', TestHttpResource.query_string([])
+    end
 
-      assert_equal "?foo=fru&bar=bru&too=tru&arr=arr_one&arr=arr_two", result
+    def test_query_string_nil
+      assert_equal '', TestHttpResource.query_string(nil)
+    end
+
+    def test_query_string_hash
+      params = { foo: 'fru', bar: 'bru', arr: [:arr_one, :arr_two] }
+      result = TestHttpResource.query_string(params)
+      assert_equal "?foo=fru&bar=bru&arr=arr_one&arr=arr_two", result
+    end
+
+    def test_query_string_array_of_tuples
+      params = [[:poolid, 'abc'], [:poolid, 'def'], [:include, 'id']]
+      result = TestHttpResource.query_string(params)
+      assert_equal "?poolid=abc&poolid=def&include=id", result
+    end
+
+    def test_hash_to_query_alias
+      assert_equal "?foo=bar", TestHttpResource.hash_to_query(foo: 'bar')
     end
 
     def test_get
-      headers = { headerOne: 'headerOneValue' }
-      mock_response = stub(code: 200, body: '')
-      RestClient::Resource.any_instance.expects(:get).with(headers).returns(mock_response)
-      TestHttpResource.get('/path', headers)
+      @mock_conn.expects(:send).with(:get, '/path').yields(stub_request).returns(@mock_response)
+      TestHttpResource.get('/path', { 'headerOne' => 'headerOneValue' })
     end
 
     def test_get_no_headers
-      mock_response = stub(code: 200, body: '')
-      RestClient::Resource.any_instance.expects(:get).returns(mock_response)
+      @mock_conn.expects(:send).with(:get, '/path').yields(stub_request).returns(@mock_response)
       TestHttpResource.get('/path')
     end
 
     def test_delete
-      headers = { headerOne: 'headerOneValue' }
-      mock_response = stub(code: 200, body: '')
-      RestClient::Resource.any_instance.expects(:delete).with(headers).returns(mock_response)
-      TestHttpResource.delete('/path', headers)
+      @mock_conn.expects(:send).with(:delete, '/path').yields(stub_request).returns(@mock_response)
+      TestHttpResource.delete('/path', { 'headerOne' => 'headerOneValue' })
     end
 
     def test_put
-      headers = { headerOne: 'headerOneValue' }
-      payload = { payloadKey: 'payloadValue' }
-      mock_response = stub(code: 200, body: '')
-      RestClient::Resource.any_instance.expects(:put).with(payload, headers).returns(mock_response)
-      TestHttpResource.put('/path', payload, headers)
+      @mock_conn.expects(:send).with(:put, '/path').yields(stub_request).returns(@mock_response)
+      TestHttpResource.put('/path', { payloadKey: 'payloadValue' }, { 'headerOne' => 'headerOneValue' })
     end
 
     def test_post
-      headers = { headerOne: 'headerOneValue' }
-      payload = { payloadKey: 'payloadValue' }
-      mock_response = stub(code: 200, body: '')
-      RestClient::Resource.any_instance.expects(:post).with(payload, headers).returns(mock_response)
-      TestHttpResource.post('/path', payload, headers)
+      @mock_conn.expects(:send).with(:post, '/path').yields(stub_request).returns(@mock_response)
+      TestHttpResource.post('/path', { payloadKey: 'payloadValue' }, { 'headerOne' => 'headerOneValue' })
+    end
+
+    def test_process_response_success
+      response = stub(status: 200, body: '{"result": "ok"}')
+      result = TestHttpResource.process_response(response)
+      assert_equal response, result
+    end
+
+    def test_process_response_error
+      response = stub(status: 404, body: '{"displayMessage": "Not found"}')
+      error = assert_raises(HttpResource::HttpError) do
+        TestHttpResource.process_response(response)
+      end
+      assert_equal '404', error.code
+      assert_equal 'Not found', error.message
+      assert_equal '{"displayMessage": "Not found"}', error.response_body
+    end
+
+    private
+
+    def stub_request
+      req = stub
+      req.stubs(:headers).returns({})
+      req.stubs(:body=)
+      req
     end
   end
 end

--- a/test/lib/http_resource_test.rb
+++ b/test/lib/http_resource_test.rb
@@ -45,7 +45,7 @@ module Katello
 
     def test_get
       @mock_conn.expects(:send).with(:get, '/path').yields(stub_request).returns(@mock_response)
-      TestHttpResource.get('/path', { 'headerOne' => 'headerOneValue' })
+      TestHttpResource.get('/path', headers: { 'headerOne' => 'headerOneValue' })
     end
 
     def test_get_no_headers
@@ -53,19 +53,24 @@ module Katello
       TestHttpResource.get('/path')
     end
 
+    def test_get_with_params
+      @mock_conn.expects(:send).with(:get, '/path?foo=bar').yields(stub_request).returns(@mock_response)
+      TestHttpResource.get('/path', params: { foo: 'bar' })
+    end
+
     def test_delete
       @mock_conn.expects(:send).with(:delete, '/path').yields(stub_request).returns(@mock_response)
-      TestHttpResource.delete('/path', { 'headerOne' => 'headerOneValue' })
+      TestHttpResource.delete('/path', headers: { 'headerOne' => 'headerOneValue' })
     end
 
     def test_put
       @mock_conn.expects(:send).with(:put, '/path').yields(stub_request).returns(@mock_response)
-      TestHttpResource.put('/path', { payloadKey: 'payloadValue' }, { 'headerOne' => 'headerOneValue' })
+      TestHttpResource.put('/path', { payloadKey: 'payloadValue' }, headers: { 'headerOne' => 'headerOneValue' })
     end
 
     def test_post
       @mock_conn.expects(:send).with(:post, '/path').yields(stub_request).returns(@mock_response)
-      TestHttpResource.post('/path', { payloadKey: 'payloadValue' }, { 'headerOne' => 'headerOneValue' })
+      TestHttpResource.post('/path', { payloadKey: 'payloadValue' }, headers: { 'headerOne' => 'headerOneValue' })
     end
 
     def test_process_response_success

--- a/test/lib/http_resource_test.rb
+++ b/test/lib/http_resource_test.rb
@@ -108,6 +108,27 @@ module Katello
       assert_equal '{"displayMessage": "Not found"}', error.response_body
     end
 
+    def test_process_response_plain_text_error_preserves_body
+      response = stub(status: 500, body: 'upstream plain-text failure')
+      error = assert_raises(HttpResource::HttpError) do
+        TestHttpResource.process_response(response)
+      end
+      assert_equal '500', error.code
+      assert_equal 'upstream plain-text failure', error.message
+      assert_equal 'upstream plain-text failure', error.response_body
+    end
+
+    def test_raise_faraday_exception_without_http_response_raises_network_exception
+      error = stub(message: 'execution expired', response: nil)
+
+      network_error = assert_raises(HttpResource::NetworkException) do
+        TestHttpResource.raise_faraday_exception(error, '/path', 'GET')
+      end
+
+      assert_match(/execution expired/, network_error.message)
+      assert_match(%r{\(GET /path\)}, network_error.message)
+    end
+
     private
 
     def stub_request

--- a/test/lib/http_resource_test.rb
+++ b/test/lib/http_resource_test.rb
@@ -73,6 +73,25 @@ module Katello
       TestHttpResource.post('/path', { payloadKey: 'payloadValue' }, headers: { 'headerOne' => 'headerOneValue' })
     end
 
+    def test_issue_request_with_custom_connection
+      custom_conn = stub
+      custom_conn.stubs(:url_prefix).returns(URI.parse('https://upstream.example.com'))
+      custom_conn.expects(:send).with(:get, '/subscription/consumers').yields(stub_request).returns(@mock_response)
+      TestHttpResource.issue_request(
+        method: :get,
+        path: '/subscription/consumers',
+        headers: {},
+        connection: custom_conn,
+        process: false
+      )
+    end
+
+    def test_issue_request_process_false_returns_raw_response
+      @mock_conn.expects(:send).with(:get, '/path').yields(stub_request).returns(@mock_response)
+      result = TestHttpResource.issue_request(method: :get, path: '/path', process: false)
+      assert_equal @mock_response, result
+    end
+
     def test_process_response_success
       response = stub(status: 200, body: '{"result": "ok"}')
       result = TestHttpResource.process_response(response)

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -71,6 +71,33 @@ module Katello
         end
       end
 
+      class UpstreamConsumerPingTest < ActiveSupport::TestCase
+        def setup
+          @mock_response = stub(status: 200, body: '', headers: {})
+          UpstreamConsumer.stubs(:issue_request).returns(@mock_response)
+        end
+
+        def test_ping_success
+          response = UpstreamConsumer.ping
+          assert_equal 200, response.status
+        end
+
+        def test_ping_401_raises_gone
+          @mock_response.stubs(:status).returns(401)
+          assert_raises(Katello::Errors::UpstreamConsumerGone) { UpstreamConsumer.ping }
+        end
+
+        def test_ping_410_raises_gone
+          @mock_response.stubs(:status).returns(410)
+          assert_raises(Katello::Errors::UpstreamConsumerGone) { UpstreamConsumer.ping }
+        end
+
+        def test_ping_404_raises_not_found
+          @mock_response.stubs(:status).returns(404)
+          assert_raises(Katello::Errors::UpstreamConsumerNotFound) { UpstreamConsumer.ping }
+        end
+      end
+
       class CandlepinResourceTest < ActiveSupport::TestCase
         def test_default_headers_includes_cp_oauth_header
           User.stubs(:cp_oauth_header).returns({'cp-user' => 'admin'})

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -149,12 +149,12 @@ module Katello
       class ContentOverridesEdgeCaseTest < ActiveSupport::TestCase
         def test_consumer_update_content_overrides_empty_array
           result = Consumer.update_content_overrides('test-uuid', [])
-          assert_equal [], result
+          assert_empty result
         end
 
         def test_activation_key_update_content_overrides_empty_array
           result = ActivationKey.update_content_overrides('test-ak-id', [])
-          assert_equal [], result
+          assert_empty result
         end
       end
 

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -69,6 +69,12 @@ module Katello
           assert headers.key?('accept'), "Headers should still include 'accept'"
           assert headers.key?('content-type'), "Headers should still include 'content-type'"
         end
+
+        def test_site_preserves_non_default_port
+          UpstreamCandlepinResource.stubs(:upstream_api_uri).returns(URI.parse('https://cdn.example.com:8443/subscription'))
+
+          assert_equal 'https://cdn.example.com:8443', UpstreamCandlepinResource.site
+        end
       end
 
       class UpstreamConsumerPingTest < ActiveSupport::TestCase
@@ -154,6 +160,15 @@ module Katello
 
         def test_activation_key_update_content_overrides_empty_array
           result = ActivationKey.update_content_overrides('test-ak-id', [])
+          assert_empty result
+        end
+
+        def test_activation_key_update_content_overrides_empty_response_body
+          ActivationKey.stubs(:default_headers).returns({})
+          Candlepin::CandlepinResource.expects(:issue_request).returns(stub(body: ''))
+
+          result = ActivationKey.update_content_overrides('test-ak-id', [{ name: 'repo-1', value: nil }])
+
           assert_empty result
         end
       end

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -109,6 +109,55 @@ module Katello
         end
       end
 
+      class ConsumerGetUrlTest < ActiveSupport::TestCase
+        def setup
+          SETTINGS.stubs(:dig).returns(nil)
+          SETTINGS[:katello] = { candlepin: { bulk_load_size: 100 } }
+          stub_request(:any, /.*/)
+            .to_return(body: '[]', headers: { 'Content-Type' => 'application/json' })
+        end
+
+        def test_get_with_owner_and_include_only
+          Consumer.get('owner' => 'acme', :include_only => [:uuid], :sort_by => 'uuid')
+          first_request = WebMock::RequestRegistry.instance.requested_signatures.hash.keys.first
+          url = first_request.uri.to_s
+          assert_match %r{/candlepin/consumers\?}, url, "URL should start query string with ?"
+          assert_match(/owner=acme/, url)
+          assert_match(/include=uuid/, url)
+          assert_match(/per_page=/, url)
+          refute_match(/consumers&/, url, "Should not have bare & after path")
+        end
+
+        def test_get_with_include_only_and_no_other_params
+          Consumer.get(:include_only => [:uuid])
+          first_request = WebMock::RequestRegistry.instance.requested_signatures.hash.keys.first
+          url = first_request.uri.to_s
+          assert_match %r{/candlepin/consumers\?}, url, "URL should start query string with ?"
+          assert_match(/include=uuid/, url)
+          refute_match(/consumers&include/, url, "Should not have bare & before include")
+        end
+
+        def test_get_with_string_param_returns_single_consumer
+          stub_request(:get, /.*/)
+            .to_return(body: { 'uuid' => 'abc-123', 'name' => 'test' }.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+          result = Consumer.get('abc-123')
+          assert_equal 'abc-123', result['uuid']
+        end
+      end
+
+      class ContentOverridesEdgeCaseTest < ActiveSupport::TestCase
+        def test_consumer_update_content_overrides_empty_array
+          result = Consumer.update_content_overrides('test-uuid', [])
+          assert_equal [], result
+        end
+
+        def test_activation_key_update_content_overrides_empty_array
+          result = ActivationKey.update_content_overrides('test-ak-id', [])
+          assert_equal [], result
+        end
+      end
+
       class ProductTest < ActiveSupport::TestCase
         def setup
         end

--- a/test/lib/tasks/clean_backend_objects_test.rb
+++ b/test/lib/tasks/clean_backend_objects_test.rb
@@ -120,5 +120,16 @@ module Katello
 
       Rake.application.invoke_task('katello:clean_backend_objects')
     end
+
+    def test_restores_bulk_load_size_after_failure
+      original_page_size = SETTINGS[:katello][:candlepin][:bulk_load_size]
+      Katello::Resources::Candlepin::Consumer.expects(:all_uuids).raises(StandardError, 'boom')
+
+      assert_raises(StandardError) do
+        Rake.application.invoke_task('katello:clean_backend_objects')
+      end
+
+      assert_equal original_page_size, SETTINGS[:katello][:candlepin][:bulk_load_size]
+    end
   end
 end

--- a/test/lib/tasks/upgrades/4.21/cleanup_python_publications_test.rb
+++ b/test/lib/tasks/upgrades/4.21/cleanup_python_publications_test.rb
@@ -63,7 +63,7 @@ module Katello
 
       pub1 = OpenStruct.new(pulp_href: '/pulp/api/v3/publications/python/pypi/already-deleted/')
       publications_api_mock = mock('publications_api')
-      publications_api_mock.expects(:delete).with(pub1.pulp_href).raises(HttpResource::HttpError.new(message: 'Not found', code: '404', service_code: ''))
+      publications_api_mock.expects(:delete).with(pub1.pulp_href).raises(RestClient::NotFound)
       Katello::Pulp3::Api::Core.any_instance.stubs(:publications_list_all).returns([pub1])
       Katello::Pulp3::Api::Core.any_instance.stubs(:publications_api).returns(publications_api_mock)
 

--- a/test/lib/tasks/upgrades/4.21/cleanup_python_publications_test.rb
+++ b/test/lib/tasks/upgrades/4.21/cleanup_python_publications_test.rb
@@ -63,7 +63,7 @@ module Katello
 
       pub1 = OpenStruct.new(pulp_href: '/pulp/api/v3/publications/python/pypi/already-deleted/')
       publications_api_mock = mock('publications_api')
-      publications_api_mock.expects(:delete).with(pub1.pulp_href).raises(RestClient::NotFound)
+      publications_api_mock.expects(:delete).with(pub1.pulp_href).raises(HttpResource::HttpError.new(message: 'Not found', code: '404', service_code: ''))
       Katello::Pulp3::Api::Core.any_instance.stubs(:publications_list_all).returns([pub1])
       Katello::Pulp3::Api::Core.any_instance.stubs(:publications_api).returns(publications_api_mock)
 

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -35,13 +35,12 @@ module Katello
                [:tomato, "salad"],
                [:include, "mayo"]]
 
-      RestClient::ParamsArray.expects(:new).with(input)
-
-      Katello::UpstreamPool.request_params(
+      result = Katello::UpstreamPool.request_params(
         base_params: {bacon: "jam"},
         extra_params: [[:tomato, "sandwich"], [:tomato, "salad"]],
         included_fields: ["mayo"]
       )
+      assert_equal input, result
     end
 
     def test_fetch_pools

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -16,7 +16,7 @@ module Katello
         'productId' => :product_id,
         'subscriptionId' => :subscription_id,
       }]
-      @response = stub(to_str: @raw_pool.to_json, headers: {})
+      @response = stub(body: @raw_pool.to_json, headers: {}, status: 200)
     end
 
     def stub_fetch_pools(response, base_params: {}, extra_params: [], included_fields: UpstreamPool.all_fields)
@@ -58,7 +58,7 @@ module Katello
     end
 
     def test_fetch_pools_total_with_header
-      response = stub(to_str: '[]', headers: {x_total_count: 4})
+      response = stub(body: '[]', headers: {x_total_count: 4}, status: 200)
       stub_fetch_pools(response)
 
       pools = UpstreamPool.fetch_pools({})

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -58,7 +58,7 @@ module Katello
     end
 
     def test_fetch_pools_total_with_header
-      response = stub(body: '[]', headers: {x_total_count: 4}, status: 200)
+      response = stub(body: '[]', headers: {'x-total-count' => 4}, status: 200)
       stub_fetch_pools(response)
 
       pools = UpstreamPool.fetch_pools({})

--- a/test/routing/candlepin_proxies_test.rb
+++ b/test/routing/candlepin_proxies_test.rb
@@ -11,8 +11,12 @@ module Katello
       {controller: @proxies_controller, action: 'list_owners', login: '1'}.must_recognize(method: :get, path: '/rhsm/users/1/owners')
     end
 
+    def test_consumer_compliance
+      {controller: @proxies_controller, action: 'consumer_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/compliance')
+    end
+
     def test_consumer_purpose_compliance
-      {controller: @proxies_controller, action: 'get', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
+      {controller: @proxies_controller, action: 'consumer_purpose_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
     end
   end
 end

--- a/test/routing/candlepin_proxies_test.rb
+++ b/test/routing/candlepin_proxies_test.rb
@@ -11,12 +11,8 @@ module Katello
       {controller: @proxies_controller, action: 'list_owners', login: '1'}.must_recognize(method: :get, path: '/rhsm/users/1/owners')
     end
 
-    def test_consumer_compliance
-      {controller: @proxies_controller, action: 'consumer_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/compliance')
-    end
-
     def test_consumer_purpose_compliance
-      {controller: @proxies_controller, action: 'consumer_purpose_compliance', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
+      {controller: @proxies_controller, action: 'get', id: '1'}.must_recognize(method: :get, path: '/rhsm/consumers/1/purpose_compliance')
     end
   end
 end

--- a/test/scenarios/scenario_test.rb
+++ b/test/scenarios/scenario_test.rb
@@ -40,10 +40,11 @@ module Scenarios
     def test_update_org_service_level
       # Without any choices, should not be able to set a service level
       assert_nil @org.service_level
-      e = assert_raises(RestClient::BadRequest) do
+      e = assert_raises(HttpResource::HttpError) do
         @org.service_level = 'Premium'
       end
-      refute_nil JSON.parse(e.response)['displayMessage']
+      assert_equal '400', e.code
+      refute_nil JSON.parse(e.response_body)['displayMessage']
       assert_nil @org.service_level
 
       # Should be able to set clear the default

--- a/test/services/katello/pulp3/api/core_test.rb
+++ b/test/services/katello/pulp3/api/core_test.rb
@@ -14,9 +14,9 @@ module Katello
             @primary = SmartProxy.pulp_primary
           end
 
-          def test_with_excon
+          def test_with_net_http_persistent
             default = Faraday.default_adapter
-            Faraday.default_adapter = :excon
+            Faraday.default_adapter = :net_http_persistent
 
             assert Katello::Pulp3::Api::Core.new(@primary).tasks_api.list(limit: 1)
           ensure

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -294,7 +294,7 @@ module Katello
 
       def test_force_registration_existing_host
         ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(1)
-        ::Katello::RegistrationManager.expects(:unregister_host).raises(RestClient::Gone)
+        ::Katello::RegistrationManager.expects(:unregister_host).raises(HttpResource::HttpError.new(message: 'Gone', code: '410', service_code: ''))
         ::Katello::RegistrationManager.expects(:create_in_candlepin)
         ::Katello::RegistrationManager.expects(:finalize_registration)
         Rails.logger.expects(:debug).with("Host #{@host.name} has been removed in preparation for reregistration")
@@ -445,7 +445,7 @@ module Katello
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
 
         ::Host.expects(:find).returns(@host)
-        ::Katello::Resources::Candlepin::Consumer.expects(:destroy).raises(RestClient::ResourceNotFound)
+        ::Katello::Resources::Candlepin::Consumer.expects(:destroy).raises(HttpResource::HttpError.new(message: 'Not found', code: '404', service_code: ''))
 
         @host.expects(:destroy).returns(true)
 

--- a/test/services/katello/ui_notifications/subscriptions/manifest_expired_warning_test.rb
+++ b/test/services/katello/ui_notifications/subscriptions/manifest_expired_warning_test.rb
@@ -43,7 +43,7 @@ module Katello
         end
 
         def test_with_failure
-          Net::HTTP.any_instance.stubs(:request).raises(HttpResource::HttpError.new(message: 'Forbidden', code: '403', service_code: ''))
+          Net::HTTP.any_instance.stubs(:request).raises(RestClient::Forbidden)
           @class.deliver!([@product.organization])
           assert_equal 1, NotificationBlueprint.find_by(name: 'manifest_expired_warning').notifications.count
         end

--- a/test/services/katello/ui_notifications/subscriptions/manifest_expired_warning_test.rb
+++ b/test/services/katello/ui_notifications/subscriptions/manifest_expired_warning_test.rb
@@ -43,7 +43,7 @@ module Katello
         end
 
         def test_with_failure
-          Net::HTTP.any_instance.stubs(:request).raises(RestClient::Forbidden)
+          Net::HTTP.any_instance.stubs(:request).raises(HttpResource::HttpError.new(message: 'Forbidden', code: '403', service_code: ''))
           @class.deliver!([@product.organization])
           assert_equal 1, NotificationBlueprint.find_by(name: 'manifest_expired_warning').notifications.count
         end

--- a/test/support/scenario_support.rb
+++ b/test/support/scenario_support.rb
@@ -73,7 +73,7 @@ class ScenarioSupport
     yield
     true
   rescue HttpResource::HttpError => e
-    raise unless e.code == '404'
+    raise unless e.code.to_s == '404'
     false
   end
 end

--- a/test/support/scenario_support.rb
+++ b/test/support/scenario_support.rb
@@ -21,10 +21,10 @@ class ScenarioSupport
   def import_manifest(owner_label, path_to_file)
     filename = path_to_file.split('/').last
     record("import_manifest_#{filename}", match_requests_on: [:method, :path, :params]) do
-      path = "/candlepin/owners/#{owner_label}/imports/async?force=SIGNATURE_CONFLICT&force=MANIFEST_SAME"
-      client = ::Katello::Resources::Candlepin::CandlepinResource.rest_client(Net::HTTP::Post, :post, path)
-      body = {:import => File.new(path_to_file, 'rb')}
-      client.post body, {:accept => :json}.merge(User.cp_oauth_header)
+      ::Katello::Resources::Candlepin::Owner.import(
+        owner_label, path_to_file,
+        force: 'SIGNATURE_CONFLICT'
+      )
     end
   end
 
@@ -72,7 +72,8 @@ class ScenarioSupport
   def exists?
     yield
     true
-  rescue RestClient::ResourceNotFound
+  rescue HttpResource::HttpError => e
+    raise unless e.code == '404'
     false
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Replace the unmaintained RestClient gem with Faraday 2.x and the net_http_persistent adapter for the Candlepin HTTP layer, enabling persistent TCP+TLS connection reuse between Puma and Candlepin. This eliminates per-request connection setup overhead during concurrent host registration.

**Prerequisite**: theforeman/foreman_azure_rm#209 must merge first — the retired Azure SDK pins faraday < 2 via ms_rest, which blocks this upgrade.

**Note**: rest-client remains as a dependency — it is still used by CDN resource code (cdn.rb). Only the Candlepin HTTP layer is migrated to Faraday.

Key changes:

- **Faraday 2.x migration**: Replace RestClient::Resource with Faraday::Connection, memoized at the class level for connection pooling across Puma threads. net-http-persistent v4.x provides per-thread TCP connection isolation via connection_pool internally.
- **OAuth 1.0a concern**: Extract request signing into OauthRequestSigning concern, making auth a pluggable strategy (preparation for mTLS transition). Memoize OAuth::Consumer to avoid per-request allocation.
- **Unified request pipeline**: All Candlepin HTTP traffic (direct, proxy, upstream) flows through issue_request with connection: (custom Faraday for upstream certs), process: (skip error raising for pass-through), and params: (query string) keywords.
- **Keyword args on HTTP verbs**: get(path, headers:, params:), post(path, payload, headers:, params:) — replaces fragile positional arg parsing.
- **HttpError**: Transport-neutral replacement for RestClientException with response_body for controller error rendering.
- **Upstream connection lifecycle**: Per-org memoized faraday_connection for upstream Candlepin, with reset_connection! called in manifest import/refresh/delete finalize.
- **Lazy debug logging**: logger.debug { } blocks skip serialization when debug is disabled.

#### Considerations taken when implementing this change?

- **Connection reuse impact**: In A/B testing on a Satellite 6.16 environment, ActiveOpens (TCP connections created) dropped from 692K to 2.7K over a 2000-host registration run — a 99.6% reduction.
- **PQC readiness**: Persistent connections amortize TLS handshake cost. With upcoming Post-Quantum Cryptography adoption (ML-KEM/ML-DSA), handshake overhead increases significantly — connection reuse prevents this from regressing registration latency.
- **Thread safety**: net-http-persistent v4.x uses connection_pool internally, providing per-thread connection isolation.
- **Upstream multi-org safety**: faraday_connection and upstream_owner_id are keyed by Organization.current.id to prevent cross-org credential leaks in multi-threaded Puma.
- **Backward compatibility**: All 24 RestClient rescue sites updated to HttpError with status code checks. All 41+ callers updated from positional args to keyword headers: args. hash_to_query kept as alias for query_string.
- **rest-client retained**: CDN code (cdn.rb) still uses RestClient exceptions and must keep the gem dependency until a separate CDN migration is done.

Gemspec changes:

Added:
- faraday (>= 2.0, < 3.0)
- faraday-net_http_persistent (~> 2.0)
- faraday-multipart (~> 1.0)

Retained (still used by CDN):
- rest-client

Packaging note: RPM packages need to add rubygem-faraday, rubygem-faraday-net_http_persistent, rubygem-faraday-multipart, and rubygem-net-http-persistent. Do NOT remove rubygem-rest-client — it is still required by CDN resource code.

#### What are the testing steps for this pull request?

- [x] Unit tests for issue_request with connection:, process: false, and params: keywords
- [x] Unit tests for HttpError with response_body
- [x] Unit tests for ping status mapping (401/410 -> UpstreamConsumerGone, 404 -> UpstreamConsumerNotFound)
- [x] Unit tests for query_string helper
- [x] Updated http_resource_test.rb for keyword args
- [x] Updated candlepin_test.rb for Faraday mocks
- [x] Updated registration_manager_test.rb for HttpError
- [x] Updated candlepin_proxies_controller_test.rb for Faraday response API
- [ ] Full Katello test suite (bundle exec rake test:katello)
- [ ] Registration workflow: register host, verify Candlepin consumer created
- [ ] Manifest import/refresh/delete cycle — verify upstream connection reset
- [ ] Concurrent registration (50+ hosts) — verify no connection errors
- [ ] Verify ActiveOpens reduction with PCP (pmrep network.tcp.activeopens)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth signing added for outgoing HTTP requests.
  * Manifest workflows now refresh upstream backend connections after import/refresh/delete.

* **Bug Fixes**
  * More consistent HTTP error handling and clearer CLI vs plain-text error responses.
  * Improved logging and safer error payload reporting for backend failures.

* **Refactor**
  * Unified HTTP client and standardized upstream/resource interactions and header usage.

* **Tests**
  * Expanded and updated tests to cover the new HTTP client behavior.

* **Chores**
  * Updated HTTP client dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->