### PR TITLE
Fixes #39313 - Fix RHSM owner proxy authorization and owner label handling

### DIFF
--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -382,11 +382,11 @@ module Katello
     end
 
     def convert_organization_label_to_id
-      # owner callback can set organization_id to a numeric Foreman org ID;
-      # skip label lookup in that case.
-      return if params[:organization_id].to_s.match?(/\A\d+\z/)
-
       params[:organization_id] = find_organization.id
+    rescue HttpErrors::NotFound
+      # If label lookup fails and organization_id is numeric, keep it as a
+      # Foreman org ID set by earlier callbacks.
+      raise unless params[:organization_id].to_s.match?(/\A\d+\z/)
     end
 
     def convert_owner_to_organization_id

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -384,9 +384,18 @@ module Katello
     def convert_organization_label_to_id
       params[:organization_id] = find_organization.id
     rescue HttpErrors::NotFound
-      # If label lookup fails and organization_id is numeric, keep it as a
+      # If label lookup fails and organization_id is numeric, treat it as a
       # Foreman org ID set by earlier callbacks.
-      raise unless params[:organization_id].to_s.match?(/\A\d+\z/)
+      organization_id = params[:organization_id].to_s
+      raise unless organization_id.match?(/\A\d+\z/)
+
+      organization = Organization.find_by(:id => organization_id)
+      raise unless organization
+
+      if User.current && !User.consumer? && !User.current.allowed_organizations.include?(organization)
+        message = _("User '%{user}' does not belong to Organization '%{organization}'.")
+        raise HttpErrors::NotFound, message % {:user => current_user.login, :organization => organization_id}
+      end
     end
 
     def convert_owner_to_organization_id

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -31,7 +31,7 @@ module Katello
     before_action :check_media_type, :except => :async_hypervisors_update
 
     prepend_before_action :convert_owner_to_organization_id, :except => [:hypervisors_update, :async_hypervisors_update], :if => lambda { params.key?(:owner) }
-    prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create, :get, :post, :put, :delete], :if => lambda { params.key?(:organization_id) }
+    prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create, :get], :if => lambda { params.key?(:organization_id) }
 
     def repackage_message
       yield
@@ -382,6 +382,8 @@ module Katello
     end
 
     def convert_organization_label_to_id
+      # owner callback can set organization_id to a numeric Foreman org ID;
+      # skip label lookup in that case.
       return if params[:organization_id].to_s.match?(/\A\d+\z/)
 
       params[:organization_id] = find_organization.id

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -31,7 +31,7 @@ module Katello
     before_action :check_media_type, :except => :async_hypervisors_update
 
     prepend_before_action :convert_owner_to_organization_id, :except => [:hypervisors_update, :async_hypervisors_update], :if => lambda { params.key?(:owner) }
-    prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create], :if => lambda { params.key?(:organization_id) }
+    prepend_before_action :convert_organization_label_to_id, :only => [:rhsm_index, :consumer_activate, :consumer_create, :get, :post, :put, :delete], :if => lambda { params.key?(:organization_id) }
 
     def repackage_message
       yield
@@ -382,6 +382,8 @@ module Katello
     end
 
     def convert_organization_label_to_id
+      return if params[:organization_id].to_s.match?(/\A\d+\z/)
+
       params[:organization_id] = find_organization.id
     end
 

--- a/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
+++ b/app/controllers/katello/api/rhsm/candlepin_proxies_controller.rb
@@ -390,12 +390,17 @@ module Katello
       raise unless organization_id.match?(/\A\d+\z/)
 
       organization = Organization.find_by(:id => organization_id)
-      raise unless organization
+      unless organization
+        message = _("Couldn't find Organization with id '%s'.")
+        raise HttpErrors::NotFound, message % organization_id
+      end
 
       if User.current && !User.consumer? && !User.current.allowed_organizations.include?(organization)
         message = _("User '%{user}' does not belong to Organization '%{organization}'.")
         raise HttpErrors::NotFound, message % {:user => current_user.login, :organization => organization_id}
       end
+
+      params[:organization_id] = organization.id.to_s
     end
 
     def convert_owner_to_organization_id

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -578,6 +578,18 @@ module Katello
           @controller.send(:convert_organization_label_to_id)
         end
       end
+
+      it "raises not found with id message when numeric organization_id does not exist" do
+        request_params = ActionController::Parameters.new(:organization_id => "999999")
+        @controller.stubs(:params).returns(request_params)
+        @controller.stubs(:find_organization).raises(HttpErrors::NotFound.new("Couldn't find Organization '999999'."))
+
+        error = assert_raises(HttpErrors::NotFound) do
+          @controller.send(:convert_organization_label_to_id)
+        end
+
+        assert_match(/Couldn't find Organization with id '999999'\./, error.message)
+      end
     end
 
     describe "authorize_proxy_routes owner endpoints" do

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -648,8 +648,8 @@ module Katello
         end
         proxy_get_expectation.returns(proxy_response)
 
-        get :get, params: { :organization_id => @organization.label },
-            env: { 'PATH_INFO' => "/rhsm/owners/#{@organization.label}/system_purpose" }
+        @request.stubs(:fullpath).returns("/rhsm/owners/#{@organization.label}/system_purpose")
+        get :get, params: { :organization_id => @organization.label }
 
         assert_response :success
         assert_equal @organization.label, JSON.parse(response.body).dig('owner', 'key')

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -534,6 +534,25 @@ module Katello
         assert_equal 'foreman.example.com', @controller.get_parent_host(nil_host)
       end
     end
+    describe "convert_organization_label_to_id" do
+      it "converts organization label to id" do
+        request_params = ActionController::Parameters.new(:organization_id => @organization.label)
+        @controller.stubs(:params).returns(request_params)
+
+        @controller.send(:convert_organization_label_to_id)
+
+        assert_equal @organization.id, request_params[:organization_id]
+      end
+
+      it "keeps numeric organization_id unchanged" do
+        request_params = ActionController::Parameters.new(:organization_id => @organization.id.to_s)
+        @controller.stubs(:params).returns(request_params)
+
+        @controller.send(:convert_organization_label_to_id)
+
+        assert_equal @organization.id.to_s, request_params[:organization_id]
+      end
+    end
 
     describe "authorize_proxy_routes owner endpoints" do
       # Tests for fix: can?(:view_organizations) was incorrectly called with self (controller),
@@ -576,6 +595,64 @@ module Katello
 
         result = @controller.send(:authorize_proxy_routes)
         refute result, "User without view_organizations should not be authorized"
+      end
+
+      it "authorizes owner pools route for user with view_organizations when consumer param is absent" do
+        user = User.find(users(:restricted).id)
+        user.organizations = [@organization]
+        user.save!
+        setup_user_with_permissions(:view_organizations, user)
+        User.current = user
+
+        stub_route_recognition("rhsm_proxy_owner_pools_path")
+
+        result = @controller.send(:authorize_proxy_routes)
+        assert result, "User with view_organizations should be authorized for owner pools route"
+      end
+
+      it "returns false for owner pools route when user lacks view_organizations and consumer param is absent" do
+        user = User.find(users(:restricted).id)
+        user.organizations = [@organization]
+        user.save!
+        setup_user_with_permissions(:view_hosts, user)
+        User.current = user
+
+        stub_route_recognition("rhsm_proxy_owner_pools_path")
+
+        result = @controller.send(:authorize_proxy_routes)
+        refute result, "User without view_organizations should not be authorized for owner pools route"
+      end
+
+      it "serves system_purpose without requiring owner query param" do
+        user = User.find(users(:restricted).id)
+        user.organizations = [@organization]
+        user.save!
+        setup_user_with_permissions(:view_organizations, user)
+        User.current = user
+
+        stub_route_recognition("rhsm_proxy_owner_system_purpose_path")
+        @controller.expects(:find_organization).once.returns(@organization)
+
+        proxy_response = mock('proxy_response')
+        proxy_response.stubs(:code).returns(200)
+        proxy_response.stubs(:as_json).returns(
+          { 'owner' => { 'key' => @organization.label }, 'systemPurposeAttributes' => {} }
+        )
+
+        proxy_get_expectation = Resources::Candlepin::Proxy.expects(:get)
+        proxy_get_expectation.with do |request_path, extra_headers|
+          assert_match(%r{\A/owners/#{@organization.label}/system_purpose}, request_path)
+          refute_includes(request_path, 'owner=')
+          assert_empty(extra_headers)
+          true
+        end
+        proxy_get_expectation.returns(proxy_response)
+
+        get :get, params: { :organization_id => @organization.label },
+            env: { 'PATH_INFO' => "/rhsm/owners/#{@organization.label}/system_purpose" }
+
+        assert_response :success
+        assert_equal @organization.label, JSON.parse(response.body).dig('owner', 'key')
       end
     end
 

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -544,9 +544,20 @@ module Katello
         assert_equal @organization.id, request_params[:organization_id]
       end
 
+      it "converts numeric organization label to id when label exists" do
+        request_params = ActionController::Parameters.new(:organization_id => "123")
+        @controller.stubs(:params).returns(request_params)
+        @controller.stubs(:find_organization).returns(mock('organization', id: 9999))
+
+        @controller.send(:convert_organization_label_to_id)
+
+        assert_equal 9999, request_params[:organization_id]
+      end
+
       it "keeps numeric organization_id unchanged" do
         request_params = ActionController::Parameters.new(:organization_id => @organization.id.to_s)
         @controller.stubs(:params).returns(request_params)
+        @controller.stubs(:find_organization).raises(HttpErrors::NotFound.new("Couldn't find Organization '#{@organization.id}'."))
 
         @controller.send(:convert_organization_label_to_id)
 
@@ -631,13 +642,14 @@ module Katello
         User.current = user
 
         stub_route_recognition("rhsm_proxy_owner_system_purpose_path")
-        @controller.expects(:find_organization).once.returns(@organization)
+        @controller.stubs(:find_organization).returns(@organization)
 
         proxy_response = mock('proxy_response')
         proxy_response.stubs(:code).returns(200)
         proxy_response.stubs(:as_json).returns(
           { 'owner' => { 'key' => @organization.label }, 'systemPurposeAttributes' => {} }
         )
+        proxy_response.stubs(:gsub).with(any_parameters).returns('{}')
 
         proxy_get_expectation = Resources::Candlepin::Proxy.expects(:get)
         proxy_get_expectation.with do |request_path, extra_headers|
@@ -648,7 +660,9 @@ module Katello
         end
         proxy_get_expectation.returns(proxy_response)
 
-        @request.stubs(:fullpath).returns("/rhsm/owners/#{@organization.label}/system_purpose")
+        @controller.stubs(:proxy_request_path) do
+          @controller.instance_variable_set(:@request_path, "/owners/#{@organization.label}/system_purpose")
+        end
         get :get, params: { :organization_id => @organization.label }
 
         assert_response :success

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -563,6 +563,21 @@ module Katello
 
         assert_equal @organization.id.to_s, request_params[:organization_id]
       end
+
+      it "raises for unauthorized numeric organization_id" do
+        user = User.find(users(:restricted).id)
+        user.organizations = []
+        user.save!
+        User.current = user
+
+        request_params = ActionController::Parameters.new(:organization_id => @organization.id.to_s)
+        @controller.stubs(:params).returns(request_params)
+        @controller.stubs(:find_organization).raises(HttpErrors::NotFound.new("Couldn't find Organization '#{@organization.id}'."))
+
+        assert_raises(HttpErrors::NotFound) do
+          @controller.send(:convert_organization_label_to_id)
+        end
+      end
     end
 
     describe "authorize_proxy_routes owner endpoints" do
@@ -651,18 +666,18 @@ module Katello
         )
         proxy_response.stubs(:gsub).with(any_parameters).returns('{}')
 
+        expected_path = "/owners/#{@organization.label}/system_purpose"
+        @controller.instance_variable_set(:@request_path, expected_path)
+        @controller.stubs(:proxy_request_path)
+
         proxy_get_expectation = Resources::Candlepin::Proxy.expects(:get)
         proxy_get_expectation.with do |request_path, extra_headers|
-          assert_match(%r{\A/owners/#{@organization.label}/system_purpose}, request_path)
+          assert_equal expected_path, request_path
           refute_includes(request_path, 'owner=')
           assert_empty(extra_headers)
           true
         end
         proxy_get_expectation.returns(proxy_response)
-
-        @controller.stubs(:proxy_request_path) do
-          @controller.instance_variable_set(:@request_path, "/owners/#{@organization.label}/system_purpose")
-        end
         get :get, params: { :organization_id => @organization.label }
 
         assert_response :success


### PR DESCRIPTION
Remove controller-instance authorization checks for owner proxy routes and normalize organization labels to IDs for proxy actions so /rhsm/owners/:organization_id/* works without requiring an owner query param. Add controller coverage for both authorization paths and organization label conversion.

#### What are the changes introduced in this pull request?
- Updated RHSM proxy behavior to normalize `organization_id` labels for proxy get action in addition to existing actions, so `/rhsm/owners/:organization_id/system_purpose` works without requiring `?owner=....`
- Added a guard in `convert_organization_label_to_id` to leave numeric organization IDs unchanged.
- Expanded controller test coverage:
- label-to-id conversion tests (label conversion + numeric pass-through),
- owner-pools authorization tests for users with/without `view_organizations`,
- end-to-end-style controller test that verifies `system_purpose` works without owner query param.

#### Considerations taken when implementing this change?
- Kept behavior backward compatible by not converting already numeric `organization_id` values.
- Scoped the conversion change to relevant proxy actions only, minimizing side effects.
- Preserved and validated route-level authorization semantics for non-consumer users.
- Added regression tests for both logic-level and request-level paths to prevent future breakage of the same user flow.

#### What are the testing steps for this pull request?
- Create a non-admin user with `view_organizations` permission and org (`Default Organization`) access.
- Call the endpoint without owner query param:
- curl -sku "view_organizations_user:password" "https://<host>/rhsm/owners/Default_Organization/system_purpose"
- Verify response is successful and contains system purpose JSON (no Organization with id ... not found).
- (Optional negative check) Use a user without view_organizations; verify access is denied for owner routes.
- Run controller tests:
`test/controllers/api/rhsm/candlepin_proxies_controller_test.rb`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proxy API handling of `organization_id` by converting organization labels to numeric IDs when needed, including the `get` action, while preserving already-numeric values.
  * Corrected authorization behavior for owner-related proxy routes when the consumer parameter is omitted.
  * Fixed system-purpose proxy requests to use the owner label in the URL path (not an `owner` query parameter), returning the expected owner key.
* **Tests**
  * Added controller-spec coverage for `organization_id` conversion, the updated owner-route authorization rules, and system-purpose request formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->