### PR TITLE
Fixes #39392 - Use find_by in DeleteDistributions finalize

### DIFF
--- a/app/lib/actions/pulp3/repository/delete_distributions.rb
+++ b/app/lib/actions/pulp3/repository/delete_distributions.rb
@@ -12,8 +12,8 @@ module Actions
         end
 
         def finalize
-          # Only destroy the distribution reference after Pulp task succeeds
-          repo = ::Katello::Repository.find(input[:repository_id])
+          repo = ::Katello::Repository.find_by(id: input[:repository_id])
+          return unless repo
           dist_ref = repo.backend_service(smart_proxy).distribution_reference
           dist_ref&.destroy!
         end

--- a/test/actions/pulp3/repository/delete_distributions_test.rb
+++ b/test/actions/pulp3/repository/delete_distributions_test.rb
@@ -1,0 +1,28 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3::Repository
+  class DeleteDistributionsTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::RemoteAction
+
+    let(:action_class) { ::Actions::Pulp3::Repository::DeleteDistributions }
+
+    before do
+      stub_remote_user
+    end
+
+    it 'finalize does not raise when repository is already destroyed' do
+      smart_proxy = SmartProxy.pulp_primary
+      planned_action = create_and_plan_action(
+        action_class,
+        -1,
+        smart_proxy
+      )
+
+      assert_nil ::Katello::Repository.find_by(id: -1)
+      assert_nothing_raised do
+        finalize_action(planned_action)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

PR #11762 changed `DeleteDistributions` from a synchronous action to `AbstractAsyncTask`, adding a `finalize` method that calls `Repository.find(id)` to clean up the distribution reference after the Pulp task completes. However, during organization destroy, `Repository::Destroy#finalize` runs first and deletes the repository record, so `DeleteDistributions#finalize` raises `ActiveRecord::RecordNotFound`.

This switches to `find_by` with a guard clause, matching the pattern already used by `Repository::Destroy#finalize`.

**Root cause trace:**
1. `DeleteDistributions#invoke_external_task` — finds the repo, starts async Pulp distribution delete
2. `Repository::Destroy#finalize` — calls `repository.destroy!`, deleting the DB record
3. `DeleteDistributions#finalize` — calls `Repository.find(id)` — raises because record is gone

**CI evidence:** foreman-pipeline-katello-rpm-nightly [#1134](https://ci.theforeman.org/job/foreman-pipeline-katello-rpm-nightly/1134/) — all `fb-destroy-organization.bats` tests failing with `Couldn't find Katello::Repository with 'id'=14`

## Test plan

- [ ] Run `hammer organization delete` on an org with synced repos, content views, and lifecycle environments
- [ ] Verify org deletes cleanly without `Couldn't find Katello::Repository` errors
- [ ] Verify standalone repo deletion still cleans up distribution references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Finalization now safely skips cleanup when the target repository record is missing, preventing errors if the repository was removed earlier and ensuring background cleanup completes without exceptions.

* **Tests**
  * Added a test confirming finalization does not raise when the repository has already been destroyed, improving reliability of remote action handling and regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->