### PR TITLE
Fixes #39423 - Update content_label as well via ProductContentImporter

### DIFF
--- a/app/services/katello/product_content_importer.rb
+++ b/app/services/katello/product_content_importer.rb
@@ -162,6 +162,9 @@ module Katello
       new_name = prod_content_json[:content][:name]
       attrs_to_update[:name] = new_name if content.name != new_name
 
+      new_label = prod_content_json[:content][:label]
+      attrs_to_update[:label] = new_label if content.label != new_label
+
       new_url = prod_content_json[:content][:contentUrl]
       if content.content_url != new_url
         if content.can_update_to_url?(new_url)

--- a/test/services/katello/product_content_importer_test.rb
+++ b/test/services/katello/product_content_importer_test.rb
@@ -9,6 +9,7 @@ module Katello
         "content" => {
           "id" => "4010",
           "type" => "file",
+          "label" => "foo-content-label",
           "name" => "foo",
           "contentUrl" => "/content/dist/rhel/server/6/$releasever/$basearch/satellite/5.7/iso",
         },
@@ -27,9 +28,11 @@ module Katello
       assert_equal 1, @fedora.product_contents.count
       refute @fedora.reload.product_contents.first.enabled
       assert_equal 'foo', @fedora.contents.first.name
+      assert_equal 'foo-content-label', @fedora.contents.first.label
 
       @product_content.first['enabled'] = true
       @product_content.first['content']['name'] = 'bar'
+      @product_content.first['content']['label'] = 'bar-content-label'
 
       @service = ProductContentImporter.new
       @service.add_product_content(@fedora, @product_content)
@@ -40,6 +43,7 @@ module Katello
       assert_equal 1, @fedora.product_contents.count
       assert @fedora.reload.product_contents.first.enabled
       assert_equal 'bar', @fedora.contents.first.name
+      assert_equal 'bar-content-label', @fedora.contents.first.label
     end
 
     def test_import_missing_prod_content


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

https://github.com/Katello/katello/blob/master/app/services/katello/product_content_importer.rb#L160-L176 do not worry about updating the content_label as well when it is changed in the source for some reason. This PR ensures that, when for the same  cp_content_id, the content_label got changed on the side of redhat, the same change is properly reflected in katello_contents as well, making it consistent with the Candlepin DB. 

#### Considerations taken when implementing this change?

There may be a change happening by Red Hat for any given repository set, whose content_id remains the same, but the label has been corrected. 

Since manifest refresh is expected to be the easiest way to fix it, product_content_importer needs to ensure that it knows how to update the content_label as well if a change has been detected for it on an existing content_id. 


#### What are the testing steps for this pull request?

* Setup a katello devel env and import a subscription manifest 
* Enable satellite client 6 for rhel 9 repo
* Modify the label in the Katello DB

~~~
katello=# select * from katello_contents where label = 'satellite-client-6-for-rhel-9-x86_64-rpms' or cp_content_id = '12626';
id  | cp_content_id | content_type |                        name                         |                    label                    | vendor  |                      gpg_url                       |                    content_url                    
 | organization_id 
------+---------------+--------------+-----------------------------------------------------+---------------------------------------------+---------+----------------------------------------------------+---------------------------------------------------
-+-----------------
 5517 | 12626         | yum          | Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs) | satellite-client-6-for-rhel-9-x86_64-rpms | Red Hat | file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release | /content/dist/layered/rhel9/x86_64/sat-client/6/os
 |               1
(1 row)


katello=# UPDATE katello_contents SET label = 'satellite-client-66-for-rhel-99-x86_64-rpms' where cp_content_id = '12626';
UPDATE 1



katello=# select * from katello_contents where label = 'satellite-client-6-for-rhel-9-x86_64-rpms' or cp_content_id = '12626';
id  | cp_content_id | content_type |                        name                         |                    label                    | vendor  |                      gpg_url                       |                    content_url                    
 | organization_id 
------+---------------+--------------+-----------------------------------------------------+---------------------------------------------+---------+----------------------------------------------------+---------------------------------------------------
-+-----------------
 5517 | 12626         | yum          | Red Hat Satellite Client 6 for RHEL 9 x86_64 (RPMs) | satellite-client-66-for-rhel-99-x86_64-rpms | Red Hat | file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release | /content/dist/layered/rhel9/x86_64/sat-client/6/os
 |               1
(1 row)
~~~

* Try a manifest refresh and notice that the label remained broken

* Apply the patch from this PR and restart the application 

* Try another manifest refresh and observed that the content label has now updated to the correct label. 


----
Assisted By: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Content labels are now properly synchronized during product import and updates. When a content label changes, the system will correctly detect and apply the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->