### PR TITLE
Refs #39303 - Narrow redhat_cdn_host? to actual CDN hostnames

### DIFF
--- a/app/models/katello/cdn_configuration.rb
+++ b/app/models/katello/cdn_configuration.rb
@@ -8,6 +8,7 @@ module Katello
     CUSTOM_CDN_TYPE = 'custom_cdn'.freeze
 
     TYPES = [CDN_TYPE, NETWORK_SYNC, EXPORT_SYNC, CUSTOM_CDN_TYPE].freeze
+    REDHAT_CDN_HOST_PATTERN = /\Acdn(-[a-z]+)?\.redhat\.com\z/
 
     belongs_to :organization, :inverse_of => :cdn_configuration
 
@@ -42,7 +43,7 @@ module Katello
     end
 
     def redhat_cdn_host?
-      URI.parse(url).host&.end_with?('.redhat.com')
+      URI.parse(url).host&.match?(REDHAT_CDN_HOST_PATTERN)
     rescue URI::InvalidURIError
       false
     end

--- a/test/models/cdn_configuration_test.rb
+++ b/test/models/cdn_configuration_test.rb
@@ -33,6 +33,26 @@ module Katello
       end
     end
 
+    def test_redhat_cdn_host
+      config = FactoryBot.build(:katello_cdn_configuration, :custom_cdn)
+
+      ['cdn.redhat.com', 'cdn-eu.redhat.com', 'cdn-us.redhat.com'].each do |host|
+        config.url = "https://#{host}/content"
+        assert config.redhat_cdn_host?, "Expected #{host} to be a Red Hat CDN host"
+      end
+
+      ['satellite.example.redhat.com', 'internal.fqdn.redhat.com'].each do |host|
+        config.url = "https://#{host}/pub/repos"
+        refute config.redhat_cdn_host?, "Expected #{host} NOT to be a Red Hat CDN host"
+      end
+
+      config.url = 'https://cdn.example.com/content'
+      refute config.redhat_cdn_host?
+
+      config.url = 'not a url'
+      refute config.redhat_cdn_host?
+    end
+
     def test_types_updated_correctly
       org = Organization.first
       content_credential = ContentCredential.create!(:name => "CA",


### PR DESCRIPTION
## Problem

The `*.redhat.com` check in `redhat_cdn_host?` is too broad — it matches any host in the `redhat.com` domain, including Satellite instances hosted in Red Hat infrastructure. This caused subscription client certificates to be injected when enabling repos via a custom CDN pointing at such a host, which the server rejected with `tlsv1 alert unknown ca`.

## Solution

Narrow the check to `cdn.redhat.com` and `cdn-{region}.redhat.com` (e.g. `cdn-eu.redhat.com`, `cdn-us.redhat.com`) using a constant regex `REDHAT_CDN_HOST_PATTERN`. The three tests added by #11732 are unaffected — all use `cdn-eu.redhat.com` which still matches.

## Testing

Added unit tests for `redhat_cdn_host?` covering:
- Known Red Hat CDN hostnames (`cdn.redhat.com`, `cdn-eu.redhat.com`, `cdn-us.redhat.com`) → match
- Generic `*.redhat.com` hosts → no match
- Non-redhat.com hosts → no match
- Malformed URL → no match (returns false)

Existing tests in `cdn_test.rb` and `yum_test.rb` added by #11732 pass unchanged.

Robottelo test that hit this issue should pass with this fix:
```
pytest tests/foreman/cli/test_satellitesync.py -k test_positive_custom_cdn_with_credential
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Red Hat CDN hostname detection to more reliably recognize official CDN hostnames (including optional suffix variants), reducing false negatives/positives during validation.

* **Tests**
  * Added unit tests that verify detection against multiple matching and non-matching hostnames and invalid URL inputs to guard against regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Katello/katello/pull/11766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->