### PR TITLE
Refs #39330 - Reload host after create to preserve content facet

### DIFF
--- a/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/hosts_controller_extensions.rb
@@ -49,7 +49,10 @@ module Katello
           # validations should occur before the action so that the request can fail and not render multiple responses
           cves = validate_content_view_environment_params
           yield
-          # the actual assigning needs to wait until the host is created
+          # Skip if the create action didn't persist the host
+          return unless @host&.persisted?
+          # Reload so @host.content_facet reflects what the create action saved
+          @host.reload
           set_content_view_environments(cves)
         end
 

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -178,15 +178,12 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     @controller.expects(:validate_content_view_environment_params).returns([katello_content_view_environments(:library_default_view_environment)])
     @controller.expects(:set_content_view_environments).with([katello_content_view_environments(:library_default_view_environment)])
 
-    post :create, params: {
-      :host => {
-        :name => "contenthost.example.com",
-        :content_facet_attributes => {
-          :content_view_environments => ["Library"],
-        },
-      },
-    }, session: set_session_user
-    # no assertions needed about the response, we're just making sure handle_content_view_environments_for_create is called
+    cf_attrs = {:content_view_id => @content_view.id, :lifecycle_environment_id => @environment.id,
+                :content_view_environments => ["Library"]}
+    attrs = @host.clone.attributes.merge("name" => "contenthost.example.com", "content_facet_attributes" => cf_attrs).compact
+
+    post :create, params: attrs, session: set_session_user
+    assert_response :success
   end
 
   def test_handle_content_view_environments_for_update


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Add `@host&.reload` after `yield` in `handle_content_view_environments_for_create` so that the content facet built by the normal create action (with `content_source_id`, `kickstart_repository_id`, etc.) is loaded into memory before `set_content_view_environments` runs.

This allows PRT to pass on https://github.com/SatelliteQE/robottelo/pull/21644

#### Considerations taken when implementing this change?

After the `around_action` yields to the Foreman host create action, `@host.content_facet` may not be loaded in memory even though it was persisted to the database. Without a reload, `set_content_view_environments` sees `content_facet` as blank and creates a new empty `ContentFacet`, losing `content_source_id` and other attributes that were set during the normal create flow.

#### What are the testing steps for this pull request?

1. Create a host via API with `content_facet_attributes` containing both `content_source_id` and `content_view_environment_ids`
2. Read the host back and verify `content_source_id` is present in the response

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host creation now reliably preserves and reflects selected content view environments and content sources by using the persisted host state after create.

* **Tests**
  * Controller test updated to better simulate host creation parameters, improving coverage of content view environment persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->