### PR TITLE
Fixes #39345 - Add support for Debian Architecture-Variants

### DIFF
--- a/app/models/katello/root_repository.rb
+++ b/app/models/katello/root_repository.rb
@@ -441,8 +441,15 @@ module Katello
 
     def format_arches
       if self.deb?
-        # Pulp 2 needed a "," separated string-list, but Pulp 3 needs " " separated!
-        self.deb_architectures&.gsub(" ", ",")
+        return nil if self.deb_architectures.blank?
+
+        bases = self.deb_architectures
+          .split(/[,\s]+/)
+          .reject(&:blank?)
+          .map { |t| t.delete(":") }
+          .uniq
+
+        bases.empty? ? nil : bases.join(",")
       else
         self.arch == "noarch" ? nil : self.arch
       end

--- a/test/models/root_repository_test.rb
+++ b/test/models/root_repository_test.rb
@@ -721,6 +721,47 @@ module Katello
       @fedora_root.save!
       assert @fedora_root.pulp_update_needed?
     end
+
+    def test_pulp_format_arches_removes_architecture_variant_separator
+      deb = katello_root_repositories(:debian_10_amd64_root)
+      deb.deb_architectures = "amd64:v3"
+
+      assert_equal "amd64v3", deb.format_arches
+    end
+
+    def test_deb_format_arches_removes_variant_separator_and_handles_multiple
+      deb = katello_root_repositories(:debian_10_amd64_root)
+      deb.deb_architectures = "amd64:v3 arm64"
+
+      assert_equal "amd64v3,arm64", deb.format_arches
+    end
+
+    def test_deb_format_arches_keeps_base_and_variant_as_distinct_arches
+      deb = katello_root_repositories(:debian_10_amd64_root)
+      deb.deb_architectures = "amd64 amd64:v3"
+
+      assert_equal "amd64,amd64v3", deb.format_arches
+    end
+
+    def test_deb_format_arches_deduplicates_identical_normalized_arches
+      deb = katello_root_repositories(:debian_10_amd64_root)
+      deb.deb_architectures = "amd64:v3 amd64v3"
+
+      assert_equal "amd64v3", deb.format_arches
+    end
+
+    def test_deb_architectures_allows_and_persists_variant_token
+      deb = FactoryBot.build(:katello_root_repository,
+                           :deb_root,
+                           product: katello_products(:debian))
+      deb.url = "http://myrepo.com"
+      deb.deb_releases = "buster"
+      deb.deb_components = "main"
+      deb.deb_architectures = "amd64:v3"
+
+      assert deb.save, deb.errors.full_messages.join(", ")
+      assert_equal "amd64:v3", deb.reload.deb_architectures
+    end
   end
 
   class RootRepositoryApplicabilityTest < RepositoryTestBase


### PR DESCRIPTION
This PR requires are pulp_version that includes this change: https://github.com/pulp/pulp_deb/pull/1392