### PR TITLE
Fixes #39432 - Errata Last Sync Status Mismatch Between Default Organization View and Content View

### DIFF
--- a/app/models/katello/repository.rb
+++ b/app/models/katello/repository.rb
@@ -660,7 +660,7 @@ module Katello
     end
 
     def latest_sync_audit
-      self.audits.where(:action => AUDIT_SYNC_ACTION).order(:created_at).last
+      library_instance_or_self.audits.where(:action => AUDIT_SYNC_ACTION).order(:created_at).last
     end
 
     def cancel_dynflow_sync
@@ -676,8 +676,9 @@ module Katello
     end
 
     def latest_dynflow_sync
+      sync_repo = library_instance_or_self
       @latest_dynflow_sync ||= ForemanTasks::Task::DynflowTask.where(:label => ::Actions::Katello::Repository::Sync.name).
-                                for_resource(self).order(:started_at).last
+                                for_resource(sync_repo).order(:started_at).last
     end
 
     def blocking_task

--- a/test/models/repository_test.rb
+++ b/test/models/repository_test.rb
@@ -568,6 +568,33 @@ module Katello
       assert_includes @fedora_17_x86_64.clones, @fedora_17_x86_64_dev
     end
 
+    def test_latest_dynflow_sync_delegates_to_library_instance
+      library_repo = @fedora_17_x86_64
+      clone_repo = @fedora_17_x86_64_dev
+      sync_task = ForemanTasks::Task::DynflowTask.create!(
+        :label => ::Actions::Katello::Repository::Sync.name,
+        :state => 'stopped',
+        :type => 'ForemanTasks::Task::DynflowTask',
+        :result => 'success',
+        :started_at => 2.days.ago,
+        :ended_at => 1.day.ago
+      )
+      ForemanTasks::Link.link!(library_repo, sync_task)
+
+      assert_equal sync_task, library_repo.latest_dynflow_sync
+      assert_equal sync_task, clone_repo.latest_dynflow_sync
+    end
+
+    def test_latest_sync_audit_delegates_to_library_instance
+      library_repo = @fedora_17_x86_64
+      clone_repo = @fedora_17_x86_64_dev
+
+      library_repo.audit_sync
+
+      assert_not_nil library_repo.latest_sync_audit
+      assert_equal library_repo.latest_sync_audit, clone_repo.latest_sync_audit
+    end
+
     def test_group
       assert_includes @fedora_17_x86_64.group, @fedora_17_x86_64_dev
       assert_includes @fedora_17_x86_64.group, @fedora_17_x86_64


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

https://github.com/Katello/katello/blob/master/app/models/katello/repository.rb#L662-L682 describes errata showing as synced under Default Organization View but Not Synced when viewed through a Content View, even though hosts can still apply the errata. Upstream repository sync only runs on Default Organization View (library instance) repos. Sync Foreman tasks are recorded against those repos. When you filter by a Content View, the API returns CV clone repos — same errata content, but no sync tasks on those records.

The UI treats last_sync == null as "Not Synced", even though the content was synced via the library instance and published into the CV.

This PR does the below:

Default Org View repo → library_instance_or_self returns self (unchanged behavior)
CV clone repo → returns its library_instance, where sync tasks actually live
Errata content availability is unchanged — only sync status display is corrected

#### Considerations taken when implementing this change?

Last sync should be displayed for a errata irrespective of the content view selected.

#### What are the testing steps for this pull request?

1. Setup a katello devel env and import a subscription manifest.
2. Sync any repo with errata.
3. Add this repo in a cv and publish it.
4.  Now go Content -> Content Types -> Errata -> Click on any errata -> Repositories
5.  When Library and Default Org View is selected, the last sync shows up correctly
6.  Now change the cv to the one where the errata was added, last sync does not show the data
7.  Applying the patch & restarting the application fixes the last sync information when a cv is selected.

- Assisted by: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved consistency when retrieving the latest synchronization audit and Dynflow sync task, ensuring derived repositories correctly reflect the corresponding values from their associated library instance.
* **Tests**
  * Added coverage to verify delegation behavior for both the latest Dynflow sync task and the latest sync audit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->