### PR TITLE
Fixes #39367 - prevent global override of CSS

### DIFF
--- a/webpack/ForemanColumnExtensions/index.scss
+++ b/webpack/ForemanColumnExtensions/index.scss
@@ -1,9 +1,11 @@
 #image-mode-column-title-icon {
   padding: 5px;
 }
+
 .image-mode-column-td-icon {
   padding: 6px;
 }
+
 .package-mode-column-td-icon {
   padding: 4px;
 }

--- a/webpack/components/Bookmark/Bookmark.scss
+++ b/webpack/components/Bookmark/Bookmark.scss
@@ -1,3 +1,4 @@
+[data-ouia-component-id="bookmark-dropdown"] {
   .pf-v5-c-dropdown__toggle-text {
     padding: 0 5px;
 
@@ -9,8 +10,9 @@
   .pf-v5-c-dropdown__toggle-icon {
     margin: 0;
   }
+}
 
-
+[data-ouia-component-id="add-bookmark-modal"] {
   .pf-m-inline {
     align-content: center;
 
@@ -26,3 +28,4 @@
       margin-top: 2px;
     }
   }
+}

--- a/webpack/components/OptionTooltip/OptionTooltip.scss
+++ b/webpack/components/OptionTooltip/OptionTooltip.scss
@@ -5,17 +5,21 @@
     list-style-type: none;
     padding: 0;
   }
+
   .popover-content{
     min-width: 120px;
     max-width: 160px;
   }
+
   span {
     margin-left: 8px;
   }
 }
+
 .tooltip-open {
   color: $color-pf-blue-400;
 }
+
 .tooltip-button {
   cursor: pointer;
 }

--- a/webpack/components/RoutedTabs/RoutedTabs.scss
+++ b/webpack/components/RoutedTabs/RoutedTabs.scss
@@ -1,7 +1,7 @@
 // Fix for PatternFly 5 horizontal tabs active indicator position
 // The active indicator should appear at the bottom border of the tab area
 // Scoped to RoutedTabs component only
-.pf-v5-c-tabs[data-ouia-component-id="routed-tabs"] {
+[data-ouia-component-id="routed-tabs"].pf-v5-c-tabs {
   &:not(.pf-m-vertical) {
     .pf-v5-c-tabs__list {
       // Remove any extra margin that pushes the indicator up
@@ -16,6 +16,6 @@
 }
 
 // Apply margin only to RoutedTabs component
-.pf-v5-c-tabs[data-ouia-component-id="routed-tabs"] {
+[data-ouia-component-id="routed-tabs"].pf-v5-c-tabs {
   margin: 0 24px;
 }

--- a/webpack/components/Table/MainTable.scss
+++ b/webpack/components/Table/MainTable.scss
@@ -8,6 +8,7 @@
   .pf-v5-c-dropdown__menu {
     min-width: 0;
   }
+
   .pf-v5-c-wizard__footer {
     z-index: 1;
   }

--- a/webpack/components/TooltipButton/TooltipButton.scss
+++ b/webpack/components/TooltipButton/TooltipButton.scss
@@ -7,26 +7,32 @@
     pointer-events: none;
   }
 }
+
 .btn-group-vertical > .tooltip-button-helper,
 .btn-group > .tooltip-button-helper {
   float: left;
   position: relative;
 }
+
 .btn-toolbar .tooltip-button-helper {
   float: left;
 }
+
 .btn-toolbar > .tooltip-button-helper {
   margin-left: 5px;
 }
+
 .btn-group > .tooltip-button-helper:first-child:not(:last-child) > .btn:not(.dropdown-toggle) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
+
 .btn-group > .tooltip-button-helper:last-child:not(:first-child) > .btn,
 .btn-group > .tooltip-button-helper:not(:first-child) > .dropdown-toggle {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
+
 .btn-group .btn + .tooltip-button-helper,
 .btn-group .tooltip-button-helper + .btn,
 .btn-group .tooltip-button-helper + .tooltip-button-helper,

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/ContentViewDetailsCard.scss
@@ -1,32 +1,34 @@
-.pf-v5-c-card__body.empty {
-  padding-bottom: 0;
+[data-ouia-component-id="content-view-details-card"] {
+  .pf-v5-c-card__body.empty {
+    padding-bottom: 0;
 
-  .pf-v5-l-bullseye {
-    position: relative;
-    top: -20px;
-  }
+    .pf-v5-l-bullseye {
+      position: relative;
+      top: -20px;
+    }
 
-  .pf-v5-c-empty-state__icon {
-    font-size: 2em;
-  }
+    .pf-v5-c-empty-state__icon {
+      font-size: 2em;
+    }
 
-  .pf-v5-c-empty-state__header,
-  .pf-v5-c-empty-state__header h4 {
-    font-size: 0.875rem !important;
-    font-weight: 600;
-  }
+    .pf-v5-c-empty-state__header,
+    .pf-v5-c-empty-state__header h4 {
+      font-size: 0.875rem !important;
+      font-weight: 600;
+    }
 
-  .pf-m-lg {
-    margin: -20px;
-  }
+    .pf-m-lg {
+      margin: -20px;
+    }
 
-  .pf-v5-c-empty-state__body {
-    font-size: smaller;
-    margin-top: 1.4em;
-    margin-bottom: 1em;
-  }
+    .pf-v5-c-empty-state__body {
+      font-size: smaller;
+      margin-top: 1.4em;
+      margin-bottom: 1em;
+    }
 
-  .pf-m-secondary {
-    margin-top: 5px;
+    .pf-m-secondary {
+      margin-top: 5px;
+    }
   }
 }

--- a/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/_shared-assignment-styles.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ContentViewDetailsCard/_shared-assignment-styles.scss
@@ -174,9 +174,9 @@
       margin-top: 0.15rem;
     }
   }
-}
 
-hr {
-  border: 0;
-  border-top: 1px solid var(--pf-v5-global--BorderColor--100);
+  hr {
+    border: 0;
+    border-top: 1px solid var(--pf-v5-global--BorderColor--100);
+  }
 }

--- a/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/ErrataOverviewCard.scss
@@ -2,6 +2,7 @@
   .pf-v5-c-empty-state {
     margin-top: 0;
   }
+
   .piechart-overflow {
     margin-right: -20px;
     position: relative;

--- a/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/HostCollectionsCard/HostCollectionsCard.scss
@@ -3,21 +3,26 @@
     position: relative;
     top: -20px;
   }
+
   .pf-v5-c-empty-state__icon {
     font-size: 2em;
   }
+
   .pf-m-lg {
     margin: -20px;
   }
+
   .pf-v5-c-empty-state__body {
     font-size: smaller;
     margin-top: 1.4em;
     margin-bottom: 1em;
   }
+
   .pf-m-secondary {
     margin-top: 5px;
   }
 }
+
 .host-collection-card-body.empty {
   padding-bottom: 0;
 }

--- a/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.scss
+++ b/webpack/components/extensions/HostDetails/Cards/SystemPurposeCard/SystemPurposeCard.scss
@@ -1,5 +1,6 @@
 .system-purpose-card-body {
   font-size: small;
+
   .pf-v5-c-label {
     font-size: smaller;
   }

--- a/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/ErrataTab/ErrataTab.scss
@@ -1,11 +1,11 @@
 #errata-tab {
   margin: 16px 0;
+
+  .pf-v5-c-toggle-group__text {
+    color: black;
+  }
 }
 
 #errata-alert {
   margin: 16px 24px;
-}
-
-.pf-v5-c-toggle-group__text {
-  color: black;
 }

--- a/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.scss
+++ b/webpack/components/extensions/HostDetails/Tabs/TracesTab/EnableTracerModal.scss
@@ -1,16 +1,20 @@
-.pf-v5-c-content {
-  ul {
+[data-ouia-component-id="enable-tracer-modal"] {
+  .pf-v5-c-content {
+    ul {
       margin-top: 1rem;
+
       li svg {
         margin-right: 0.3rem;
         margin-left: 0.3rem;
       }
-      }
-  #enable-tracer-modal-p {
-    width: 32rem;
-  }
-}
+    }
 
-#enable-repo-sets-p {
-  width: 28rem;
+    #enable-tracer-modal-p {
+      width: 32rem;
+    }
+  }
+
+  #enable-repo-sets-p {
+    width: 28rem;
+  }
 }

--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -16,11 +16,10 @@ html .pagination-pf-pagesize.btn-group {
 
 // don't use this class if you need a dropdown menu to extend outside the table cell
 .neat-table-cells {
-
   td,
   th {
     overflow: auto;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 }
 
@@ -29,12 +28,12 @@ html .pagination-pf-pagesize.btn-group {
   td {
     max-width: 200px;
     overflow: unset;
-    word-wrap: break-word;
+    overflow-wrap: break-word;
   }
 }
 
 // override foreman's .editable styles, that are conflicting with the patternfly ones
-.pf-table-inline-edit {
+#subscriptions-page .pf-table-inline-edit {
   .editable {
     background: none;
   }
@@ -79,7 +78,7 @@ html .pagination-pf-pagesize.btn-group {
 }
 
 .gap-16 {
-  grid-gap: 16px;
+  gap: 16px;
 }
 
 .margin-bottom-24 {
@@ -101,12 +100,10 @@ html .pagination-pf-pagesize.btn-group {
 // needed to ensure correct spacing between buttons and the button
 // container
 .toolbar-pf .form-group {
-
   .btn,
   .btn-group,
   .btn-container,
   .tooltip-button-helper {
-
     +.btn,
     +.btn-group,
     +.btn-container,
@@ -121,7 +118,8 @@ html .pagination-pf-pagesize.btn-group {
   outline: none;
 }
 
-// Modal sizing fix
+// Modal sizing fix — intentional global override for sidebar offset
+// stylelint-disable-next-line foreman/no-root-pf-overrides
 .pf-v5-l-bullseye .pf-v5-c-modal-box {
   margin-top: 76px;
   max-height: calc(100vh - 76px);
@@ -146,7 +144,6 @@ html .pagination-pf-pagesize.btn-group {
 }
 
 @keyframes hideme {
-
   0%,
   70% {
     opacity: 1;

--- a/webpack/scenes/ContainerImages/Synced/SyncedContainerImagesPage.scss
+++ b/webpack/scenes/ContainerImages/Synced/SyncedContainerImagesPage.scss
@@ -1,4 +1,4 @@
-table.pf-v5-c-table {
+[data-ouia-component-id="synced-container-images-table"] {
   tr.child-manifest-row {
     background-color: inherit;
     border: none;

--- a/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/matchContentModal.scss
+++ b/webpack/scenes/ContentViews/Details/Filters/MatchContentModal/matchContentModal.scss
@@ -1,3 +1,5 @@
-.pf-v5-c-empty-state {
-  margin-top: 0;
+[data-ouia-component-id="rpm-matching-content"] {
+  .pf-v5-c-empty-state {
+    margin-top: 0;
+  }
 }

--- a/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.scss
+++ b/webpack/scenes/ContentViews/Details/Versions/Compare/CVVersionCompare.scss
@@ -20,6 +20,7 @@
   .compare-table-container {
     flex-grow: 4;
   }
+
   .pf-v5-c-tabs.pf-m-vertical {
     max-width: 230px;
     border-right: 1px solid #d2d2d2;

--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionErrata.scss
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionErrata.scss
@@ -1,7 +1,7 @@
 .errata-icons-with-commas {
   margin: 0;
 
-  &:not(:last-child):after {
+  &:not(:last-child)::after {
     content: ', ';
     margin-right: 4px;
   }

--- a/webpack/scenes/ContentViews/Publish/cvPublishForm.scss
+++ b/webpack/scenes/ContentViews/Publish/cvPublishForm.scss
@@ -5,7 +5,7 @@
 
   .pf-v5-c-wizard__main-body {
     display: flex;
-    grid-gap: 16px;
+    gap: 16px;
     flex-direction: column;
   }
 

--- a/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
+++ b/webpack/scenes/ContentViews/components/EnvironmentPaths/EnvironmentPaths.scss
@@ -2,12 +2,13 @@
   .pf-v5-c-form__group {
     margin: 20px 0;
   }
+
   .pf-v5-c-check__label, .pf-v5-c-radio__label {
     margin: 0;
   }
 
   .env-path__labels-with-pointer {
-    &:not(:last-child):after {
+    &:not(:last-child)::after {
       content: '>';
       margin-top: 0px;
       margin-right: 0.5rem;

--- a/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.scss
+++ b/webpack/scenes/Subscriptions/Manifest/ManageManifestModal.scss
@@ -17,6 +17,7 @@
       margin: 5px 15px 12px 5px;
     }
   }
+
   .manifest-actions > * {
     margin: 10px 5px 0 0 ;
   }
@@ -24,6 +25,7 @@
   #manifest-actions-row {
     display: flex;
     flex-direction: row;
+
     & > * {
       margin-right: 8px;
     }

--- a/webpack/scenes/Subscriptions/SubscriptionsPage.scss
+++ b/webpack/scenes/Subscriptions/SubscriptionsPage.scss
@@ -15,6 +15,7 @@
 
       tr.open-grouped-row {
         background-color: $table-bg-hover;
+
         td {
           border-bottom-color: $table-border-hover;
         }

--- a/webpack/scenes/SyncStatus/SyncStatus.scss
+++ b/webpack/scenes/SyncStatus/SyncStatus.scss
@@ -1,6 +1,6 @@
 // Sticky toolbar and table header coordination
 // Target the toolbar by its ouiaId with more specific selector
-.pf-v5-c-toolbar.pf-m-sticky[data-ouia-component-id="sync-status-toolbar"] {
+[data-ouia-component-id="sync-status-toolbar"].pf-v5-c-toolbar.pf-m-sticky {
   position: sticky;
   top: 0;
   // Toolbar needs higher z-index than table header (which uses 100) so dropdowns appear above it
@@ -9,7 +9,7 @@
 }
 
 // Target the table by its ouiaId and offset the sticky header
-.pf-v5-c-table[data-ouia-component-id="sync-status-table"] {
+[data-ouia-component-id="sync-status-table"].pf-v5-c-table {
   thead {
     position: sticky;
     top: 70px;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
I ran stylelint from https://github.com/theforeman/foreman/pull/10968
And updated Katello to not override everyones UI. 
Found this while looking at empty state for Hosts Index page, and saw that when Katello is not present it has `margin-top:100px`, but `webpack/scenes/ContentViews/Details/Filters/MatchContentModal/matchContentModal.scss` overrides it. 

#### Considerations taken when implementing this change?
The css extra classes were AI added. The spaces were added with `--fix` arg when running stylelint.

#### What are the testing steps for this pull request?
Please take a look at the effected pages to make sure the styles still apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved styling consistency and scoping across multiple UI components.
  * Fixed component positioning and layout for tabs, cards, modals, and tables.
  * Modernized CSS properties for better browser compatibility.

* **Refactor**
  * Reorganized stylesheet rules for improved maintainability and specificity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->