### PR TITLE
Rename displayMessage to message in API error responses

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -42,11 +42,16 @@ module Katello
           if body_json['message'] && body_json['displayMessage'].nil?
             body_json['displayMessage'] = body_json['message']
           end
-          response.body = body_json.to_s
+          response.body = body_json.to_json
         rescue JSON::ParserError
           # Not a json response, leave as-is
         end
       end
+    end
+
+    # subscription-manager expects displayMessage in error responses
+    def error_response_json(display_message, errors)
+      { :displayMessage => display_message, :errors => errors }
     end
 
     rescue_from RestClient::Exception do |e|
@@ -164,7 +169,7 @@ module Katello
       User.as_anonymous_admin do
         @host.import_tracer_profile(params[:traces])
       end
-      render json: { displayMessage: _("Tracer profile uploaded successfully") }
+      render json: { message: _("Tracer profile uploaded successfully") }
     end
 
     def available_releases

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -163,7 +163,7 @@ module Katello
                            "Updated content view environments for %{count} hosts",
                            registered_hosts.count) % { :count => registered_hosts.count }
 
-      response = { :displayMessage => success_message }
+      response = { :message => success_message }
 
       if unregistered_count > 0
         skipped_message = n_("Skipped %{count} unregistered host",

--- a/app/lib/katello/api/v2/error_handling.rb
+++ b/app/lib/katello/api/v2/error_handling.rb
@@ -127,17 +127,21 @@ module Katello
           options[:errors] = exception.try(:record).try(:errors) || [exception.message]
 
           logger.error pp_exception(exception) if options[:with_logging]
+          error_json = error_response_json(options[:display_message], options[:errors])
           respond_to do |format|
-            #json has to be displayMessage for older RHEL 5.7 subscription managers
-            format.json { render :json => { :displayMessage => options[:display_message], :errors => options[:errors]}, :status => options[:status] }
+            format.json { render :json => error_json, :status => options[:status] }
             format.all do
               if options[:force_json]
-                render :json => { :displayMessage => options[:display_message], :errors => options[:errors]}, :status => options[:status]
+                render :json => error_json, :status => options[:status]
               else
                 render :plain => options[:text], :status => options[:status]
               end
             end
           end
+        end
+
+        def error_response_json(display_message, errors)
+          { :message => display_message, :errors => errors }
         end
 
         def pp_exception(exception, options = {})
@@ -153,9 +157,10 @@ module Katello
         def format_subsys_exception_hash(exception)
           orig_hash = JSON.parse(exception.response).with_indifferent_access rescue {}
 
-          orig_hash[:displayMessage] = exception.response.to_s.gsub(/^"|"$/, "") if orig_hash[:displayMessage].nil? && exception.respond_to?(:response)
-          orig_hash[:displayMessage] = exception.message if orig_hash[:displayMessage].blank?
-          orig_hash[:errors] = [orig_hash[:displayMessage]] if orig_hash[:errors].nil?
+          orig_hash[:message] = orig_hash.delete(:displayMessage) || orig_hash[:message]
+          orig_hash[:message] = exception.response.to_s.gsub(/^"|"$/, "") if orig_hash[:message].nil? && exception.respond_to?(:response)
+          orig_hash[:message] = exception.message if orig_hash[:message].blank?
+          orig_hash[:errors] = [orig_hash[:message]] if orig_hash[:errors].nil?
           orig_hash
         end
       end

--- a/engines/bastion/app/assets/javascripts/bastion/auth/auth.module.js
+++ b/engines/bastion/app/assets/javascripts/bastion/auth/auth.module.js
@@ -40,7 +40,7 @@ angular.module('Bastion.auth').config(['$httpProvider', '$provide',
                                 // Add unauthorized display message to response
                                 message = translate('You are not authorized to perform this action.');
                                 response.data.errors = [message];
-                                response.data.displayMessage = message;
+                                response.data.message = message;
                             }
 
                             return $q.reject(response);

--- a/engines/bastion/test/test-mocks.module.js
+++ b/engines/bastion/test/test-mocks.module.js
@@ -71,7 +71,7 @@ angular.module('Bastion.test-mocks').factory('MockResource', ['$q', function ($q
                 }
 
                 if (this.failed) {
-                    error({ data: {errors: ['error!'], displayMessage: 'error!'}});
+                    error({ data: {errors: ['error!'], message: 'error!'}});
                 } else {
                     success(this);
                 }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-copy.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-copy.controller.js
@@ -16,7 +16,7 @@
             ActivationKey.copy({id: $scope.activationKey.id, 'new_name': newName}, function (response) {
                 $scope.transitionTo('activation-key.info', {activationKeyId: response.id});
             }, function (response) {
-                Notification.setErrorMessage(response.data.displayMessage);
+                Notification.setErrorMessage(response.data.message);
             });
         };
         // Labels so breadcrumb strings can be translated

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/activation-keys/details/activation-key-details.controller.js
@@ -50,7 +50,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
                 Notification.setSuccessMessage(translate('Activation Key updated'));
             }, function (response) {
                 deferred.reject(response);
-                Notification.setErrorMessage(translate("An error occurred saving the Activation Key: ") + response.data.displayMessage);
+                Notification.setErrorMessage(translate("An error occurred saving the Activation Key: ") + response.data.message);
             });
             return deferred.promise;
         };
@@ -64,7 +64,7 @@ angular.module('Bastion.activation-keys').controller('ActivationKeyDetailsContro
                 $scope.transitionTo('activation-keys');
                 Notification.setSuccessMessage(translate('Activation Key removed.'));
             }, function (response) {
-                Notification.setErrorMessage(translate("An error occurred removing the Activation Key: ") + response.data.displayMessage);
+                Notification.setErrorMessage(translate("An error occurred removing the Activation Key: ") + response.data.message);
             });
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -25,11 +25,11 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
 
         function processError(response, prependMsg) {
             var msg = '';
-            if (response.data && response.data.displayMessage) {
+            if (response.data && response.data.message) {
                 if (angular.isDefined(prependMsg)) {
                     msg = msg + prependMsg;
                 }
-                msg = msg + response.data.displayMessage;
+                msg = msg + response.data.message;
                 Notification.setErrorMessage(msg);
             }
         }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-details-info.controller.js
@@ -31,7 +31,7 @@ angular.module('Bastion.content-credentials').controller('ContentCredentialDetai
                     $scope.uploadStatus = 'success';
                     $scope.contentCredential.$get();
                 } else {
-                    Notification.setErrorMessage(content.displayMessage);
+                    Notification.setErrorMessage(content.message);
                     $scope.uploadStatus = 'error';
                 }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/details/content-credential-details.controller.js
@@ -33,7 +33,7 @@ angular.module('Bastion.content-credentials').controller('ContentCredentialDetai
 
             }, function (response) {
                 deferred.reject(response);
-                Notification.setErrorMessage(response.data.displayMessage);
+                Notification.setErrorMessage(response.data.message);
             });
 
             return deferred.promise;
@@ -46,7 +46,7 @@ angular.module('Bastion.content-credentials').controller('ContentCredentialDetai
                 $scope.transitionTo('content-credentials');
             }, function (response) {
                 deferred.reject(response);
-                Notification.setErrorMessage(response.data.displayMessage);
+                Notification.setErrorMessage(response.data.message);
             });
             return deferred.promise;
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/new/new-content-credential.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/content-credentials/new/new-content-credential.controller.js
@@ -31,7 +31,7 @@ angular.module('Bastion.content-credentials').controller('NewContentCredentialCo
                     $scope.transitionTo('content-credential.info', {contentCredentialId: response.id});
                     Notification.setSuccessMessage(translate('Content Credential %s has been created.').replace('%s', response.name));
                 } else {
-                    Notification.setErrorMessage(translate("An error occurred while creating the Content Credential: ") + response.displayMessage);
+                    Notification.setErrorMessage(translate("An error occurred while creating the Content Credential: ") + response.message);
                     $scope.uploadStatus = 'error';
                 }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/environments/details/environment.controller.js
@@ -61,7 +61,7 @@
 
             function error(response) {
                 Notification.setErrorMessage(translate("An error occurred removing the environment: ") +
-                    response.data.displayMessage);
+                    response.data.message);
             }
 
             promise = environment.$delete();

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-add-hosts.controller.js
@@ -74,7 +74,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionAddHostsCon
                 contentNutupane.refresh();
                 $scope.refreshHostCollection();
             }, function (response) {
-                Notification.setErrorMessage(response.data.displayMessage);
+                Notification.setErrorMessage(response.data.message);
                 $scope.isAdding = false;
             });
         };

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-copy.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-copy.controller.js
@@ -16,7 +16,7 @@
             HostCollection.copy({id: $scope.$stateParams.hostCollectionId, 'host_collection': {name: newName}}, function (response) {
                 $scope.transitionTo('host-collection.info', {hostCollectionId: response.id});
             }, function (response) {
-                Notification.setErrorMessage(response.data.displayMessage);
+                Notification.setErrorMessage(response.data.message);
             });
         };
         // Labels so breadcrumb strings can be translated

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-details.controller.js
@@ -86,7 +86,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionDetailsCont
                 $scope.table.replaceRow(response);
             }, function (response) {
                 deferred.reject(response);
-                Notification.setErrorMessage(translate("An error occurred saving the Host Collection: ") + response.data.displayMessage);
+                Notification.setErrorMessage(translate("An error occurred saving the Host Collection: ") + response.data.message);
             });
             return deferred.promise;
         };
@@ -96,7 +96,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionDetailsCont
                 $scope.transitionTo('host-collections');
                 Notification.setSuccessMessage(translate('Host Collection removed.'));
             }, function (response) {
-                Notification.setErrorMessage(translate("An error occurred removing the Host Collection: ") + response.data.displayMessage);
+                Notification.setErrorMessage(translate("An error occurred removing the Host Collection: ") + response.data.message);
             });
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-hosts.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/host-collections/details/host-collection-hosts.controller.js
@@ -74,7 +74,7 @@ angular.module('Bastion.host-collections').controller('HostCollectionHostsContro
                 $scope.isRemoving = false;
             }, function (response) {
                 $scope.isRemoving = false;
-                Notification.setErrorMessage(translate("An error occurred removing the content hosts.") + response.data.displayMessage);
+                Notification.setErrorMessage(translate("An error occurred removing the content hosts.") + response.data.message);
             });
         };
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-info.controller.js
@@ -160,7 +160,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                     Notification.setSuccessMessage(translate('Repository Saved.'));
                 }, function (response) {
                     deferred.reject(response);
-                    Notification.setErrorMessage(translate("An error occurred saving the Repository: ") + response.data.displayMessage);
+                    Notification.setErrorMessage(translate("An error occurred saving the Repository: ") + response.data.message);
                 });
 
                 return deferred.promise;
@@ -185,7 +185,7 @@ angular.module('Bastion.repositories').controller('RepositoryDetailsInfoControll
                         Notification.setSuccessMessage(translate('Successfully uploaded content: ') + uploaded);
                         $scope.repository.$get();
                     } else {
-                        error = returnData.displayMessage;
+                        error = (returnData && returnData.message) || returnData || translate('Unknown error');
                         Notification.setErrorMessage(translate('Error during upload: ') + error);
                     }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/details/repository-details-manage-content.controller.js
@@ -56,7 +56,7 @@ angular.module('Bastion.repositories').controller('RepositoryManageContentContro
 
         function error(data) {
             $scope.table.working = true;
-            Notification.setErrorMessage(data.response.displayMessage);
+            Notification.setErrorMessage(data.response.message);
         }
 
         $scope.repository = Repository.get({id: $scope.$stateParams.repositoryId}, function (repository) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/details/repositories/new/new-repository.controller.js
@@ -52,7 +52,7 @@ angular.module('Bastion.repositories').controller('NewRepositoryController',
                 });
 
                 if (!foundError) {
-                    Notification.setErrorMessage(response.data.displayMessage);
+                    Notification.setErrorMessage(response.data.message);
                 }
             }
 

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/products/discovery/discovery-create.controller.js
@@ -67,7 +67,7 @@ angular.module('Bastion.products').controller('DiscoveryCreateController',
         function repoCreateError(response) {
             var currentlyCreating = $scope.currentlyCreating;
             $scope.currentlyCreating = undefined;
-            currentlyCreating.messages = response.data.displayMessage;
+            currentlyCreating.messages = response.data.message;
             currentlyCreating.creating = false;
             currentlyCreating.form.$invalid = true;
         }

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-add-products.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/sync-plans/details/sync-plan-add-products.controller.js
@@ -61,7 +61,7 @@ angular.module('Bastion.sync-plans').controller('SyncPlanAddProductsController',
 
                 error = function (response) {
                     deferred.reject(response.data.errors);
-                    Notification.setErrorMessage(response.data.displayMessage);
+                    Notification.setErrorMessage(response.data.message);
                     $scope.table.working = false;
                 };
 

--- a/engines/bastion_katello/test/content-credentials/details/content-credential-details-info.controller.test.js
+++ b/engines/bastion_katello/test/content-credentials/details/content-credential-details-info.controller.test.js
@@ -52,7 +52,7 @@ describe('Controller: ContentCredentialDetailsInfoController', function() {
         spyOn(Notification, 'setErrorMessage');
 
         spyOn($scope.contentCredential, '$get');
-        $scope.uploadContent({"errors": "....", "displayMessage":"......"});
+        $scope.uploadContent({"errors": "....", "message":"......"});
 
         expect(Notification.setErrorMessage).toHaveBeenCalled();
         expect($scope.contentCredential.$get).not.toHaveBeenCalled();

--- a/engines/bastion_katello/test/content-credentials/new/new-content-credential-controller.test.js
+++ b/engines/bastion_katello/test/content-credentials/new/new-content-credential-controller.test.js
@@ -49,7 +49,7 @@ describe('Controller: NewContentCredentialController', function() {
         spyOn(Notification, "setSuccessMessage");
         spyOn(Notification, 'setErrorMessage');
 
-        $scope.uploadContent({"errors": "....", "displayMessage":"......"});
+        $scope.uploadContent({"errors": "....", "message":"......"});
 
         expect(Notification.setSuccessMessage).not.toHaveBeenCalled();
         expect(Notification.setErrorMessage).toHaveBeenCalled();

--- a/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
+++ b/engines/bastion_katello/test/products/details/repositories/details/repository-details-info.controller.test.js
@@ -182,7 +182,7 @@ describe('Controller: RepositoryDetailsInfoController', function() {
 
     it('should set an error message if a file upload status is not success', function() {
         spyOn(Notification, 'setErrorMessage');
-        $scope.uploadContent('<pre>{"displayMessage": "blah"}</pre>', true);
+        $scope.uploadContent('<pre>{"message": "blah"}</pre>', true);
         expect(Notification.setErrorMessage).toHaveBeenCalledWith('Error during upload: blah');
     });
 

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -135,6 +135,19 @@ module Katello
         assert_equal 'Registering to multiple environments is not enabled.', body['displayMessage']
         assert_response 400
       end
+
+      it "should return displayMessage instead of message for RHSM error responses" do
+        ::Katello::RegistrationManager.expects(:process_registration).never
+
+        post(:consumer_create, params: { :organization_id => 'nonexistent_org', :facts => @facts })
+
+        assert_response :not_found
+        body = JSON.parse(response.body)
+        assert body.key?('displayMessage'), 'RHSM error responses must include displayMessage for subscription-manager compatibility'
+        assert_not_nil body['displayMessage']
+        refute_empty body['displayMessage']
+        refute body.key?('message'), 'RHSM error responses should use displayMessage, not message'
+      end
     end
 
     describe "update enabled_repos" do

--- a/test/controllers/api/v2/activation_keys_controller_test.rb
+++ b/test/controllers/api/v2/activation_keys_controller_test.rb
@@ -603,8 +603,8 @@ module Katello
       response_body = JSON.parse(@response.body).with_indifferent_access
       assert_response 400
       assert response_body[:errors].count > 0
-      assert_match "not found in the Organization", response_body[:displayMessage]
-      ["croissant", "crepe"].map { |label| assert_includes response_body[:displayMessage], label }
+      assert_match "not found in the Organization", response_body[:message]
+      ["croissant", "crepe"].map { |label| assert_includes response_body[:message], label }
     end
 
     def test_remove_host_collections

--- a/test/controllers/api/v2/content_export_incrementals_controller_test.rb
+++ b/test/controllers/api/v2/content_export_incrementals_controller_test.rb
@@ -169,7 +169,7 @@ module Katello
 
       post :library, params: { organization_id: org.id,
                                from_latest_increment: true }
-      response = JSON.parse(@response.body)['displayMessage']
+      response = JSON.parse(@response.body)['message']
       assert_match(/Unable to find a base content view to use for incremental export. Please run a complete export instead./, response)
       assert_response :bad_request
     end

--- a/test/controllers/api/v2/content_views_controller_test.rb
+++ b/test/controllers/api/v2/content_views_controller_test.rb
@@ -287,7 +287,7 @@ module Katello
       view_version2 = create(:katello_content_view_version, :content_view => view, :major => 9001)
 
       put :update, params: { id: composite.id, content_view: { component_ids: [view_version.id, view_version2.id] } }
-      display_message = JSON.parse(response.body)['displayMessage']
+      display_message = JSON.parse(response.body)['message']
       test_message = "Validation failed: Base Another component already includes content view with ID #{view_version.content_view_id}"
       assert_equal test_message, display_message
     end

--- a/test/controllers/api/v2/flatpak_remote_repositories_controller_test.rb
+++ b/test/controllers/api/v2/flatpak_remote_repositories_controller_test.rb
@@ -111,7 +111,7 @@ module Katello
 
       assert_response :bad_request
       response_body = JSON.parse(response.body)
-      assert_match(/Product must be specified/, response_body['displayMessage'])
+      assert_match(/Product must be specified/, response_body['message'])
     end
 
     def test_mirror_product_name_organization_missing
@@ -122,7 +122,7 @@ module Katello
 
       assert_response :bad_request
       response_body = JSON.parse(response.body)
-      assert_match(/Organization must be specified when providing product by name/, response_body['displayMessage'])
+      assert_match(/Organization must be specified when providing product by name/, response_body['message'])
     end
 
     def test_mirror_product_id_invalid
@@ -143,7 +143,7 @@ module Katello
 
       assert_response :not_found
       response_body = JSON.parse(response.body)
-      assert_match(/Could not find product/, response_body['displayMessage'])
+      assert_match(/Could not find product/, response_body['message'])
     end
 
     def test_mirror_product_redhat
@@ -155,7 +155,7 @@ module Katello
 
       assert_response :unprocessable_entity
       response_body = JSON.parse(response.body)
-      assert_match(/cannot be mirrored into Red Hat products/, response_body['displayMessage'])
+      assert_match(/cannot be mirrored into Red Hat products/, response_body['message'])
     end
   end
 end

--- a/test/controllers/api/v2/host_collections_controller_test.rb
+++ b/test/controllers/api/v2/host_collections_controller_test.rb
@@ -99,7 +99,7 @@ module Katello
       assert_response :unprocessable_entity
       results = JSON.parse(response.body)
       error_message = "must be a positive integer value."
-      assert_includes results["displayMessage"], error_message
+      assert_includes results["message"], error_message
     end
 
     def test_nil_max_hosts
@@ -107,7 +107,7 @@ module Katello
       assert_response :unprocessable_entity
       results = JSON.parse(response.body)
       error_message = "must be given a value if this host collection is not unlimited."
-      assert_includes results["displayMessage"], error_message
+      assert_includes results["message"], error_message
     end
 
     test_attributes :pid => '9dc0ad72-58c2-4079-b1ca-2c4373472f0f'

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -105,8 +105,8 @@ module Katello
 
       assert_response :success
       body = JSON.parse(response.body)
-      assert_includes body['displayMessage'], 'Updated content view environments'
-      assert_includes body['displayMessage'], '2 hosts'
+      assert_includes body['message'], 'Updated content view environments'
+      assert_includes body['message'], '2 hosts'
 
       # Verify hosts were updated
       @host1.reload
@@ -135,8 +135,8 @@ module Katello
 
       assert_response :success
       body = JSON.parse(response.body)
-      assert_includes body['displayMessage'], 'Updated content view environments'
-      assert_includes body['displayMessage'], '2 hosts'
+      assert_includes body['message'], 'Updated content view environments'
+      assert_includes body['message'], '2 hosts'
 
       # Verify hosts were updated with multiple content view environments
       @host1.reload
@@ -166,9 +166,9 @@ module Katello
       assert_response :success
       body = JSON.parse(response.body)
       # Verify singular form is used for 1 host
-      assert_includes body['displayMessage'], 'Updated content view environments'
-      assert_includes body['displayMessage'], '1 host'
-      refute_includes body['displayMessage'], '1 hosts'
+      assert_includes body['message'], 'Updated content view environments'
+      assert_includes body['message'], '1 host'
+      refute_includes body['message'], '1 hosts'
     end
 
     def test_assign_content_view_environments_missing_params
@@ -179,7 +179,7 @@ module Katello
 
       assert_response :unprocessable_entity
       body = JSON.parse(response.body)
-      assert_includes body['displayMessage'], 'content_view_environments or content_view_environment_ids must be provided'
+      assert_includes body['message'], 'content_view_environments or content_view_environment_ids must be provided'
     end
 
     def test_assign_content_view_environments_invalid_content_view_environment
@@ -191,7 +191,7 @@ module Katello
 
       assert_response :unprocessable_entity
       body = JSON.parse(response.body)
-      assert_includes body['displayMessage'], 'No content view environments found with ids'
+      assert_includes body['message'], 'No content view environments found with ids'
     end
 
     def test_assign_content_view_environments_permissions
@@ -230,7 +230,7 @@ module Katello
       assert_response :success
       body = JSON.parse(response.body)
       # Should process 1 registered host and skip 1 unregistered
-      assert_includes body['displayMessage'], 'Updated content view environments for 1 host'
+      assert_includes body['message'], 'Updated content view environments for 1 host'
       assert_includes body['warningMessage'], 'Skipped 1 unregistered host'
 
       # Verify registered host was updated
@@ -261,7 +261,7 @@ module Katello
       assert_response :success
       body = JSON.parse(response.body)
       # Should process 2 registered hosts and skip 2 unregistered
-      assert_includes body['displayMessage'], 'Updated content view environments for 2 hosts'
+      assert_includes body['message'], 'Updated content view environments for 2 hosts'
       assert_includes body['warningMessage'], 'Skipped 2 unregistered hosts'
 
       # Verify registered hosts were updated
@@ -285,7 +285,7 @@ module Katello
 
       assert_response :success
       body = JSON.parse(response.body)
-      assert_includes body['displayMessage'], 'Updated content view environments'
+      assert_includes body['message'], 'Updated content view environments'
 
       # Verify hosts were updated
       @host1.reload
@@ -616,7 +616,7 @@ module Katello
 
       body = JSON.parse(response.body)
 
-      assert_includes body['displayMessage'], 'Either trace_search or trace_ids must be provided'
+      assert_includes body['message'], 'Either trace_search or trace_ids must be provided'
     end
 
     def test_resolve_traces_permission

--- a/test/controllers/api/v2/repositories_controller_test.rb
+++ b/test/controllers/api/v2/repositories_controller_test.rb
@@ -59,7 +59,7 @@ module Katello
       get :index, params: { :organization_id => @organization.id, :content_type => 'cheese' }
 
       assert_response 422
-      response = "{\"displayMessage\":\"Invalid params provided - content_type must be one of ansible_collection,deb,docker,file,ostree,python,yum\"," \
+      response = "{\"message\":\"Invalid params provided - content_type must be one of ansible_collection,deb,docker,file,ostree,python,yum\"," \
         "\"errors\":[\"Invalid params provided - content_type must be one of ansible_collection,deb,docker,file,ostree,python,yum\"]}"
       assert_match response, @response.body
     end
@@ -68,7 +68,7 @@ module Katello
       get :index, params: { :organization_id => @organization.id, :with_content => 'cheese' }
 
       assert_response 422
-      response = "{\"displayMessage\":\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,erratum,file,modulemd,"\
+      response = "{\"message\":\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,erratum,file,modulemd,"\
           "ostree_ref,package_group,python_package,rpm,srpm\",\"errors\":"\
         "[\"Invalid params provided - with_content must be one of ansible_collection,deb,docker_manifest,docker_manifest_list,docker_tag,erratum,file,modulemd,ostree_ref,package_group,python_package,rpm,srpm\"]}"
       assert_match response, @response.body
@@ -780,7 +780,7 @@ module Katello
       put :remove_content, params: { :id => @repository.id, :ids => [@rpm.pulp_id], :content_type => 'cheese' }
 
       assert_response 400
-      assert_match "{\"displayMessage\":\"Content type cheese is incompatible with repositories of type yum\",\"errors\":[\"Content type cheese is incompatible with repositories of type yum\"]}",
+      assert_match "{\"message\":\"Content type cheese is incompatible with repositories of type yum\",\"errors\":[\"Content type cheese is incompatible with repositories of type yum\"]}",
         @response.body
     end
 
@@ -966,7 +966,7 @@ module Katello
       post :upload_content, params: { :id => @repository.id, :content_type => 'cheese' }
 
       assert_response 422
-      response =  "{\"displayMessage\":\"Invalid params provided - content_type must be one of deb,file,ostree_ref,python_package,rpm,srpm\"," \
+      response =  "{\"message\":\"Invalid params provided - content_type must be one of deb,file,ostree_ref,python_package,rpm,srpm\"," \
         "\"errors\":[\"Invalid params provided - content_type must be one of deb,file,ostree_ref,python_package,rpm,srpm\"]}"
       assert_match response, @response.body
     end
@@ -991,8 +991,9 @@ module Katello
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
 
       response = JSON.parse(@response.body)
-      assert response.key?('displayMessage')
-      assert_equal 'Checksum is a required parameter.', response['displayMessage']
+      assert response.key?('message')
+      refute response.key?('displayMessage'), 'Non-RHSM API error responses should use message, not displayMessage'
+      assert_equal 'Checksum is a required parameter.', response['message']
 
       assert_response :bad_request
     end
@@ -1003,8 +1004,8 @@ module Katello
       put :import_uploads, params: { id: @repository.id, uploads: uploads }
 
       response = JSON.parse(@response.body)
-      assert response.key?('displayMessage')
-      assert_equal 'Name is a required parameter.', response['displayMessage']
+      assert response.key?('message')
+      assert_equal 'Name is a required parameter.', response['message']
 
       assert_response :bad_request
     end

--- a/webpack/components/Table/EmptyStateMessage.js
+++ b/webpack/components/Table/EmptyStateMessage.js
@@ -43,7 +43,7 @@ const EmptyStateMessage = ({
     } else if (error?.response?.status) {
       const { response: { status } } = error;
       emptyStateTitle = status;
-      emptyStateBody = error?.response?.data?.displayMessage || __('Something went wrong! Please check server logs!');
+      emptyStateBody = error?.response?.data?.message || __('Something went wrong! Please check server logs!');
     }
   }
   const defaultSecondaryActionText = searchIsActive ? __('Clear search') : __('Clear filters');

--- a/webpack/components/extensions/Hosts/BulkActions/BulkAssignCVEnvsModal/actions.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkAssignCVEnvsModal/actions.js
@@ -8,8 +8,8 @@ import { foremanApi } from '../../../../../services/api';
 const BULK_ASSIGN_CVES_KEY = 'BULK_ASSIGN_CONTENT_VIEW_ENVIRONMENTS';
 
 const successToast = (response) => {
-  const { displayMessage, warningMessage } = response.data || {};
-  const successMessage = displayMessage || __('Host content view environments updated.');
+  const { message: responseMessage, warningMessage } = response.data || {};
+  const successMessage = responseMessage || __('Host content view environments updated.');
 
   // Success toast
   store.dispatch(addToast({

--- a/webpack/mockRequest.js
+++ b/webpack/mockRequest.js
@@ -10,7 +10,7 @@ const methods = {
   DELETE: 'onDelete',
 };
 
-const errorResponse = msg => ({ displayMessage: msg });
+const errorResponse = msg => ({ message: msg });
 
 export const mockRequest = ({
   method = 'GET',

--- a/webpack/redux/actions/RedHatRepositories/repositorySetRepositories.js
+++ b/webpack/redux/actions/RedHatRepositories/repositorySetRepositories.js
@@ -80,7 +80,7 @@ const loadRepositorySetRepos = (contentId, productId) => async (dispatch) => {
 loadRepositorySetRepos.propTypes = {
   data: PropTypes.shape({
     error: PropTypes.shape({
-      displayMessage: PropTypes.string,
+      message: PropTypes.string,
     }),
   }),
 };

--- a/webpack/scenes/ContentCredentials/Details/ContentCredentialsDetailsActions.js
+++ b/webpack/scenes/ContentCredentials/Details/ContentCredentialsDetailsActions.js
@@ -39,8 +39,7 @@ export const updateContentCredential = (credentialId, params) => async (dispatch
     return response;
   } catch (error) {
     // Show error notification
-    const errorMessage = error?.response?.data?.displayMessage ||
-                         error?.response?.data?.message ||
+    const errorMessage = error?.response?.data?.message ||
                          error?.message ||
                          __('Failed to update content credential.');
     dispatch(addToast({

--- a/webpack/scenes/ContentCredentials/Details/__tests__/ContentCredentialsDetails.test.js
+++ b/webpack/scenes/ContentCredentials/Details/__tests__/ContentCredentialsDetails.test.js
@@ -245,7 +245,7 @@ test('shows error toast when delete fails', async () => {
   const deleteScope = nockInstance
     .delete(credentialDetailsPath)
     .reply(422, {
-      displayMessage: 'Cannot delete credential in use',
+      message: 'Cannot delete credential in use',
     });
 
   const { getByLabelText, getByText, queryByText } = renderWithRedux(

--- a/webpack/scenes/ContentCredentials/Details/__tests__/DetailsTab.test.js
+++ b/webpack/scenes/ContentCredentials/Details/__tests__/DetailsTab.test.js
@@ -128,7 +128,7 @@ test('failed file upload sends POST with error response', async () => {
   const uploadScope = nockInstance
     .post(uploadPath)
     .reply(422, {
-      displayMessage: 'Invalid GPG key content',
+      message: 'Invalid GPG key content',
       errors: { content: ['is invalid'] },
     });
 

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepositories.js
@@ -59,7 +59,7 @@ export const RepositorySetRepositories = ({
     return (
       <Alert
         variant="danger"
-        title={data.error.displayMessage}
+        title={data.error.message}
         ouiaId="repository-set-error-alert"
         isInline
       />
@@ -93,7 +93,7 @@ RepositorySetRepositories.propTypes = {
     loading: PropTypes.bool.isRequired,
     repositories: PropTypes.arrayOf(PropTypes.shape({})),
     error: PropTypes.shape({
-      displayMessage: PropTypes.string,
+      message: PropTypes.string,
     }),
   }).isRequired,
 };

--- a/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/__test__/RepositorySetRepository.test.js
+++ b/webpack/scenes/RedHatRepositories/components/RepositorySetRepository/__test__/RepositorySetRepository.test.js
@@ -277,7 +277,7 @@ describe('RepositorySetRepository Component', () => {
       const enableScope = nockInstance
         .put(enableApiPath)
         .reply(422, {
-          displayMessage: 'Repository cannot be enabled',
+          message: 'Repository cannot be enabled',
           errors: ['Repository already exists'],
         });
 

--- a/webpack/scenes/Settings/Tables/TableActions.js
+++ b/webpack/scenes/Settings/Tables/TableActions.js
@@ -12,7 +12,10 @@ import {
   UPDATE_TABLE_FAILURE,
 } from './TableConstants';
 
-const getResponseError = ({ data }) => data && (data.displayMessage || data.error);
+const getResponseError = (response = {}) => {
+  const { data } = response;
+  return data && (data.message || data.error);
+};
 
 export const loadTables = () => async (dispatch) => {
   dispatch({ type: TABLES_REQUEST, params: {} });

--- a/webpack/utils/helpers.js
+++ b/webpack/utils/helpers.js
@@ -34,10 +34,9 @@ const getCustomMessage = (actionType, message) => {
 
 export const getResponseErrorMsgs = ({ data, actionType } = {}) => {
   if (data) {
-    const customMessage = getCustomMessage(actionType, data.displayMessage);
+    const customMessage = getCustomMessage(actionType, data.message);
     const messages =
       customMessage ||
-      data.displayMessage ||
       data.message ||
       data.errors ||
       data.error?.message;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Align Katello API error responses with Foreman core's standard `message` key. The `displayMessage` convention originated from RHEL 5.7 subscription-manager compatibility which is long EOL.

Extract error_response_json method in ErrorHandling that returns `message` by default. CandlepinProxiesController overrides it to return `displayMessage` so subscription-manager clients continue to work.

Also fixes repackage_message to use to_json instead of to_s which produced invalid Ruby hash syntax instead of JSON.

#### Considerations taken when implementing this change?

Did not change anything related to bulk actions or host collections which uses `displayMessages`

#### What are the testing steps for this pull request?

Test errors with subman, hammer, UI to make sure they still flow through correctly:

```bash
subscription-manager environments --set Library/RHEL9
This operation requires user credentials
Username: admin
Password:
Validation failed: Host host.example.com: Cannot add content view environment to content facet. The host's content source 'capsule.example.com' does not sync lifecycle environment 'Library'. (HTTP error code 422: Unprocessable Entity)
```

```bash
hammer host update --id 3 --content-view-environments Library/Zoo
Could not update the host:
Validation failed: Host host.example.com: Cannot add content view environment to content facet. The host's content source 'capsule.example.com' does not sync lifecycle environment 'Library'.
```

<img width="610" height="102" alt="image" src="https://github.com/user-attachments/assets/667a27f2-141d-4edf-a823-7168cc1e882c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized API error/success payloads to use a single "message" field so notifications, toasts, and error displays are consistent across uploads, saves, deletes, bulk actions, and other failures.
  * Improved error normalization so remote/server errors render reliably in the UI.

* **Chores**
  * Updated tests and mock responses to align with the new error/success payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->