### PR TITLE
Fixes #39440 - filter content uploads controller repository context

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -51,7 +51,8 @@ module Katello
     private
 
     def find_repository
-      @repository = Repository.find(params[:repository_id])
+      @repository = Repository.editable.find_by(id: params[:repository_id])
+      throw_resource_not_found(name: 'repository', id: params[:repository_id]) if @repository.nil?
     end
   end
 end

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -128,5 +128,47 @@ module Katello
         delete :destroy, params: { :id => "1", :repository_id => @repo.id }
       end
     end
+
+    def test_create_upload_cannot_access_unauthorized_repository
+      unauthorized_repo = Repository.find(katello_repositories(:uln_ovm2_2_1_1_i386_patch).id)
+      product = @repo.product
+
+      login_user(User.find(users(:restricted).id))
+      setup_current_user_with_permissions(
+        { :name => :edit_products, :search => "name=\"#{product.name}\"" },
+        organizations: [get_organization]
+      )
+
+      post :create, params: { :repository_id => unauthorized_repo.id, :size => 100 }
+      assert_response :not_found
+    end
+
+    def test_update_cannot_access_unauthorized_repository
+      unauthorized_repo = Repository.find(katello_repositories(:uln_ovm2_2_1_1_i386_patch).id)
+      product = @repo.product
+
+      login_user(User.find(users(:restricted).id))
+      setup_current_user_with_permissions(
+        { :name => :edit_products, :search => "name=\"#{product.name}\"" },
+        organizations: [get_organization]
+      )
+
+      put :update, params: { :id => "1", :offset => "0", :content => "/tmp/file.rpm", :repository_id => unauthorized_repo.id }
+      assert_response :not_found
+    end
+
+    def test_destroy_cannot_access_unauthorized_repository
+      unauthorized_repo = Repository.find(katello_repositories(:uln_ovm2_2_1_1_i386_patch).id)
+      product = @repo.product
+
+      login_user(User.find(users(:restricted).id))
+      setup_current_user_with_permissions(
+        { :name => :edit_products, :search => "name=\"#{product.name}\"" },
+        organizations: [get_organization]
+      )
+
+      delete :destroy, params: { :id => "1", :repository_id => unauthorized_repo.id }
+      assert_response :not_found
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Ensures that the repository requested by the content uploads controller is actually editable by the user. See https://app.opencve.io/cve/CVE-2026-12515.

#### Considerations taken when implementing this change?

Throwing a 404 here is better than not loading the repository and erroring out later in the code.

#### What are the testing steps for this pull request?
Exercise the content uploads controller with a user who has repo edit permissions but with a specific filter that restricts there access to a certain set of repositories.

---

I haven't tested this yet, it was a quick write-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced proper access control for content uploads — users without adequate repository permissions can no longer create, update, or destroy content uploads on unauthorized repositories.

* **Tests**
  * Added tests to verify access control restrictions are applied to restricted users for all content upload operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->