### PR TITLE
Fixes #39441 - set PATH to run commands like shutdown

### DIFF
--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -16,6 +16,7 @@ template_inputs:
 commands = @host.traces_helpers(search: input('Traces search query'))
 reboot = commands.delete('reboot')
 -%>
+PATH="$PATH:/usr/bin:/usr/sbin:/bin:/sbin"
 <% if reboot -%>
 shutdown -r +1
 <% else -%>


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command resolution in the **“Resolve Traces - Katello Script Default”** job template by extending the generated script’s `PATH` to include common system directories. This helps ensure subsequent commands are found and executed consistently during the script run, including around the reboot-related logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->