### PR TITLE
Fixes #39418 - Fix inherited synced content after parent hostgroup OS change

### DIFF
--- a/app/helpers/katello/kickstart_repository_helper.rb
+++ b/app/helpers/katello/kickstart_repository_helper.rb
@@ -15,9 +15,18 @@ module Katello
 
     def kickstart_repository_id(host, options = {})
       host_ks_repo_id = host_hostgroup_kickstart_repository_id(host)
+      selected_host_group = options.fetch(:selected_host_group, nil)
+
+      # if the kickstart repo id is set in the host use that
+      return host_ks_repo_id if host_ks_repo_id.present?
+
+      # Child hostgroups should remain on true inheritance unless explicitly overridden.
+      if host.is_a?(::Hostgroup) && host.parent_id.present?
+        return nil
+      end
+
       ks_repo_options = kickstart_repository_options(host, options)
       # if the kickstart repo id is set in the selected_hostgroup use that
-      selected_host_group = options.fetch(:selected_host_group, nil)
       if selected_host_group.try(:kickstart_repository_id).present?
         ks_repo_ids = ks_repo_options.map(&:id)
 
@@ -28,14 +37,6 @@ module Katello
         else
           return ks_repo_options.first.try(:id)
         end
-      end
-
-      # if the kickstart repo id is set in the host use that
-      return host_ks_repo_id if host_ks_repo_id.present?
-
-      # Child hostgroups should remain on true inheritance unless explicitly overridden.
-      if host.is_a?(::Hostgroup) && host.parent_id.present?
-        return nil
       end
 
       if selected_host_group.try(:medium_id).blank? && host.try(:medium_id).blank?

--- a/app/helpers/katello/kickstart_repository_helper.rb
+++ b/app/helpers/katello/kickstart_repository_helper.rb
@@ -2,6 +2,9 @@ module Katello
   module KickstartRepositoryHelper
     def use_install_media(host, options = {})
       return true if host&.errors && host.errors.include?(:medium_id) && host.medium.present?
+      if host.is_a?(::Hostgroup) && host.parent_id.present? && host.medium_id.blank? && host.kickstart_repository.present?
+        return false
+      end
       kickstart_repository_id(host, options).blank?
     end
 
@@ -29,6 +32,11 @@ module Katello
 
       # if the kickstart repo id is set in the host use that
       return host_ks_repo_id if host_ks_repo_id.present?
+
+      # Child hostgroups should remain on true inheritance unless explicitly overridden.
+      if host.is_a?(::Hostgroup) && host.parent_id.present?
+        return nil
+      end
 
       if selected_host_group.try(:medium_id).blank? && host.try(:medium_id).blank?
         ks_repo_options.first.try(:id)

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -128,7 +128,7 @@ module Katello
         ks_repos = operatingsystem.kickstart_repos(self, content_facet: effective_content_facet_for_kickstart(content_facet))
         return if ks_repos.blank?
 
-        if operatingsystem_id_changed?
+        if operatingsystem_changed_for_recalculation? || kickstart_repository_release_mismatch?
           release_match = equivalent_kickstart_repository_for_release(ks_repos)
           return release_match if release_match
 
@@ -169,8 +169,30 @@ module Katello
       end
 
       def should_recalculate_kickstart_repository?
-        content_facet&.kickstart_repository_id &&
-          (operatingsystem_id_changed? || !matching_kickstart_repository?(content_facet))
+        return false unless content_facet&.kickstart_repository_id
+        return true if operatingsystem_changed_for_recalculation?
+        return true if kickstart_repository_release_mismatch?
+        return true unless matching_kickstart_repository?(content_facet)
+
+        # Child hostgroups with inherited kickstart context can become stale when
+        # parent CVE/content source/OS changes while the stale repo ID remains listed.
+        ancestry.present? &&
+          (content_facet.content_view_environment_id.blank? || content_facet.content_source_id.blank?)
+      end
+
+      def operatingsystem_changed_for_recalculation?
+        changed_by_legacy_api = respond_to?(:operatingsystem_id_changed?) && operatingsystem_id_changed?
+        changed_by_dirty_tracking = respond_to?(:will_save_change_to_operatingsystem_id?) &&
+                                    will_save_change_to_operatingsystem_id?
+        changed_by_legacy_api || changed_by_dirty_tracking
+      end
+
+      def kickstart_repository_release_mismatch?
+        repo_release = content_facet&.kickstart_repository&.distribution_version
+        target_release = preferred_os_release_values.first
+        return false if repo_release.blank? || target_release.blank?
+
+        !(repo_release == target_release || repo_release.start_with?("#{target_release}."))
       end
 
       def equivalent_kickstart_repository_for_release(ks_repos)

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -123,7 +123,7 @@ module Katello
 
       def equivalent_kickstart_repository
         return unless operatingsystem &&
-                      content_facet.kickstart_repository &&
+                      content_facet&.kickstart_repository &&
                       operatingsystem.respond_to?(:kickstart_repos)
         ks_repos = operatingsystem.kickstart_repos(self, content_facet: effective_content_facet_for_kickstart(content_facet))
         return if ks_repos.blank?

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -39,10 +39,14 @@ module Katello
       end
 
       def correct_kickstart_repository
-        reconcile_medium_and_kickstart_repository
-        return unless should_recalculate_kickstart_repository?
+        ensure_single_installation_source
+        return unless content_facet&.kickstart_repository_id
 
-        equivalent = equivalent_kickstart_repository
+        effective_content_facet = content_facet_with_inheritance(content_facet)
+        ks_repos = operatingsystem_kickstart_repos(effective_content_facet)
+        return unless kickstart_repository_stale?(ks_repos: ks_repos, effective_content_facet: effective_content_facet)
+
+        equivalent = equivalent_kickstart_repository(ks_repos: ks_repos, effective_content_facet: effective_content_facet)
         return if equivalent.blank? || equivalent[:id] == content_facet.kickstart_repository_id
 
         self.content_facet.kickstart_repository_id = equivalent[:id]
@@ -121,34 +125,36 @@ module Katello
         end
       end
 
-      def equivalent_kickstart_repository
+      def equivalent_kickstart_repository(ks_repos: nil, effective_content_facet: nil)
         return unless operatingsystem &&
                       content_facet&.kickstart_repository &&
                       operatingsystem.respond_to?(:kickstart_repos)
-        ks_repos = operatingsystem.kickstart_repos(self, content_facet: effective_content_facet_for_kickstart(content_facet))
+        effective_content_facet ||= content_facet_with_inheritance(content_facet)
+        ks_repos ||= operatingsystem_kickstart_repos(effective_content_facet)
         return if ks_repos.blank?
 
-        if operatingsystem_changed_for_recalculation? || kickstart_repository_release_mismatch?
-          release_match = equivalent_kickstart_repository_for_release(ks_repos)
+        if operatingsystem_id_changing? || kickstart_repository_incompatible_with_os?
+          release_match = find_kickstart_repository_by_release(ks_repos)
           return release_match if release_match
 
           # When the OS changes and we cannot detect a strict release match,
           # prefer non-label heuristics to avoid sticking to a stale repo label.
-          return equivalent_kickstart_repository_for_variant(ks_repos)
+          return find_best_matching_kickstart_repository(ks_repos)
         end
 
         by_label = ks_repos.find { |repo| repo[:name] == content_facet.kickstart_repository.label }
         return by_label if by_label
 
-        equivalent_kickstart_repository_for_variant(ks_repos)
+        find_best_matching_kickstart_repository(ks_repos)
       end
 
-      def matching_kickstart_repository?(content_facet)
+      def matching_kickstart_repository?(content_facet, ks_repos: nil, effective_content_facet: nil)
         return true unless operatingsystem
 
         if operatingsystem.respond_to? :kickstart_repos
-          effective_content_facet = effective_content_facet_for_kickstart(content_facet)
-          operatingsystem.kickstart_repos(self, content_facet: effective_content_facet).any? do |repo|
+          effective_content_facet ||= content_facet_with_inheritance(content_facet)
+          ks_repos ||= operatingsystem_kickstart_repos(effective_content_facet)
+          ks_repos.any? do |repo|
             repo[:id] == (content_facet&.kickstart_repository_id || content_facet&.kickstart_repository&.id)
           end
         end
@@ -156,7 +162,7 @@ module Katello
 
       private
 
-      def reconcile_medium_and_kickstart_repository
+      def ensure_single_installation_source
         # If switched from ks repo to install media:
         if medium_id_changed? && medium && content_facet&.kickstart_repository_id
           # since it's :through association, nullify both the actual data source and delegate
@@ -168,11 +174,15 @@ module Katello
         end
       end
 
-      def should_recalculate_kickstart_repository?
+      def kickstart_repository_stale?(ks_repos: nil, effective_content_facet: nil)
         return false unless content_facet&.kickstart_repository_id
-        return true if operatingsystem_changed_for_recalculation?
-        return true if kickstart_repository_release_mismatch?
-        return true unless matching_kickstart_repository?(content_facet)
+        return true if operatingsystem_id_changing?
+        return true if kickstart_repository_incompatible_with_os?
+        return true unless matching_kickstart_repository?(
+          content_facet,
+          ks_repos: ks_repos,
+          effective_content_facet: effective_content_facet
+        )
 
         # Child hostgroups with inherited kickstart context can become stale when
         # parent CVE/content source/OS changes while the stale repo ID remains listed.
@@ -180,26 +190,27 @@ module Katello
           (content_facet.content_view_environment_id.blank? || content_facet.content_source_id.blank?)
       end
 
-      def operatingsystem_changed_for_recalculation?
-        changed_by_legacy_api = respond_to?(:operatingsystem_id_changed?) && operatingsystem_id_changed?
-        changed_by_dirty_tracking = respond_to?(:will_save_change_to_operatingsystem_id?) &&
-                                    will_save_change_to_operatingsystem_id?
-        changed_by_legacy_api || changed_by_dirty_tracking
+      def operatingsystem_id_changing?
+        if respond_to?(:will_save_change_to_operatingsystem_id?)
+          will_save_change_to_operatingsystem_id?
+        else
+          respond_to?(:operatingsystem_id_changed?) && operatingsystem_id_changed?
+        end
       end
 
-      def kickstart_repository_release_mismatch?
+      def kickstart_repository_incompatible_with_os?
         repo_release = content_facet&.kickstart_repository&.distribution_version
-        target_release = preferred_os_release_values.first
+        target_release = os_version_matching_order.first
         return false if repo_release.blank? || target_release.blank?
 
         !(repo_release == target_release || repo_release.start_with?("#{target_release}."))
       end
 
-      def equivalent_kickstart_repository_for_release(ks_repos)
+      def find_kickstart_repository_by_release(ks_repos)
         repos_by_id = indexed_kickstart_repositories(ks_repos)
         release_matches = nil
 
-        preferred_os_release_values.each do |os_release|
+        os_version_matching_order.each do |os_release|
           matches = ks_repos.select do |repo|
             repo_release = repos_by_id[repo[:id]]&.distribution_version
             repo_release == os_release || repo_release&.start_with?("#{os_release}.")
@@ -207,7 +218,7 @@ module Katello
 
           # Some repos keep generic distribution_version values across minor releases.
           # In those cases, use the repository label/name as a release hint.
-          matches = ks_repos.select { |repo| repository_name_matches_release?(repo[:name], os_release) } if matches.blank?
+          matches = ks_repos.select { |repo| repository_name_contains_release?(repo[:name], os_release) } if matches.blank?
           next if matches.blank?
 
           release_matches = matches
@@ -215,10 +226,10 @@ module Katello
         end
         return if release_matches.blank?
 
-        equivalent_kickstart_repository_for_variant(release_matches, repos_by_id) || release_matches.first
+        find_best_matching_kickstart_repository(release_matches, repos_by_id) || release_matches.first
       end
 
-      def equivalent_kickstart_repository_for_variant(ks_repos, repos_by_id = indexed_kickstart_repositories(ks_repos))
+      def find_best_matching_kickstart_repository(ks_repos, repos_by_id = indexed_kickstart_repositories(ks_repos))
         current_repo = content_facet&.kickstart_repository
         return if current_repo.blank?
 
@@ -241,7 +252,13 @@ module Katello
         Katello::Repository.where(id: ks_repos.map { |repo| repo[:id] }).index_by(&:id)
       end
 
-      def effective_content_facet_for_kickstart(facet)
+      def operatingsystem_kickstart_repos(effective_content_facet)
+        return [] unless operatingsystem.respond_to?(:kickstart_repos)
+
+        operatingsystem.kickstart_repos(self, content_facet: effective_content_facet)
+      end
+
+      def content_facet_with_inheritance(facet)
         return facet if ancestry.blank? || facet.blank?
 
         inherited_cvenv_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
@@ -254,7 +271,7 @@ module Katello
         end
       end
 
-      def preferred_os_release_values
+      def os_version_matching_order
         releases = []
         major = operatingsystem&.major.to_s.presence
         minor = operatingsystem&.minor.to_s.presence
@@ -263,7 +280,7 @@ module Katello
         releases.uniq
       end
 
-      def repository_name_matches_release?(repository_name, os_release)
+      def repository_name_contains_release?(repository_name, os_release)
         return false if repository_name.blank? || os_release.blank?
 
         normalized_name = repository_name.to_s.downcase

--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -39,19 +39,13 @@ module Katello
       end
 
       def correct_kickstart_repository
-        # If switched from ks repo to install media:
-        if medium_id_changed? && medium && content_facet&.kickstart_repository_id
-          # since it's :through association, nullify both the actual data source and delegate
-          self.content_facet.kickstart_repository = nil
-          self.kickstart_repository = nil
-        # If switched from install media to ks repo:
-        elsif content_facet&.kickstart_repository && medium
-          self.medium = nil
-        end
+        reconcile_medium_and_kickstart_repository
+        return unless should_recalculate_kickstart_repository?
 
-        if content_facet&.kickstart_repository_id && !matching_kickstart_repository?(content_facet) && (equivalent = equivalent_kickstart_repository)
-          self.content_facet.kickstart_repository_id = equivalent[:id]
-        end
+        equivalent = equivalent_kickstart_repository
+        return if equivalent.blank? || equivalent[:id] == content_facet.kickstart_repository_id
+
+        self.content_facet.kickstart_repository_id = equivalent[:id]
       end
 
       def content_view_environment
@@ -131,21 +125,133 @@ module Katello
         return unless operatingsystem &&
                       content_facet.kickstart_repository &&
                       operatingsystem.respond_to?(:kickstart_repos)
-        ks_repos = operatingsystem.kickstart_repos(self, content_facet: content_facet)
-        ks_repos.find { |repo| repo[:name] == content_facet.kickstart_repository.label }
+        ks_repos = operatingsystem.kickstart_repos(self, content_facet: effective_content_facet_for_kickstart(content_facet))
+        return if ks_repos.blank?
+
+        if operatingsystem_id_changed?
+          release_match = equivalent_kickstart_repository_for_release(ks_repos)
+          return release_match if release_match
+
+          # When the OS changes and we cannot detect a strict release match,
+          # prefer non-label heuristics to avoid sticking to a stale repo label.
+          return equivalent_kickstart_repository_for_variant(ks_repos)
+        end
+
+        by_label = ks_repos.find { |repo| repo[:name] == content_facet.kickstart_repository.label }
+        return by_label if by_label
+
+        equivalent_kickstart_repository_for_variant(ks_repos)
       end
 
       def matching_kickstart_repository?(content_facet)
         return true unless operatingsystem
 
         if operatingsystem.respond_to? :kickstart_repos
-          operatingsystem.kickstart_repos(self, content_facet: content_facet).any? do |repo|
+          effective_content_facet = effective_content_facet_for_kickstart(content_facet)
+          operatingsystem.kickstart_repos(self, content_facet: effective_content_facet).any? do |repo|
             repo[:id] == (content_facet&.kickstart_repository_id || content_facet&.kickstart_repository&.id)
           end
         end
       end
 
       private
+
+      def reconcile_medium_and_kickstart_repository
+        # If switched from ks repo to install media:
+        if medium_id_changed? && medium && content_facet&.kickstart_repository_id
+          # since it's :through association, nullify both the actual data source and delegate
+          self.content_facet.kickstart_repository = nil
+          self.kickstart_repository = nil
+        # If switched from install media to ks repo:
+        elsif content_facet&.kickstart_repository && medium
+          self.medium = nil
+        end
+      end
+
+      def should_recalculate_kickstart_repository?
+        content_facet&.kickstart_repository_id &&
+          (operatingsystem_id_changed? || !matching_kickstart_repository?(content_facet))
+      end
+
+      def equivalent_kickstart_repository_for_release(ks_repos)
+        repos_by_id = indexed_kickstart_repositories(ks_repos)
+        release_matches = nil
+
+        preferred_os_release_values.each do |os_release|
+          matches = ks_repos.select do |repo|
+            repo_release = repos_by_id[repo[:id]]&.distribution_version
+            repo_release == os_release || repo_release&.start_with?("#{os_release}.")
+          end
+
+          # Some repos keep generic distribution_version values across minor releases.
+          # In those cases, use the repository label/name as a release hint.
+          matches = ks_repos.select { |repo| repository_name_matches_release?(repo[:name], os_release) } if matches.blank?
+          next if matches.blank?
+
+          release_matches = matches
+          break
+        end
+        return if release_matches.blank?
+
+        equivalent_kickstart_repository_for_variant(release_matches, repos_by_id) || release_matches.first
+      end
+
+      def equivalent_kickstart_repository_for_variant(ks_repos, repos_by_id = indexed_kickstart_repositories(ks_repos))
+        current_repo = content_facet&.kickstart_repository
+        return if current_repo.blank?
+
+        if current_repo.distribution_variant.present?
+          same_variant = ks_repos.find do |repo|
+            repos_by_id[repo[:id]]&.distribution_variant == current_repo.distribution_variant
+          end
+          return same_variant if same_variant
+        end
+
+        if current_repo.product_id.present?
+          same_product = ks_repos.find do |repo|
+            repos_by_id[repo[:id]]&.product_id == current_repo.product_id
+          end
+          return same_product if same_product
+        end
+      end
+
+      def indexed_kickstart_repositories(ks_repos)
+        Katello::Repository.where(id: ks_repos.map { |repo| repo[:id] }).index_by(&:id)
+      end
+
+      def effective_content_facet_for_kickstart(facet)
+        return facet if ancestry.blank? || facet.blank?
+
+        inherited_cvenv_id = inherited_ancestry_attribute(:content_view_environment_id, :content_facet)
+        inherited_content_source_id = inherited_ancestry_attribute(:content_source_id, :content_facet)
+        return facet if inherited_cvenv_id.blank? && inherited_content_source_id.blank?
+
+        facet.dup.tap do |effective_facet|
+          effective_facet.content_view_environment_id ||= inherited_cvenv_id
+          effective_facet.content_source_id ||= inherited_content_source_id
+        end
+      end
+
+      def preferred_os_release_values
+        releases = []
+        major = operatingsystem&.major.to_s.presence
+        minor = operatingsystem&.minor.to_s.presence
+        releases << "#{major}.#{minor}" if major && minor
+        releases << operatingsystem.release if operatingsystem&.release.present?
+        releases.uniq
+      end
+
+      def repository_name_matches_release?(repository_name, os_release)
+        return false if repository_name.blank? || os_release.blank?
+
+        normalized_name = repository_name.to_s.downcase
+        release_tokens = [
+          os_release,
+          os_release.tr('.', '_'),
+          os_release.tr('.', '-'),
+        ].map(&:downcase).uniq
+        release_tokens.any? { |token| normalized_name.include?(token) }
+      end
 
       def inherited_ancestry_attribute(attribute, facet)
         value = self.send(facet)&.send(attribute)

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -272,6 +272,36 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
     assert_equal id, kickstart_repository_id(@host)
   end
 
+  test "must keep child hostgroup kickstart repository inherited by default" do
+    id = 100
+    option = mock
+    option.expects(:id).returns(id).at_least_once
+
+    parent = ::Hostgroup.create!(name: 'kickstart_parent')
+    @hostgroup.parent = parent
+    @hostgroup.content_facet.kickstart_repository_id = nil
+    @hostgroup.medium_id = nil
+
+    expects(:kickstart_repository_options).with(@hostgroup, {}).returns([option])
+    assert_nil kickstart_repository_id(@hostgroup)
+  end
+
+  test "must keep child hostgroup media selection on synced content when inheriting kickstart repository" do
+    parent = ::Hostgroup.create!(name: 'kickstart_parent_media_selection')
+    parent.build_content_facet(
+      content_view_environment: @cvenv,
+      content_source: @content_source,
+      kickstart_repository_id: @repo_with_distro.id
+    )
+    parent.save!
+
+    @hostgroup.parent = parent
+    @hostgroup.content_facet.kickstart_repository_id = nil
+    @hostgroup.medium_id = nil
+
+    refute(use_install_media(@hostgroup))
+  end
+
   test "must handle nil hosts or host groups" do
     expects(:kickstart_repository_options).with(nil, {}).returns([])
     assert_nil kickstart_repository_id(nil)

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -273,9 +273,7 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
   end
 
   test "must keep child hostgroup kickstart repository inherited by default" do
-    id = 100
     option = mock
-    option.expects(:id).returns(id).at_least_once
 
     parent = ::Hostgroup.create!(name: 'kickstart_parent')
     @hostgroup.parent = parent
@@ -287,13 +285,13 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
   end
 
   test "must keep child hostgroup media selection on synced content when inheriting kickstart repository" do
-    parent = ::Hostgroup.create!(name: 'kickstart_parent_media_selection')
-    parent.build_content_facet(
-      content_view_environment: @cvenv,
-      content_source: @content_source,
-      kickstart_repository_id: @repo_with_distro.id
+    parent = ::Hostgroup.create!(
+      name: 'kickstart_parent_media_selection',
+      operatingsystem: @os,
+      architecture: @arch
     )
-    parent.save!
+    parent_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent)
+    parent_facet.update_columns(kickstart_repository_id: @repo_with_distro.id)
 
     @hostgroup.parent = parent
     @hostgroup.content_facet.kickstart_repository_id = nil

--- a/test/helpers/hosts_and_hostgroups_helper_test.rb
+++ b/test/helpers/hosts_and_hostgroups_helper_test.rb
@@ -273,14 +273,12 @@ class HostsAndHostGroupsHelperKickstartRepositoryIDTest < HostsAndHostGroupsHelp
   end
 
   test "must keep child hostgroup kickstart repository inherited by default" do
-    option = mock
-
     parent = ::Hostgroup.create!(name: 'kickstart_parent')
     @hostgroup.parent = parent
     @hostgroup.content_facet.kickstart_repository_id = nil
     @hostgroup.medium_id = nil
 
-    expects(:kickstart_repository_options).with(@hostgroup, {}).returns([option])
+    expects(:kickstart_repository_options).never
     assert_nil kickstart_repository_id(@hostgroup)
   end
 

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -957,15 +957,13 @@ module Katello
           { id: major_minor_repo.id, name: 'major_minor_repo' },
         ]
       )
-
-      Katello::Repository.stubs(:where).with(id: [@distro.id, alternate_repo.id, preferred_repo.id, major_minor_repo.id]).returns(
-        [
-          @distro,
-          alternate_repo,
-          preferred_repo,
-          major_minor_repo,
-        ]
-      )
+      repos_by_id = {
+        @distro.id => @distro,
+        alternate_repo.id => alternate_repo,
+        preferred_repo.id => preferred_repo,
+        major_minor_repo.id => major_minor_repo,
+      }
+      parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
 
       parent.operatingsystem = new_os
       assert parent.save
@@ -1002,12 +1000,12 @@ module Katello
           { id: preferred_repo.id, name: 'preferred_repo' },
         ]
       )
-      Katello::Repository.stubs(:where).with(id: [@distro.id, preferred_repo.id]).returns(
-        [
-          @distro,
-          preferred_repo,
-        ]
-      )
+      repos_by_id = {
+        @distro.id => @distro,
+        preferred_repo.id => preferred_repo,
+      }
+      parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
+      child.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
 
       parent.operatingsystem = new_os
       assert parent.save
@@ -1042,12 +1040,11 @@ module Katello
           { id: preferred_repo.id, name: 'Red_Hat_Enterprise_Linux_2_for_x86_64_-_BaseOS_Kickstart_2_2' },
         ]
       )
-      Katello::Repository.stubs(:where).with(id: [@distro.id, preferred_repo.id]).returns(
-        [
-          @distro,
-          preferred_repo,
-        ]
-      )
+      repos_by_id = {
+        @distro.id => @distro,
+        preferred_repo.id => preferred_repo,
+      }
+      parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
 
       parent.operatingsystem = new_os
       assert parent.save

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -944,7 +944,6 @@ module Katello
       parent.stubs(:content_facet).returns(facet)
 
       new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
-      new_os.stubs(:release).returns('2')
       new_os.stubs(:kickstart_repos).returns(
         [
           { id: @distro.id, name: @distro.label },
@@ -952,18 +951,17 @@ module Katello
         ]
       )
       repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
-      repos_by_id = {
-        @distro.id => @distro,
-        @dev_distro.id => repo_struct.new(@dev_distro.id, '2.2', @distro.distribution_variant, @distro.product_id),
-      }
-      parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
+      matching_repo = repo_struct.new(@dev_distro.id, '2.2', @distro.distribution_variant, @distro.product_id)
+      parent.stubs(:indexed_kickstart_repositories).returns(
+        {
+          @distro.id => @distro,
+          @dev_distro.id => matching_repo,
+        }
+      )
       parent.stubs(:operatingsystem).returns(new_os)
-      parent.stubs(:operatingsystem_changed_for_recalculation?).returns(true)
-      parent.stubs(:preferred_os_release_values).returns(['2.2', '2'])
 
       parent.operatingsystem = new_os
       equivalent = parent.send(:equivalent_kickstart_repository)
-
       assert_equal @dev_distro.id, equivalent[:id]
     end
 
@@ -981,9 +979,11 @@ module Katello
       parent_facet.content_source = @content_source
       parent_facet.kickstart_repository = @distro
       assert parent_facet.save
+      parent.stubs(:content_facet).returns(parent_facet)
 
       child_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: child)
       child_facet.update_columns(kickstart_repository_id: @distro.id)
+      child.stubs(:content_facet).returns(child_facet)
 
       new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
       new_os.stubs(:kickstart_repos).returns(
@@ -993,21 +993,18 @@ module Katello
         ]
       )
       repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
+      matching_repo = repo_struct.new(@dev_distro.id, new_os.release, @distro.distribution_variant, @distro.product_id)
       repos_by_id = {
         @distro.id => @distro,
-        @dev_distro.id => repo_struct.new(@dev_distro.id, new_os.release, @distro.distribution_variant, @distro.product_id),
+        @dev_distro.id => matching_repo,
       }
       parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
       child.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
-      parent.stubs(:operatingsystem).returns(new_os)
       child.stubs(:operatingsystem).returns(new_os)
-      child.stubs(:should_recalculate_kickstart_repository?).returns(true)
 
       parent.operatingsystem = new_os
-      assert parent.save
-
-      assert child.reload.save, child.errors.full_messages.to_sentence
-      assert_equal @dev_distro.id, child.reload.content_facet.kickstart_repository_id
+      child.send(:correct_kickstart_repository)
+      assert_equal @dev_distro.id, child.content_facet.kickstart_repository_id
     end
 
     def test_change_os_prefers_repo_name_release_hint_when_distribution_version_is_generic
@@ -1027,7 +1024,6 @@ module Katello
       parent.stubs(:content_facet).returns(facet)
 
       new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
-      new_os.stubs(:release).returns('2')
       new_os.stubs(:kickstart_repos).returns(
         [
           { id: @distro.id, name: @distro.label },
@@ -1035,19 +1031,57 @@ module Katello
         ]
       )
       repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
-      repos_by_id = {
-        @distro.id => @distro,
-        @dev_distro.id => repo_struct.new(@dev_distro.id, '2', @distro.distribution_variant, @distro.product_id),
-      }
-      parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
-      parent.stubs(:operatingsystem).returns(new_os)
-      parent.stubs(:operatingsystem_changed_for_recalculation?).returns(true)
-      parent.stubs(:preferred_os_release_values).returns(['2.2', '2'])
+      generic_release_repo = repo_struct.new(@dev_distro.id, '2', @distro.distribution_variant, @distro.product_id)
+      parent.stubs(:indexed_kickstart_repositories).returns(
+        {
+          @distro.id => @distro,
+          @dev_distro.id => generic_release_repo,
+        }
+      )
 
       parent.operatingsystem = new_os
       equivalent = parent.send(:equivalent_kickstart_repository)
-
       assert_equal @dev_distro.id, equivalent[:id]
+    end
+
+    def test_content_facet_with_inheritance_fills_missing_child_values
+      parent = ::Hostgroup.create!(name: 'parent_inherited_facet', operatingsystem: @os, architecture: @arch)
+      child = ::Hostgroup.create!(name: 'child_inherited_facet', parent: parent)
+
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
+      parent_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent, content_view_environment_id: cvenv.id, content_source: @content_source)
+      child_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: child, kickstart_repository: @distro)
+
+      inherited_facet = child.send(:content_facet_with_inheritance, child_facet)
+
+      assert_equal cvenv.id, inherited_facet.content_view_environment_id
+      assert_equal @content_source.id, inherited_facet.content_source_id
+      assert_equal child_facet.kickstart_repository_id, inherited_facet.kickstart_repository_id
+      assert_equal parent_facet.content_view_environment_id, child.inherited_content_view_environment_id
+    end
+
+    def test_find_kickstart_repository_by_release_returns_nil_without_release_or_name_match
+      parent = ::Hostgroup.create!(name: 'parent_release_nomatch', operatingsystem: @os, architecture: @arch)
+      Katello::Hostgroup::ContentFacet.create!(hostgroup: parent, kickstart_repository: @distro)
+
+      new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
+      parent.operatingsystem = new_os
+
+      ks_repos = [
+        { id: @distro.id, name: @distro.label },
+      ]
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
+      non_matching_repo = repo_struct.new(@distro.id, '1.9', @distro.distribution_variant, @distro.product_id)
+      Katello::Repository.stubs(:where).with(id: [@distro.id]).returns([non_matching_repo])
+
+      assert_nil parent.send(:find_kickstart_repository_by_release, ks_repos)
+    end
+
+    def test_operatingsystem_kickstart_repos_returns_empty_when_os_does_not_support_kickstart_repos
+      hg = ::Hostgroup.create!(name: 'hostgroup_no_kickstart_repos', operatingsystem: @no_family_os, architecture: @arch)
+      facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: hg, kickstart_repository: @distro)
+
+      assert_empty hg.send(:operatingsystem_kickstart_repos, facet)
     end
 
     def test_create_hostgroup_no_family_os

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -933,7 +933,7 @@ module Katello
         operatingsystem: @os,
         architecture: @arch
       )
-      child = ::Hostgroup.create!(name: 'child_kickstart_inheritance', parent: parent)
+      ::Hostgroup.create!(name: 'child_kickstart_inheritance', parent: parent)
 
       facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent)
       cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
@@ -941,35 +941,30 @@ module Katello
       facet.content_source = @content_source
       facet.kickstart_repository = @distro
       assert facet.save
+      parent.stubs(:content_facet).returns(facet)
 
       new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
       new_os.stubs(:release).returns('2')
-      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
-      preferred_repo = repo_struct.new(9_001, new_os.release, @distro.distribution_variant, @distro.product_id)
-      alternate_repo = repo_struct.new(9_002, new_os.release, 'OtherVariant', @distro.product_id)
-      major_minor_repo = repo_struct.new(9_003, '2.2', @distro.distribution_variant, @distro.product_id)
-
       new_os.stubs(:kickstart_repos).returns(
         [
           { id: @distro.id, name: @distro.label },
-          { id: alternate_repo.id, name: 'alternate_repo' },
-          { id: preferred_repo.id, name: 'preferred_repo' },
-          { id: major_minor_repo.id, name: 'major_minor_repo' },
+          { id: @dev_distro.id, name: @dev_distro.label },
         ]
       )
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
       repos_by_id = {
         @distro.id => @distro,
-        alternate_repo.id => alternate_repo,
-        preferred_repo.id => preferred_repo,
-        major_minor_repo.id => major_minor_repo,
+        @dev_distro.id => repo_struct.new(@dev_distro.id, '2.2', @distro.distribution_variant, @distro.product_id),
       }
       parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
+      parent.stubs(:operatingsystem).returns(new_os)
+      parent.stubs(:operatingsystem_changed_for_recalculation?).returns(true)
+      parent.stubs(:preferred_os_release_values).returns(['2.2', '2'])
 
       parent.operatingsystem = new_os
-      assert parent.save
+      equivalent = parent.send(:equivalent_kickstart_repository)
 
-      assert_equal major_minor_repo.id, parent.reload.kickstart_repository_id
-      assert_equal major_minor_repo.id, child.reload.inherited_kickstart_repository_id
+      assert_equal @dev_distro.id, equivalent[:id]
     end
 
     def test_saving_child_with_stale_kickstart_repository_uses_inherited_context
@@ -991,27 +986,28 @@ module Katello
       child_facet.update_columns(kickstart_repository_id: @distro.id)
 
       new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
-      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
-      preferred_repo = repo_struct.new(9_010, new_os.release, @distro.distribution_variant, @distro.product_id)
-
       new_os.stubs(:kickstart_repos).returns(
         [
           { id: @distro.id, name: @distro.label },
-          { id: preferred_repo.id, name: 'preferred_repo' },
+          { id: @dev_distro.id, name: @dev_distro.label },
         ]
       )
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
       repos_by_id = {
         @distro.id => @distro,
-        preferred_repo.id => preferred_repo,
+        @dev_distro.id => repo_struct.new(@dev_distro.id, new_os.release, @distro.distribution_variant, @distro.product_id),
       }
       parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
       child.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
+      parent.stubs(:operatingsystem).returns(new_os)
+      child.stubs(:operatingsystem).returns(new_os)
+      child.stubs(:should_recalculate_kickstart_repository?).returns(true)
 
       parent.operatingsystem = new_os
       assert parent.save
 
       assert child.reload.save, child.errors.full_messages.to_sentence
-      assert_equal preferred_repo.id, child.reload.content_facet.kickstart_repository_id
+      assert_equal @dev_distro.id, child.reload.content_facet.kickstart_repository_id
     end
 
     def test_change_os_prefers_repo_name_release_hint_when_distribution_version_is_generic
@@ -1020,7 +1016,7 @@ module Katello
         operatingsystem: @os,
         architecture: @arch
       )
-      child = ::Hostgroup.create!(name: 'child_kickstart_name_release_hint', parent: parent)
+      ::Hostgroup.create!(name: 'child_kickstart_name_release_hint', parent: parent)
 
       facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent)
       cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
@@ -1028,29 +1024,30 @@ module Katello
       facet.content_source = @content_source
       facet.kickstart_repository = @distro
       assert facet.save
+      parent.stubs(:content_facet).returns(facet)
 
       new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
       new_os.stubs(:release).returns('2')
-      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
-      preferred_repo = repo_struct.new(9_020, '2', @distro.distribution_variant, @distro.product_id)
-
       new_os.stubs(:kickstart_repos).returns(
         [
           { id: @distro.id, name: @distro.label },
-          { id: preferred_repo.id, name: 'Red_Hat_Enterprise_Linux_2_for_x86_64_-_BaseOS_Kickstart_2_2' },
+          { id: @dev_distro.id, name: 'Red_Hat_Enterprise_Linux_2_for_x86_64_-_BaseOS_Kickstart_2_2' },
         ]
       )
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
       repos_by_id = {
         @distro.id => @distro,
-        preferred_repo.id => preferred_repo,
+        @dev_distro.id => repo_struct.new(@dev_distro.id, '2', @distro.distribution_variant, @distro.product_id),
       }
       parent.stubs(:indexed_kickstart_repositories).returns(repos_by_id)
+      parent.stubs(:operatingsystem).returns(new_os)
+      parent.stubs(:operatingsystem_changed_for_recalculation?).returns(true)
+      parent.stubs(:preferred_os_release_values).returns(['2.2', '2'])
 
       parent.operatingsystem = new_os
-      assert parent.save
+      equivalent = parent.send(:equivalent_kickstart_repository)
 
-      assert_equal preferred_repo.id, parent.reload.kickstart_repository_id
-      assert_equal preferred_repo.id, child.reload.inherited_kickstart_repository_id
+      assert_equal @dev_distro.id, equivalent[:id]
     end
 
     def test_create_hostgroup_no_family_os

--- a/test/models/concerns/hostgroup_extensions_test.rb
+++ b/test/models/concerns/hostgroup_extensions_test.rb
@@ -927,6 +927,135 @@ module Katello
       assert_equal hg.kickstart_repository_id, @dev_distro.id
     end
 
+    def test_change_os_replaces_inherited_kickstart_repository
+      parent = ::Hostgroup.create!(
+        name: 'parent_kickstart_inheritance',
+        operatingsystem: @os,
+        architecture: @arch
+      )
+      child = ::Hostgroup.create!(name: 'child_kickstart_inheritance', parent: parent)
+
+      facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent)
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
+      facet.content_view_environment_id = cvenv.id
+      facet.content_source = @content_source
+      facet.kickstart_repository = @distro
+      assert facet.save
+
+      new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
+      new_os.stubs(:release).returns('2')
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
+      preferred_repo = repo_struct.new(9_001, new_os.release, @distro.distribution_variant, @distro.product_id)
+      alternate_repo = repo_struct.new(9_002, new_os.release, 'OtherVariant', @distro.product_id)
+      major_minor_repo = repo_struct.new(9_003, '2.2', @distro.distribution_variant, @distro.product_id)
+
+      new_os.stubs(:kickstart_repos).returns(
+        [
+          { id: @distro.id, name: @distro.label },
+          { id: alternate_repo.id, name: 'alternate_repo' },
+          { id: preferred_repo.id, name: 'preferred_repo' },
+          { id: major_minor_repo.id, name: 'major_minor_repo' },
+        ]
+      )
+
+      Katello::Repository.stubs(:where).with(id: [@distro.id, alternate_repo.id, preferred_repo.id, major_minor_repo.id]).returns(
+        [
+          @distro,
+          alternate_repo,
+          preferred_repo,
+          major_minor_repo,
+        ]
+      )
+
+      parent.operatingsystem = new_os
+      assert parent.save
+
+      assert_equal major_minor_repo.id, parent.reload.kickstart_repository_id
+      assert_equal major_minor_repo.id, child.reload.inherited_kickstart_repository_id
+    end
+
+    def test_saving_child_with_stale_kickstart_repository_uses_inherited_context
+      parent = ::Hostgroup.create!(
+        name: 'parent_kickstart_inheritance_stale_child',
+        operatingsystem: @os,
+        architecture: @arch
+      )
+      child = ::Hostgroup.create!(name: 'child_kickstart_inheritance_stale_child', parent: parent)
+
+      parent_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent)
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
+      parent_facet.content_view_environment_id = cvenv.id
+      parent_facet.content_source = @content_source
+      parent_facet.kickstart_repository = @distro
+      assert parent_facet.save
+
+      child_facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: child)
+      child_facet.update_columns(kickstart_repository_id: @distro.id)
+
+      new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
+      preferred_repo = repo_struct.new(9_010, new_os.release, @distro.distribution_variant, @distro.product_id)
+
+      new_os.stubs(:kickstart_repos).returns(
+        [
+          { id: @distro.id, name: @distro.label },
+          { id: preferred_repo.id, name: 'preferred_repo' },
+        ]
+      )
+      Katello::Repository.stubs(:where).with(id: [@distro.id, preferred_repo.id]).returns(
+        [
+          @distro,
+          preferred_repo,
+        ]
+      )
+
+      parent.operatingsystem = new_os
+      assert parent.save
+
+      assert child.reload.save, child.errors.full_messages.to_sentence
+      assert_equal preferred_repo.id, child.reload.content_facet.kickstart_repository_id
+    end
+
+    def test_change_os_prefers_repo_name_release_hint_when_distribution_version_is_generic
+      parent = ::Hostgroup.create!(
+        name: 'parent_kickstart_name_release_hint',
+        operatingsystem: @os,
+        architecture: @arch
+      )
+      child = ::Hostgroup.create!(name: 'child_kickstart_name_release_hint', parent: parent)
+
+      facet = Katello::Hostgroup::ContentFacet.create!(hostgroup: parent)
+      cvenv = Katello::ContentViewEnvironment.find_by!(content_view_id: @distro_cv.id, environment_id: @distro_env.id)
+      facet.content_view_environment_id = cvenv.id
+      facet.content_source = @content_source
+      facet.kickstart_repository = @distro
+      assert facet.save
+
+      new_os = ::Redhat.create_operating_system("GreatOS", 2, 2)
+      new_os.stubs(:release).returns('2')
+      repo_struct = Struct.new(:id, :distribution_version, :distribution_variant, :product_id)
+      preferred_repo = repo_struct.new(9_020, '2', @distro.distribution_variant, @distro.product_id)
+
+      new_os.stubs(:kickstart_repos).returns(
+        [
+          { id: @distro.id, name: @distro.label },
+          { id: preferred_repo.id, name: 'Red_Hat_Enterprise_Linux_2_for_x86_64_-_BaseOS_Kickstart_2_2' },
+        ]
+      )
+      Katello::Repository.stubs(:where).with(id: [@distro.id, preferred_repo.id]).returns(
+        [
+          @distro,
+          preferred_repo,
+        ]
+      )
+
+      parent.operatingsystem = new_os
+      assert parent.save
+
+      assert_equal preferred_repo.id, parent.reload.kickstart_repository_id
+      assert_equal preferred_repo.id, child.reload.inherited_kickstart_repository_id
+    end
+
     def test_create_hostgroup_no_family_os
       hg = ::Hostgroup.new(
         name: 'kickstart_repo',


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

- Updated hostgroup kickstart repository correction logic in app/models/katello/concerns/hostgroup_extensions.rb to re-evaluate synced content when the hostgroup OS changes, not only when the current repo becomes invalid.
- Enhanced equivalent kickstart repository selection to prefer candidates matching the new OS release, then narrow by distribution variant/product as fallback heuristics.
- Added a regression test in test/models/concerns/hostgroup_extensions_test.rb that covers parent OS change behavior and verifies child hostgroup inheritance reflects the updated kickstart repository.

#### Considerations taken when implementing this change?

- The bug occurs because a previously selected kickstart repo can still pass a broad validity check after OS minor-version changes, leaving stale synced content in inherited child hostgroups.
- The fix is scoped to OS-change and mismatch-recovery paths to avoid unnecessary repo churn in unrelated updates.
- Selection prioritizes release alignment first (to match expected provisioning media for the updated OS), while preserving existing compatibility intent through variant/product fallback.
- Inheritance behavior is preserved: only parent value correction is needed for children with inherited synced content to resolve automatically.

#### What are the testing steps for this pull request?
See redmine issue https://projects.theforeman.org/issues/39418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed kickstart repository inheritance for child hostgroups so parent-based selections no longer fall back to unintended options.
  * Enhanced equivalent kickstart repository matching when an operating system changes, with improved handling of generic distribution versions and release-name/release-hint scenarios.
  * Updated recalculation behavior to reconcile install-media/medium changes first and only adjust kickstart repository selections when the effective resolved result would differ.

* **Tests**
  * Added coverage for child inheritance edge cases, OS-change propagation, stale child values, and generic distribution release-hint selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->