### PR TITLE
fixes #39337 - show helper text on repo discovery

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/views/discovery.html
@@ -57,6 +57,10 @@
              ng-disabled="discovery.working"
              ng-required="discovery.contentType === 'docker' && discovery.registryType === 'redhat'"
              name="upstreamPassword"/>
+      <h6 translate ng-if="discovery.contentType === 'docker' && discovery.registryType === 'redhat'">
+          Username and password are required for syncing the repository after it is created. Credentials are not validated during discovery.
+      </h6>
+
     </div>
 
     <div bst-form-group ng-show="discovery.contentType === 'docker'"

--- a/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
+++ b/engines/bastion_katello/test/products/discovery/discovery.controller.test.js
@@ -210,4 +210,3 @@ describe('Controller: DiscoveryController', function() {
         expect(Task.unregisterSearch).toHaveBeenCalled();
     });
 });
-


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Show helper text conditionally when username + password field is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added translated, context-sensitive help in the repository discovery UI: when Docker + Red Hat registry is selected, a help message clarifies that username/password will be required for actions like syncing after repository creation and that credentials are not validated during discovery.
* **Tests**
  * Added tests to verify the help text appears for Docker + Red Hat and does not appear for non-Docker scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11757?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->