### PR TITLE
Fixes #39433 - Nullify ACS SSL credentials before destroying organization

### DIFF
--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -21,6 +21,7 @@ module Katello
         # has_many :environments is already defined in Foreman taxonomy.rb
         has_many :kt_environments, :class_name => "Katello::KTEnvironment", :dependent => :restrict_with_exception, :inverse_of => :organization
         has_one :library, lambda { where(:library => true) }, :class_name => "Katello::KTEnvironment", :dependent => :destroy
+        before_destroy :nullify_acs_ssl_credentials
         has_many :gpg_keys, :class_name => "Katello::ContentCredential", :dependent => :destroy, :inverse_of => :organization
         has_many :sync_plans, :class_name => "Katello::SyncPlan", :dependent => :destroy, :inverse_of => :organization
         has_many :host_collections, :class_name => "Katello::HostCollection", :dependent => :destroy, :inverse_of => :organization
@@ -152,6 +153,14 @@ module Katello
             default_proxy.organizations << self
             default_proxy.save
           end
+        end
+
+        def nullify_acs_ssl_credentials
+          cc_ids = gpg_keys.pluck(:id)
+          return if cc_ids.empty?
+          Katello::AlternateContentSource.where(ssl_ca_cert_id: cc_ids).update_all(ssl_ca_cert_id: nil)
+          Katello::AlternateContentSource.where(ssl_client_cert_id: cc_ids).update_all(ssl_client_cert_id: nil)
+          Katello::AlternateContentSource.where(ssl_client_key_id: cc_ids).update_all(ssl_client_key_id: nil)
         end
 
         def validate_destroy(current_org)

--- a/test/models/concerns/organization_extensions_test.rb
+++ b/test/models/concerns/organization_extensions_test.rb
@@ -22,5 +22,25 @@ module Katello
       @org.expects(:imports).returns([{'foo' => 'bar' }, {'foo' => 'bar'}])
       assert_equal 'bar', @org.manifest_history[0].foo
     end
+
+    def test_nullify_acs_ssl_credentials_clears_acs_references_before_destroy
+      cc_ids = @org.gpg_keys.pluck(:id)
+
+      assert Katello::AlternateContentSource.where(ssl_ca_cert_id: cc_ids).exists?,
+             "expected ACS fixtures to reference the org's content credentials"
+
+      @org.nullify_acs_ssl_credentials
+
+      assert_empty Katello::AlternateContentSource.where(ssl_ca_cert_id: cc_ids)
+      assert_empty Katello::AlternateContentSource.where(ssl_client_cert_id: cc_ids)
+      assert_empty Katello::AlternateContentSource.where(ssl_client_key_id: cc_ids)
+    end
+
+    def test_nullify_acs_ssl_credentials_is_noop_without_gpg_keys
+      org_without_ccs = get_organization(:organization2)
+      org_without_ccs.gpg_keys.delete_all
+
+      assert_nothing_raised { org_without_ccs.nullify_acs_ssl_credentials }
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Adds a before_destroy callback in OrganizationExtensions that nullifies ssl_ca_cert_id, ssl_client_cert_id, and ssl_client_key_id on any Alternate Content Source records referencing the organization's Content Credentials before the Content Credentials themselves are destroyed.

#### Considerations taken when implementing this change?
AlternateContentSource has no organization_id and is not directly owned by the organization, so it is not destroyed as part of the org deletion cascade. The fix introduced in #11737 changed the ACS associations on ContentCredential from dependent: :nullify to dependent: :restrict_with_exception, which correctly blocks standalone CC deletion but also broke org deletion. The callback is placed before has_many :gpg_keys in the included block to ensure it fires before the Content Credentials are destroyed.

#### What are the testing steps for this pull request?
1. Create a Content Credential of cert type.
2. Create an ACS using that credential as CA cert, client cert, or client key.
3. Delete the organization that owns the Content Credential -> deletion should succeed.
4. Verify the ACS still exists but its SSL cert references are now blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced organization deletion to properly clean up SSL certificate and client key references associated with alternate content sources.

* **Tests**
  * Added test cases to verify SSL credential cleanup during organization destruction and handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->