### PR TITLE
Fixes #39338 - Clear setTimeout in LoadingState on unmount

### DIFF
--- a/webpack/components/LoadingState/LoadingState.js
+++ b/webpack/components/LoadingState/LoadingState.js
@@ -13,9 +13,15 @@ class LoadingState extends Component {
   }
 
   componentDidMount() {
-    setTimeout(() => {
+    this.timeoutId = setTimeout(() => {
       this.setState({ render: true });
     }, this.props.timeout);
+  }
+
+  componentWillUnmount() {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+    }
   }
 
   render() {

--- a/webpack/components/LoadingState/LoadingState.test.js
+++ b/webpack/components/LoadingState/LoadingState.test.js
@@ -40,3 +40,13 @@ test('Loading State renders spinner after timeout when loading', () => {
   expect(getByText('Loading')).toBeInTheDocument();
   expect(queryByText('Loading Complete')).not.toBeInTheDocument();
 });
+
+test('Loading State clears timeout on unmount without warnings', () => {
+  const { unmount } = render(loadingComponent);
+
+  // Unmount before timeout fires - should not cause React warnings
+  unmount();
+
+  // Run timers after unmount - no setState should be called
+  act(() => { jest.runAllTimers(); });
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The LoadingState component now stores its timeout ID and clears it in componentWillUnmount, preventing React warnings when the component unmounts before the timeout fires. Added a test using claude to verify this.

#### Considerations taken when implementing this change?

Applied standard React cleanup pattern for timers without changing component behavior.

#### What are the testing steps for this pull request?

1. Run npx jest webpack/components/SelectOrg/__tests__/SetOrganization.test.js - all 5 tests should pass without React unmount warnings
2. Run bundle exec npm run test:plugins katello - SetOrganization.test.js should pass (previously failed with 4 failures)
3. Run npx jest webpack/components/LoadingState/LoadingState.test.js - verify timeout cleanup test passes
4. Verify no regressions in other components using LoadingState

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Loading state component now properly manages and cleans up timers during unmount, eliminating console warnings that could occur from state update attempts on already-unmounted components.

* **Tests**
  * Added test coverage to ensure the loading state correctly clears all pending timers when unmounting and confirms no React warnings are triggered in the process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->