### PR TITLE
Fixes #39398 - Pin pulp_rpm to 3.35.2

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "pulp_ansible_client", ">= 0.29.0", "< 0.30.0"
   gem.add_dependency "pulp_container_client", ">= 2.27.0", "< 2.28.0"
   gem.add_dependency "pulp_deb_client", ">= 3.8.0", "< 3.9.0"
-  gem.add_dependency "pulp_rpm_client", ">= 3.35.0", "< 3.36.0"
+  gem.add_dependency "pulp_rpm_client", ">= 3.35.0", "< 3.35.3"
   gem.add_dependency "pulp_certguard_client", ">= 3.105.0", "< 3.106.0"
   gem.add_dependency "pulp_python_client", ">= 3.27.0", "< 3.28.0"
   gem.add_dependency "pulp_ostree_client", ">= 2.6.0", "< 2.7.0"


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Pin pulp_rpm to 3.35.2
#### Considerations taken when implementing this change?
A re-record of VCRs on 3.35.3 brings up an error with repo modify API and overwrite param not being recognized. This is a binding generation issue since that param is available on the API.

This PR will unblock nighties while we investigate the API change further.

#### What are the testing steps for this pull request?
Green tests 🍏 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined dependency version constraints to ensure improved system stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->