### PR TITLE
Fixes #39388 - Refresh capsule content tab after sync and content count tasks

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -5,7 +5,7 @@
 
 import componentRegistry from 'foremanReact/components/componentRegistry';
 import Application from './containers/Application/index';
-import Content from './scenes/SmartProxy/Content';
+import Content from './scenes/SmartProxy/SmartProxyContentWithRefresh';
 import ChangeContentSource from './scenes/Hosts/ChangeContentSource';
 
 import './redux';

--- a/webpack/scenes/SmartProxy/SmartProxyContentWithRefresh.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentWithRefresh.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Content from './Content';
+import useSmartProxyContentRefresh from './useSmartProxyContentRefresh';
+
+const SmartProxyContentWithRefresh = ({ smartProxyId, organizationId }) => {
+  useSmartProxyContentRefresh({ smartProxyId, organizationId });
+
+  return (
+    <Content smartProxyId={smartProxyId} organizationId={organizationId} />
+  );
+};
+
+SmartProxyContentWithRefresh.propTypes = {
+  smartProxyId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]).isRequired,
+  organizationId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string,
+  ]),
+};
+
+SmartProxyContentWithRefresh.defaultProps = {
+  organizationId: null,
+};
+
+export default SmartProxyContentWithRefresh;

--- a/webpack/scenes/SmartProxy/useSmartProxyContentRefresh.js
+++ b/webpack/scenes/SmartProxy/useSmartProxyContentRefresh.js
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { STATUS } from 'foremanReact/constants';
+import { selectAPIResponse, selectAPIStatus } from 'foremanReact/redux/API/APISelectors';
+import getSmartProxyContent from './SmartProxyContentActions';
+import { SMART_PROXY_COUNTS_UPDATE_KEY } from './SmartProxyContentConstants';
+import { selectSmartProxyContent } from './SmartProxyContentSelectors';
+import { startPollingTask, stopPollingTask } from '../Tasks/TaskActions';
+import { pollTaskKey } from '../Tasks/helpers';
+import { selectIsPollingTask } from '../Tasks/TaskSelectors';
+
+const SMART_PROXY_CONTENT_TASK_KEY = 'SMART_PROXY_CONTENT_TASK';
+const CAPSULE_SYNC_TASK_LABEL = 'Actions::Katello::CapsuleContent::Sync';
+const SYNC_STATUS_POLL_INTERVAL_MS = 5000;
+const FOLLOW_UP_REFRESH_DELAYS_MS = [5000, 12000];
+
+const isTaskRunning = task =>
+  task && (task.state === 'pending' || task.state === 'running');
+
+const useSmartProxyContentRefresh = ({ smartProxyId, organizationId }) => {
+  const dispatch = useDispatch();
+  const resolvedRef = useRef(false);
+  const followUpTimersRef = useRef([]);
+  const lastActiveSyncTaskIdRef = useRef(null);
+  const lastCountsTaskIdRef = useRef(null);
+
+  const contentResponse = useSelector(selectSmartProxyContent);
+  const isTaskPolling = useSelector(state =>
+    selectIsPollingTask(state, SMART_PROXY_CONTENT_TASK_KEY));
+  const pollResponse = useSelector(state =>
+    selectAPIResponse(state, pollTaskKey(SMART_PROXY_CONTENT_TASK_KEY)));
+  const pollStatus = useSelector(state =>
+    selectAPIStatus(state, pollTaskKey(SMART_PROXY_CONTENT_TASK_KEY)));
+  const countsUpdateResponse = useSelector(state =>
+    selectAPIResponse(state, SMART_PROXY_COUNTS_UPDATE_KEY));
+  const countsUpdateStatus = useSelector(state =>
+    selectAPIStatus(state, SMART_PROXY_COUNTS_UPDATE_KEY));
+
+  const refreshContent = useCallback(
+    () => dispatch(getSmartProxyContent({ smartProxyId, organizationId })),
+    [dispatch, smartProxyId, organizationId],
+  );
+
+  const clearFollowUpTimers = useCallback(() => {
+    followUpTimersRef.current.forEach(timerId => window.clearTimeout(timerId));
+    followUpTimersRef.current = [];
+  }, []);
+
+  const scheduleFollowUpRefreshes = useCallback(() => {
+    clearFollowUpTimers();
+    followUpTimersRef.current = FOLLOW_UP_REFRESH_DELAYS_MS.map(delay =>
+      window.setTimeout(refreshContent, delay));
+  }, [clearFollowUpTimers, refreshContent]);
+
+  const startTaskPolling = useCallback((taskId) => {
+    if (!taskId || isTaskPolling) {
+      return;
+    }
+    resolvedRef.current = false;
+    clearFollowUpTimers();
+    dispatch(startPollingTask(SMART_PROXY_CONTENT_TASK_KEY, { id: taskId }));
+  }, [clearFollowUpTimers, dispatch, isTaskPolling]);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      if (!isTaskPolling) {
+        refreshContent();
+      }
+    }, SYNC_STATUS_POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(interval);
+      clearFollowUpTimers();
+      dispatch(stopPollingTask(SMART_PROXY_CONTENT_TASK_KEY));
+    };
+  }, [clearFollowUpTimers, dispatch, isTaskPolling, refreshContent]);
+
+  useEffect(() => {
+    const activeTasks = contentResponse?.active_sync_tasks || [];
+    const activeTask = activeTasks[activeTasks.length - 1];
+
+    if (!isTaskRunning(activeTask) || activeTask.id === lastActiveSyncTaskIdRef.current) {
+      return;
+    }
+
+    lastActiveSyncTaskIdRef.current = activeTask.id;
+    startTaskPolling(activeTask.id);
+  }, [contentResponse, startTaskPolling]);
+
+  useEffect(() => {
+    if (countsUpdateStatus !== STATUS.RESOLVED) {
+      return;
+    }
+
+    const taskId = countsUpdateResponse?.id;
+    if (!taskId || taskId === lastCountsTaskIdRef.current) {
+      return;
+    }
+
+    lastCountsTaskIdRef.current = taskId;
+    startTaskPolling(taskId);
+  }, [countsUpdateResponse, countsUpdateStatus, startTaskPolling]);
+
+  useEffect(() => {
+    const { state, result, label } = pollResponse;
+
+    if (!isTaskPolling || resolvedRef.current) {
+      return;
+    }
+
+    const taskStopped = state === 'stopped';
+    const taskErrored = result === 'error' || pollStatus === STATUS.ERROR;
+
+    if (!taskStopped && !taskErrored) {
+      return;
+    }
+
+    resolvedRef.current = true;
+    dispatch(stopPollingTask(SMART_PROXY_CONTENT_TASK_KEY));
+    refreshContent();
+
+    if (taskStopped && result === 'success' && label === CAPSULE_SYNC_TASK_LABEL) {
+      scheduleFollowUpRefreshes();
+    }
+  }, [
+    dispatch,
+    isTaskPolling,
+    pollResponse,
+    pollStatus,
+    refreshContent,
+    scheduleFollowUpRefreshes,
+  ]);
+};
+
+export default useSmartProxyContentRefresh;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Fixes the capsule Content tab not updating after Synchronize Capsule or Update Content Counts finish (SAT-45748). Users had to reload to see Last sync, Synced, Packages, and Additional content update.

The tab uses Angular for sync and React for the content table. Angular refreshed on task completion; React only fetched sync status once and never refetched.
Changes:

- Angular fires `katello:capsuleContentSyncStarted` / `katello:capsuleContentSyncChanged` when sync starts and after sync status refresh.
- New `useSmartProxyContentRefresh` hook polls sync status and pending count-update tasks, listens for those events, and refetches content.
- `updateSmartProxyContentCounts` polls the returned Foreman task and refetches when done.
- Supporting constants and polling actions in `SmartProxyContentActions.js`; hook wired into `SmartProxyExpandableTable.js`.
No backend/API changes.


#### Considerations taken when implementing this change?

- **Hybrid UI:** Custom DOM events connect Angular sync to the React table without rewriting sync in React.
- **Chained tasks:** Post-sync Update Content Counts can still be running after sync ends; we poll for pending count tasks before the final refresh.
- **All triggers:** Covers Synchronize Capsule, Refresh counts, and automatic count updates after sync.
- **Existing patterns:** Uses Foreman interval middleware, task polling, and the same sync-status endpoint/Redux key the table already uses.
- **Cleanup:** Stops polling and listeners on unmount.

#### What are the testing steps for this pull request?

1. Open Infrastructure → Capsules, select a capsule with content, and go to the Content tab.
2. Synchronize Capsule
- Choose Synchronize → Optimized Sync (or Complete Sync).
- Wait until sync finishes and any Update Content Counts task completes (check Monitor → Tasks if needed).
- **Expected:** Last sync updates and expanded rows show current Synced, Packages, and Additional content without reloading the page.
 3. Refresh counts (environment)
 - Expand an environment, open the row kebab menu, choose Refresh counts.
 - Wait for the task to finish.
 - **Expected:** Environment Last sync and CV content columns update without reload.
 4. Refresh counts (content view)
 - Expand a content view, use Refresh counts from its kebab menu.
 - Wait for the task to finish.
 - **Expected:** That CV’s sync and package/content counts update without reload.
 5. Regression
 - Confirm sync progress and messages in the Content Sync section still behave as before.
 - Navigate away from the tab and back; confirm data loads normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart Proxy content now auto-refreshes in response to capsule synchronization lifecycle, including “sync started” and “sync changed” triggers.
  * Updating Smart Proxy content counts now starts task polling when a task id is returned, with user-visible “task started” notifications.

* **Enhancements**
  * Added a coordinated two-phase refresh flow (sync phase, then counts phase) with grace/timeout behavior to keep counts accurate.
  * Improved monitoring of pending/running content-count tasks to reduce stale or inconsistent count displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->