### PR TITLE
Fixes #39351- Fix API endpoint GET /api/host_packages/installed_packages in apidoc

### DIFF
--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -27,7 +27,7 @@ module Katello
       param :groups, Array, :desc => N_("List of package group names (Deprecated)"), :required => false
     end
 
-    api :GET, "/host_packages/installed_packages", N_("Return a list of installed packages distinct by name")
+    api :GET, "/hosts/host_packages/installed_packages", N_("Return a list of installed packages distinct by name")
     param_group :search, ::Katello::Api::V2::ApiController
     def installed_packages
       _sort_by, _sort_order, options = sort_options


### PR DESCRIPTION
### What are the changes introduced in this pull request?
This pull request corrects the Apipie API documentation path for the installed_packages action in HostPackagesController. It does not change runtime routing or controller behavior.

```
Before:
api :GET, "/host_packages/installed_packages", ...

After (line 30):
api :GET, "/hosts/host_packages/installed_packages", ...
```

The route is defined under the hosts collection in config/routes/overrides.rb as /host_packages/installed_packages, so the full API path is under /hosts/.... The old Apipie entry omitted the hosts/ prefix and did not match the real endpoint or other actions in the same controller (for example /hosts/:host_id/packages).

#### Considerations taken when implementing this change?
Documentation-only fix — Only the api Apipie declaration changed; installed_packages logic, routes, and responses are unchanged.

#### What are the testing steps for this pull request?
At ${SATELLITE}/apidoc/v2/host_packages.en.html check the endpoint` /api/hosts/host_packages/installed_packages. `Earlier it was` /api/host_packages/installed_packages `

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Updates**
  * The endpoint for retrieving installed packages was moved under the hosts namespace. Integrations should update calls to the new path to continue listing installed packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->