### PR TITLE
Fixes #39379 - Skip rolling content views in incremental updates

### DIFF
--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -226,6 +226,7 @@ module Katello
 
       ContentViewEnvironment.for_content_facets(content_facets).each do |cvenv|
         version = cvenv.content_view_version
+        next if version.content_view.rolling?
         version_environment = version_environments[version] || {:content_view_version => version, :environments => []}
         version_environment[:environments] << cvenv.environment unless version_environment[:environments].include?(cvenv.environment)
         version_environment[:next_version] ||= version.next_incremental_version

--- a/app/lib/actions/katello/content_view/incremental_updates.rb
+++ b/app/lib/actions/katello/content_view/incremental_updates.rb
@@ -35,6 +35,11 @@ module Actions
                         {:name => version.content_view.name, :version => version.version}
                     end
 
+                    if version.content_view.rolling?
+                      fail _("Cannot perform an incremental update on a Rolling Content View Version (%{name} version %{version})") %
+                        {:name => version.content_view.name, :version => version.version}
+                    end
+
                     action = plan_action(ContentViewVersion::IncrementalUpdate, version, version_environment[:environments],
                                         :resolve_dependencies => dep_solve, :content => content, :description => description,
                                         :propagated_composite_cv_ids => propagated_composite_cv_ids)


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

This PR adds filtering to skip rolling content views during incremental update operations. Two key changes were made:

1. The `available_incremental_updates` method in `hosts_bulk_actions_controller.rb` now filters out rolling CVs before returning results to the UI, preventing them from appearing in the incremental update dialog.
2. The plan method in incremental_updates.rb action skips rolling CVs during processing to handle direct API calls, hammer CLI usage, and other code paths that bypass the UI controller.

#### Considerations taken when implementing this change?

The fix filters rolling CVs at both UI and action layers. The UI layer prevents them from appearing in the dialog, while the action layer protects all entry points including API and hammer CLI calls.

#### What are the testing steps for this pull request?

1. Create a regular content view with Red Hat repositories
2. Create a composite content view that includes the regular CV as a component
3. Create a rolling content view with custom repositories
4. Register a host and subscribe it to both the composite CV and rolling CV
5. Navigate to Content -> Content Types -> Errata
6. Select a Red Hat erratum (example: RHBA-xxxx:xxxx) that is applicable but not installable on the host (create CV filter which filters out the errata from host)
7. Click "Apply" to open the incremental update dialog
8. Verify that only the composite CV and its component appear in the dialog (rolling CV should be filtered out)
9. Click "Confirm" to start the incremental update operation
10. Verify the task completes successfully without "undefined method `version_href' for nil:NilClass" error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incremental updates now exclude rolling content views from processing.
  * Attempts to run incremental updates on a rolling content view will fail with a clear localized error mentioning the content view name and version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->