### PR TITLE
Fixes #39341 - Properly toggle dropdown open state on Bulk Repository Sets Wizard

### DIFF
--- a/webpack/components/extensions/Hosts/BulkActions/BulkRepositorySetsWizard/01_BulkRepositorySetsTable.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkRepositorySetsWizard/01_BulkRepositorySetsTable.js
@@ -52,7 +52,7 @@ const ContentOverrideDropdown =
         key={`pf-ContentOverrideDropdown-${repoLabel}`}
         isOpen={isOpen}
         onSelect={onSelect}
-        onOpenChange={openVal => setIsOpen(!openVal)}
+        onOpenChange={setIsOpen}
         toggle={toggleRef => (
           <MenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
             {currentLabel}
@@ -196,7 +196,7 @@ export const BulkRepositorySetsTable = ({
     <Dropdown
       isOpen={actionToggleOpen}
       onSelect={onSelect}
-      onOpenChange={val => setActionToggleOpen(!val)}
+      onOpenChange={setActionToggleOpen}
       key="content-override-action-dropdown"
       ouiaId="content-override-action-dropdown"
       toggle={toggleRef => (


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixes an inverted state toggle preventing two different dropdowns from closing when their focus is lost 

#### Considerations taken when implementing this change?
N/A

#### What are the testing steps for this pull request?

- Select 1 or more hosts on All Hosts
- Select `Manage content -> Repository sets` from the  primary action dropdown
- Select 1 or more repository sets
- Verify the highlighted dropdowns automatically close when moving focus away from them

<img width="1160" height="628" alt="image" src="https://github.com/user-attachments/assets/223a6157-51ed-40a5-adde-50877356c217" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for dropdown components in bulk action interfaces to ensure proper open/close status tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->