### PR TITLE
Fixes #39763 - Add smart-proxy mTLS auth for container registry

### DIFF
--- a/app/controllers/katello/api/registry/registry_proxies_controller.rb
+++ b/app/controllers/katello/api/registry/registry_proxies_controller.rb
@@ -2,6 +2,7 @@ module Katello
   # rubocop:disable Metrics/ClassLength
   class Api::Registry::RegistryProxiesController < Api::V2::ApiController
     include Katello::Authentication::ClientAuthentication
+    include Foreman::Controller::SmartProxyAuth
     before_action :disable_strong_params
     before_action :confirm_settings
     skip_before_action :authorize
@@ -104,6 +105,11 @@ module Katello
     end
 
     def registry_authorize
+      if ssl_smart_proxy_with_container_registry?
+        User.current = User.anonymous_admin
+        return true
+      end
+
       @repository = find_readable_repository
       return true if ['GET', 'HEAD'].include?(request.method) && @repository && !require_user_authorization?
 
@@ -511,6 +517,15 @@ module Katello
 
     def ssl_client_authorized?(org_label)
       request.headers['HTTP_SSL_CLIENT_VERIFY'] == "SUCCESS" && request.headers['HTTP_SSL_CLIENT_S_DN'] == "O=#{org_label}"
+    end
+
+    def ssl_smart_proxy_with_container_registry?
+      qualifying_proxies = ::SmartProxy.unscoped
+                                       .with_container_registry_auth_enabled
+
+      return false if qualifying_proxies.empty?
+
+      auth_smart_proxy(qualifying_proxies)
     end
 
     def authorize_repository_read

--- a/app/controllers/katello/concerns/api/v2/smart_proxies_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/smart_proxies_controller_extensions.rb
@@ -9,6 +9,7 @@ module Katello
             param :download_policy, String, :required => false, :desc => N_('Download Policy of the capsule, must be one of %s') %
                 SmartProxy::DOWNLOAD_POLICIES.join(', ')
             param :http_proxy_id, Integer, :required => false, :desc => N_('Id of the HTTP proxy to use with alternate content sources')
+            param :container_registry_auth_enabled, :bool, :required => false, :desc => N_('Allow this smart proxy to authenticate to the container registry using its SSL client certificate')
           end
         end
       end

--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -66,6 +66,7 @@ module Katello
           :message => _("must be one of the following: %s") % DOWNLOAD_POLICIES.join(', '),
         }
         scope :with_content, -> { with_features(PULP_FEATURE, PULP_NODE_FEATURE, PULP3_FEATURE) }
+        scope :with_container_registry_auth_enabled, -> { where(:container_registry_auth_enabled => true) }
 
         def self.load_balanced
           proxies = unscoped.with_content # load balancing is only supported for pulp proxies

--- a/app/overrides/add_smart_proxy_form.rb
+++ b/app/overrides/add_smart_proxy_form.rb
@@ -17,3 +17,8 @@ Deface::Override.new(:virtual_path => "smart_proxies/_form",
                      :name => "add_smart_proxies_acs_http_proxy",
                      :insert_bottom => '#primary',
                      :partial => 'overrides/smart_proxies/acs_http_proxy')
+
+Deface::Override.new(:virtual_path => "smart_proxies/_form",
+                     :name => "add_smart_proxies_container_registry_auth",
+                     :insert_bottom => '#primary',
+                     :partial => 'overrides/smart_proxies/container_registry_auth')

--- a/app/views/overrides/smart_proxies/_container_registry_auth.html.erb
+++ b/app/views/overrides/smart_proxies/_container_registry_auth.html.erb
@@ -1,0 +1,3 @@
+<%= checkbox_f(f, :container_registry_auth_enabled,
+    :label => _("Container Registry Authentication"),
+    :label_help => _('Allow this smart proxy to pull and push container images using its SSL client certificate.')) %>

--- a/db/migrate/20260505000000_add_container_registry_auth_to_smart_proxy.katello.rb
+++ b/db/migrate/20260505000000_add_container_registry_auth_to_smart_proxy.katello.rb
@@ -1,0 +1,5 @@
+class AddContainerRegistryAuthToSmartProxy < ActiveRecord::Migration[7.0]
+  def change
+    add_column :smart_proxies, :container_registry_auth_enabled, :boolean, default: false, null: false
+  end
+end

--- a/lib/katello/plugin.rb
+++ b/lib/katello/plugin.rb
@@ -247,7 +247,7 @@ Foreman::Plugin.register :katello do
   parameter_filter ::Hostgroup, :content_view_id, :lifecycle_environment_id, :content_view_environment_id,
     :content_source_id, :kickstart_repository_id
   parameter_filter Organization, :label, :service_level
-  parameter_filter SmartProxy, :download_policy, :http_proxy_id, :lifecycle_environment_ids => []
+  parameter_filter SmartProxy, :download_policy, :http_proxy_id, :container_registry_auth_enabled, :lifecycle_environment_ids => []
 
   logger :glue, :enabled => true
   logger :pulp_rest, :enabled => true

--- a/test/controllers/api/registry/registry_proxies_controller_test.rb
+++ b/test/controllers/api/registry/registry_proxies_controller_test.rb
@@ -1618,5 +1618,108 @@ module Katello
       end
     end
     #rubocop:enable Metrics/BlockLength
+
+    describe "smart-proxy container registry authentication" do
+      def setup_smart_proxy(hostname)
+        proxy = FactoryBot.build(:smart_proxy)
+        proxy.url = "https://#{hostname}:9090"
+        proxy.container_registry_auth_enabled = true
+        proxy.save!(validate: false)
+        proxy
+      end
+
+      it "allows pull via smart-proxy SSL cert with container_registry capability" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+
+        proxy = setup_smart_proxy('proxy.example.com')
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        @controller.stubs(:auth_smart_proxy).returns(true)
+        get :pull_manifest, params: { repository: @docker_repo.container_repository_name, tag: 'latest' }
+        # 404 is expected (no Pulp backend in tests) but not 401/403
+        refute_equal 401, response.status
+        refute_equal 403, response.status
+      ensure
+        proxy&.destroy
+      end
+
+      it "rejects SSL cert whose hosts do not match any smart-proxy" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        @controller.stubs(:auth_smart_proxy).returns(false)
+        get :pull_manifest, params: { repository: @docker_repo.container_repository_name, tag: 'latest' }
+        assert_response :unauthorized
+      end
+
+      it "rejects a matching smart-proxy that lacks the container_registry capability" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+
+        feature = Feature.find_or_create_by!(name: 'Pulpcore')
+        proxy = FactoryBot.build(:smart_proxy)
+        proxy.url = "https://proxy.nocap.example.com:9090"
+        proxy.container_registry_auth_enabled = true
+        proxy.save!(validate: false)
+        spf = proxy.smart_proxy_features.build(feature: feature)
+        spf.capabilities = []
+        spf.save!
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        # auth_smart_proxy is never called because no qualifying proxies exist
+        get :pull_manifest, params: { repository: @docker_repo.container_repository_name, tag: 'latest' }
+        assert_response :unauthorized
+      ensure
+        proxy&.destroy
+      end
+
+      it "rejects a matching smart-proxy that has not been enabled for container registry auth" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+
+        proxy = FactoryBot.build(:smart_proxy)
+        proxy.url = "https://proxy.disabled.example.com:9090"
+        proxy.container_registry_auth_enabled = false
+        proxy.save!(validate: false)
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        # auth_smart_proxy is never called because no qualifying proxies exist
+        get :pull_manifest, params: { repository: @docker_repo.container_repository_name, tag: 'latest' }
+        assert_response :unauthorized
+      ensure
+        proxy&.destroy
+      end
+
+      it "rejects request when auth_smart_proxy returns false" do
+        @docker_repo.set_container_repository_name
+        @docker_repo.save!
+
+        proxy = setup_smart_proxy('proxy.example.com')
+
+        User.current = nil
+        session[:user] = nil
+        reset_api_credentials
+
+        @controller.stubs(:auth_smart_proxy).returns(false)
+        get :pull_manifest, params: { repository: @docker_repo.container_repository_name, tag: 'latest' }
+        assert_response :unauthorized
+      ensure
+        proxy&.destroy
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow smart-proxies to pull/push container images against Katello's registry using their existing Foreman SSL client certificate. 

A new `container_registry_auth_enabled` flag on SmartProxy opts proxies in explicitly.
<img width="324" height="60" alt="image" src="https://github.com/user-attachments/assets/69382251-ad5f-41fd-911d-a863d1dd700c" />



Katello PR: https://github.com/Katello/katello/pull/11776
Smart Proxy Ansible Director: https://github.com/ATIX-AG/smart_proxy_ansible_director/pull/24


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Smart Proxies can authenticate to the container registry using SSL client certificates.
  - Added a Smart Proxy setting and API support for enabling container registry authentication.
  - Smart Proxy status responses now include the container registry authentication setting.

- **Bug Fixes**
  - Registry access is limited to repositories within organizations assigned to the authenticated Smart Proxy.
  - Invalid, unauthorized, or unassigned Smart Proxy access is rejected, including cross-organization pushes.
  - Existing user authentication and organization-level certificate flows remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->