### PR TITLE
Fixes #39421 - Speed up host collection membership updates

### DIFF
--- a/app/controllers/katello/api/v2/host_collections_controller.rb
+++ b/app/controllers/katello/api/v2/host_collections_controller.rb
@@ -93,23 +93,20 @@ module Katello
     param :id, :number, :desc => N_("Id of the host collection"), :required => true
     param :host_ids, Array, :desc => N_("Array of host ids")
     def add_hosts
-      host_ids = params[:host_ids].map(&:to_i)
+      host_ids, found_host_ids, editable_host_ids = requested_host_membership_ids
 
-      @hosts = ::Host::Managed.where(id: host_ids)
-      @editable_hosts = @hosts.authorized(:edit_hosts)
-
-      already_added_host_ids = @host_collection.host_ids & host_ids
-      unfound_host_ids = host_ids - @hosts.pluck(:id)
-
-      @host_collection.host_ids = (@host_collection.host_ids +
-                                   @editable_hosts.pluck(:id)).uniq
-      @host_collection.save!
+      membership_update = @host_collection.add_host_ids!(
+        :requested_host_ids => found_host_ids,
+        :authorized_host_ids => editable_host_ids
+      )
+      already_added_host_ids = membership_update[:requested_existing_host_ids]
+      unfound_host_ids = host_ids - found_host_ids
 
       messages = format_bulk_action_messages(
           :success    => _("Successfully added %s Host(s)."),
           :error      => _("You were not allowed to add %s"),
-          :models     => @hosts.pluck(:id) - already_added_host_ids,
-          :authorized => @editable_hosts.pluck(:id) - already_added_host_ids
+          :models     => found_host_ids - already_added_host_ids,
+          :authorized => membership_update[:updated_host_ids]
       )
 
       already_added_host_ids.each do |host_id|
@@ -128,22 +125,20 @@ module Katello
     param :id, :number, :desc => N_("Id of the host collection"), :required => true
     param :host_ids, Array, :desc => N_("Array of host ids")
     def remove_hosts
-      host_ids = params[:host_ids].map(&:to_i)
+      host_ids, found_host_ids, editable_host_ids = requested_host_membership_ids
 
-      @hosts = ::Host::Managed.where(id: host_ids)
-      @editable_hosts = @hosts.authorized(:edit_hosts)
-
-      already_removed_host_ids = @hosts.pluck(:id) - @host_collection.host_ids
-      unfound_host_ids = host_ids - @hosts.pluck(:id)
-
-      @host_collection.host_ids -= @editable_hosts.pluck(:id)
-      @host_collection.save!
+      membership_update = @host_collection.remove_host_ids!(
+        :requested_host_ids => found_host_ids,
+        :authorized_host_ids => editable_host_ids
+      )
+      already_removed_host_ids = found_host_ids - membership_update[:requested_existing_host_ids]
+      unfound_host_ids = host_ids - found_host_ids
 
       messages = format_bulk_action_messages(
           :success    => _("Successfully removed %s Host(s)."),
           :error      => _("You were not allowed to sync %s"),
-          :models     => @hosts.pluck(:id) - already_removed_host_ids,
-          :authorized => @editable_hosts.pluck(:id) - already_removed_host_ids
+          :models     => found_host_ids - already_removed_host_ids,
+          :authorized => membership_update[:updated_host_ids]
       )
 
       already_removed_host_ids.each do |host_id|
@@ -200,6 +195,13 @@ module Katello
         result[:unlimited_hosts] = false
       end
       result
+    end
+
+    def requested_host_membership_ids
+      host_ids = Array(params[:host_ids]).map(&:to_i)
+      @hosts = ::Host::Managed.where(id: host_ids)
+      @editable_hosts = @hosts.authorized(:edit_hosts)
+      [host_ids, @hosts.pluck(:id), @editable_hosts.pluck(:id)]
     end
 
     def find_editable_host

--- a/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/katello/api/v2/hosts_bulk_actions_controller.rb
@@ -44,13 +44,14 @@ module Katello
     def bulk_add_host_collections
       unless params[:host_collection_ids].blank?
         display_messages = []
+        host_ids = @hosts.map(&:id)
 
         @host_collections.each do |host_collection|
-          pre_host_collection_count = host_collection.host_ids.count
-          host_collection.host_ids =  (host_collection.host_ids + @hosts.map(&:id)).uniq
-          host_collection.save!
-
-          final_count = host_collection.host_ids.count - pre_host_collection_count
+          membership_update = host_collection.add_host_ids!(
+            :requested_host_ids => host_ids,
+            :authorized_host_ids => host_ids
+          )
+          final_count = membership_update[:updated_host_ids].length
           msg = if final_count == 0
                   _("All selected hosts were already members of host collection %{host_collection}.") %
                               {:host_collection => host_collection.name }
@@ -74,12 +75,13 @@ module Katello
       display_messages = []
 
       unless params[:host_collection_ids].blank?
+        host_ids = @hosts.map(&:id)
         @host_collections.each do |host_collection|
-          pre_host_collection_count = host_collection.host_ids.count
-          host_collection.host_ids =  (host_collection.host_ids - @hosts.map(&:id)).uniq
-          host_collection.save!
-
-          final_count = pre_host_collection_count - host_collection.host_ids.count
+          membership_update = host_collection.remove_host_ids!(
+            :requested_host_ids => host_ids,
+            :authorized_host_ids => host_ids
+          )
+          final_count = membership_update[:updated_host_ids].length
           display_messages << _("Removed %{count} host(s) from host collection %{host_collection}.") %
               {:count => final_count, :host_collection => host_collection.name }
         end

--- a/app/models/katello/host_collection.rb
+++ b/app/models/katello/host_collection.rb
@@ -32,15 +32,14 @@ module Katello
       # NOTE: max_hosts_check and max_hosts_no_exceeded use size() instead of count() because
       # the host list exists as an array rather than a DB query when run as a validation.
       host_count = hosts.size
-      if !unlimited_hosts && (host_count > 0 && (host_count.to_i > max_hosts.to_i)) && max_hosts_changed?
+      if !unlimited_hosts && host_count > 0 && (host_count.to_i > max_hosts.to_i) && max_hosts_changed?
         errors.add :max_host, N_("may not be less than the number of hosts associated with the host collection.")
       end
     end
 
     def max_hosts_not_exceeded
       if !unlimited_hosts && (hosts.size.to_i > max_hosts.to_i)
-        errors.add :base, N_("You cannot have more than #{max_hosts} host(s) associated with host collection #{name}." %
-                              {:max_hosts => max_hosts, :name => name})
+        errors.add :base, max_hosts_exceeded_message
       end
     end
 
@@ -75,6 +74,36 @@ module Katello
       Rails.cache.fetch("#{cache_key}/total_hosts", expires_in: 1.minute, force: !cached) do
         hosts.count
       end
+    end
+
+    def add_host_ids!(requested_host_ids:, authorized_host_ids:)
+      update_host_membership(requested_host_ids, authorized_host_ids) do |existing_host_ids, allowed_host_ids|
+        host_ids_to_add = allowed_host_ids - existing_host_ids
+        ensure_capacity_for!(host_ids_to_add.length)
+        create_host_collection_hosts(host_ids_to_add)
+
+        {
+          :updated_host_ids => host_ids_to_add,
+          :requested_existing_host_ids => existing_host_ids,
+        }
+      end
+    end
+
+    def remove_host_ids!(requested_host_ids:, authorized_host_ids:)
+      update_host_membership(requested_host_ids, authorized_host_ids) do |existing_host_ids, allowed_host_ids|
+        host_ids_to_remove = existing_host_ids & allowed_host_ids
+        destroy_host_collection_hosts(host_ids_to_remove)
+
+        {
+          :updated_host_ids => host_ids_to_remove,
+          :requested_existing_host_ids => existing_host_ids,
+        }
+      end
+    end
+
+    def max_hosts_exceeded_message
+      _("You cannot have more than %{max_hosts} host(s) associated with host collection %{host_collection}.") %
+        { :max_hosts => max_hosts, :host_collection => name }
     end
 
     # Retrieve the list of accessible host collections in the organization specified, returning
@@ -113,6 +142,73 @@ module Katello
 
     def self.humanize_class_name(_name = nil)
       _("Host Collections")
+    end
+
+    private
+
+    def update_host_membership(requested_host_ids, authorized_host_ids)
+      normalized_requested_host_ids = normalize_host_ids(requested_host_ids)
+      normalized_authorized_host_ids = normalize_host_ids(authorized_host_ids)
+      allowed_host_ids = normalized_requested_host_ids & normalized_authorized_host_ids
+
+      return empty_membership_result if normalized_requested_host_ids.empty?
+
+      with_lock do
+        existing_host_ids = host_collection_hosts.where(:host_id => normalized_requested_host_ids).pluck(:host_id)
+        result = yield(existing_host_ids, allowed_host_ids)
+
+        clear_membership_cache if result[:updated_host_ids].any?
+
+        result
+      end
+    end
+
+    def empty_membership_result
+      {
+        :updated_host_ids => [],
+        :requested_existing_host_ids => [],
+      }
+    end
+
+    def normalize_host_ids(host_ids)
+      Array(host_ids).map(&:to_i).uniq
+    end
+
+    def ensure_capacity_for!(additional_host_count)
+      return if additional_host_count.zero? || unlimited_hosts
+
+      if host_collection_hosts.count + additional_host_count > max_hosts
+        errors.add(:base, max_hosts_exceeded_message)
+        fail ActiveRecord::RecordInvalid, self
+      end
+    end
+
+    def create_host_collection_hosts(host_ids)
+      return if host_ids.empty?
+
+      timestamp = Time.current
+      HostCollectionHosts.insert_all(
+        host_ids.map do |host_id|
+          {
+            :host_collection_id => id,
+            :host_id => host_id,
+            :created_at => timestamp,
+            :updated_at => timestamp,
+          }
+        end
+      )
+    end
+
+    def destroy_host_collection_hosts(host_ids)
+      return if host_ids.empty?
+
+      host_collection_hosts.where(:host_id => host_ids).delete_all
+    end
+
+    def clear_membership_cache
+      association(:host_collection_hosts).reset
+      association(:hosts).reset
+      Rails.cache.delete("#{cache_key}/total_hosts")
     end
 
     apipie :class, desc: "A class representing #{model_name.human} object" do

--- a/app/models/katello/host_collection_hosts.rb
+++ b/app/models/katello/host_collection_hosts.rb
@@ -9,9 +9,7 @@ module Katello
       if new_record? && self.host_collection_id
         host_collection = HostCollection.find(self.host_collection_id)
         if host_collection && !host_collection.unlimited_hosts && (host_collection.hosts.size >= host_collection.max_hosts)
-          errors.add :base,
-                     _("You cannot have more than %{max_hosts} host(s) associated with host collection '%{host_collection}'.") %
-                         { :max_hosts => host_collection.max_hosts, :host_collection => host_collection.name }
+          errors.add(:base, host_collection.max_hosts_exceeded_message)
         end
       end
     end

--- a/db/migrate/20260612120500_add_unique_index_to_katello_host_collection_hosts.rb
+++ b/db/migrate/20260612120500_add_unique_index_to_katello_host_collection_hosts.rb
@@ -1,0 +1,32 @@
+class AddUniqueIndexToKatelloHostCollectionHosts < ActiveRecord::Migration[6.1]
+  def up
+    remove_duplicate_host_collection_hosts
+
+    add_index :katello_host_collection_hosts,
+              [:host_collection_id, :host_id],
+              :unique => true,
+              :name => :index_katello_host_collection_hosts_on_collection_and_host
+  end
+
+  def down
+    remove_index :katello_host_collection_hosts,
+                 :name => :index_katello_host_collection_hosts_on_collection_and_host
+  end
+
+  private
+
+  def remove_duplicate_host_collection_hosts
+    execute(<<~SQL.squish)
+      DELETE FROM katello_host_collection_hosts
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT id,
+                 ROW_NUMBER() OVER (PARTITION BY host_collection_id, host_id ORDER BY id) AS duplicate_rank
+          FROM katello_host_collection_hosts
+        ) duplicate_rows
+        WHERE duplicate_rank > 1
+      )
+    SQL
+  end
+end

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -53,7 +53,10 @@ module Katello
       put :bulk_add_host_collections, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :host_collection_ids => [@host_collection1.id, @host_collection2.id] }
 
       assert_response :success
+      results = JSON.parse(response.body)
       assert_equal 2, @host1.host_collections.count
+      assert_includes results['displayMessages'], "Added 1 host(s) to host collection #{@host_collection1.name}."
+      assert_includes results['displayMessages'], "Added 2 host(s) to host collection #{@host_collection2.name}."
     end
 
     def test_remove_host_collection
@@ -61,7 +64,10 @@ module Katello
       put :bulk_remove_host_collections, params: { :included => {:ids => @host_ids}, :organization_id => @org.id, :host_collection_ids => [@host_collection1.id, @host_collection2.id] }
 
       assert_response :success
+      results = JSON.parse(response.body)
       assert_equal 0, @host1.host_collections.count
+      assert_includes results['displayMessages'], "Removed 1 host(s) from host collection #{@host_collection1.name}."
+      assert_includes results['displayMessages'], "Removed 0 host(s) from host collection #{@host_collection2.name}."
     end
 
     def test_destroy_hosts

--- a/test/models/host_collection_test.rb
+++ b/test/models/host_collection_test.rb
@@ -147,6 +147,56 @@ module Katello
       end
     end
 
+    def test_add_host_ids_adds_only_missing_hosts
+      result = @simple_collection.add_host_ids!(
+        :requested_host_ids => [@host_one.id, @host_two.id],
+        :authorized_host_ids => [@host_one.id, @host_two.id]
+      )
+
+      assert_equal [@host_one.id], result[:requested_existing_host_ids]
+      assert_equal [@host_two.id], result[:updated_host_ids]
+      assert_equal [@host_one.id, @host_two.id].sort, @simple_collection.reload.host_ids.sort
+    end
+
+    def test_remove_host_ids_removes_only_existing_hosts
+      result = @simple_collection.remove_host_ids!(
+        :requested_host_ids => [@host_one.id, @host_two.id],
+        :authorized_host_ids => [@host_one.id, @host_two.id]
+      )
+
+      assert_equal [@host_one.id], result[:requested_existing_host_ids]
+      assert_equal [@host_one.id], result[:updated_host_ids]
+      assert_empty @simple_collection.reload.host_ids
+    end
+
+    def test_add_host_ids_only_updates_requested_authorized_hosts
+      result = @simple_collection.add_host_ids!(
+        :requested_host_ids => [@host_two.id],
+        :authorized_host_ids => [@host_one.id]
+      )
+
+      assert_empty result[:updated_host_ids]
+      assert_equal [@host_one.id], @simple_collection.reload.host_ids
+    end
+
+    def test_add_host_ids_honors_max_hosts
+      limited_collection = katello_host_collections(:one_host_limit_host_collection)
+      limited_collection.add_host_ids!(
+        :requested_host_ids => [@host_one.id],
+        :authorized_host_ids => [@host_one.id]
+      )
+
+      error = assert_raises(ActiveRecord::RecordInvalid) do
+        limited_collection.add_host_ids!(
+          :requested_host_ids => [@host_two.id],
+          :authorized_host_ids => [@host_two.id]
+        )
+      end
+
+      assert_includes error.record.errors[:base], limited_collection.max_hosts_exceeded_message
+      assert_equal [@host_one.id], limited_collection.reload.host_ids
+    end
+
     def test_audit_on_host_collection_creation
       new_host_collection = HostCollection.new(
         :name => "Test Audit Host Collection ",


### PR DESCRIPTION
## Summary
- replace full host collection membership reassignment with delta-based add/remove operations in `HostCollection`
- reuse the same membership API from both direct host collection endpoints and bulk host collection actions
- add a unique index migration for `katello_host_collection_hosts` and batch join-table delta writes for changed hosts

## Test plan
- [x] `rubocop --force-exclusion` on changed files
- [x] syntax-check changed Ruby files locally
- [x] validate on the SAT-46033 reproducer by benchmarking 10 remove/add cycles before and after the patch
- [x] confirm the direct `add_hosts` / `remove_hosts` endpoints preserve existing success and idempotent error behavior through tests

## Validation notes
- Reproducer: host collection `4` with `7208` hosts
- Original 10-run client benchmark:
  - `remove_hosts` avg `64.04s`, p90 `65.30s`
  - `add_hosts` avg `61.73s`, p90 `63.02s`
  - combined remove+add avg `125.78s`, p90 `126.89s`
- Patched 10-run client benchmark:
  - `remove_hosts` avg `0.73s`, p90 `0.49s`
  - `add_hosts` avg `0.46s`, p90 `0.48s`
  - combined remove+add avg `1.19s`, p90 `0.96s`
- Randomized 50-host bulk benchmark against the same collection (10 sequential remove/add cycles, same sampled hosts in both states):
  - Original bulk `remove_host_collections` avg `62.41s`, p90 `63.85s`
  - Original bulk `add_host_collections` avg `63.65s`, p90 `66.12s`
  - Original bulk combined remove+add avg `126.06s`, p90 `129.23s`
  - Final bulk `remove_host_collections` avg `0.73s`, p90 `0.48s`
  - Final bulk `add_host_collections` avg `0.48s`, p90 `0.48s`
  - Final bulk combined remove+add avg `1.21s`, p90 `0.96s`
- Red Hat Jira: SAT-46033

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authorization-aware, bulk host collection membership management to add/remove hosts accurately.

* **Improvements**
  * Updated bulk action responses to report the exact hosts added/removed based on the final permitted changes.
  * Centralized and improved “maximum hosts exceeded” validation messaging and enforcement.

* **Database**
  * Added a unique constraint to prevent duplicate host assignments, with automatic deduplication during migration.

* **Tests**
  * Expanded coverage for bulk response messaging, add/remove membership behavior, and max-hosts capacity limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->