### PR TITLE
Fixes #39358 - Add missing indexes on content facet join tables

### DIFF
--- a/db/migrate/20260522000000_add_content_facet_id_indexes.rb
+++ b/db/migrate/20260522000000_add_content_facet_id_indexes.rb
@@ -1,0 +1,15 @@
+class AddContentFacetIdIndexes < ActiveRecord::Migration[6.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :katello_content_view_environment_content_facets,
+              :content_facet_id,
+              name: 'index_cve_content_facets_on_content_facet_id',
+              algorithm: :concurrently
+
+    add_index :katello_content_facet_repositories,
+              :content_facet_id,
+              name: 'index_content_facet_repos_on_content_facet_id',
+              algorithm: :concurrently
+  end
+end


### PR DESCRIPTION
## Summary

Add missing `content_facet_id` indexes to two join tables that are scanned on every registration, content view publish, and host applicability calculation.

## Problem

During registration performance testing at 1368 concurrent registrations with SQL debug logging enabled, `pg_stat_user_tables` revealed two tables with near-100% sequential scan rates:

| Table | Seq scan % | Tuples read | Rows |
|---|---|---|---|
| `katello_content_view_environment_content_facets` | 93% | 553M | 7,644 |
| `katello_content_facet_repositories` | 87% | 339M | 14,279 |

Both tables are joined via `content_facet_id` during repository resolution, but neither has an index on that column. The second table has a composite index on `(repository_id, content_facet_id)`, but queries filtering by `content_facet_id` alone cannot use it (wrong leading column).

## Fix

Add `content_facet_id` index to both tables.

## Expected impact

Each query on these tables drops from ~20ms (seq scan under contention) to <1ms (index lookup). At 912+ concurrent registrations, this frees ~18s of DB time per 30s window.

## Test plan

- [x] Migration runs without errors
- [ ] `pg_stat_user_tables` shows idx_scan increasing and seq_scan rate dropping after deployment
- [ ] No regression in registration latency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added two concurrent indexes on content-facet IDs to improve query performance.
  * Expect faster, more responsive content-related searches and deployments across environments, reducing delays during content handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->