### PR TITLE
Fixes #39388 - Refresh capsule content tab after sync and content count tasks

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/capsule-content/capsule-content.controller.js
@@ -16,12 +16,21 @@
  *   Provides the functionality for the capsule-content page.
  */
 angular.module('Bastion.capsule-content').controller('CapsuleContentController',
-    ['$scope', '$urlMatcherFactory', '$location', 'translate', 'CapsuleContent', 'AggregateTask', 'CurrentOrganization', 'syncState', 'Notification',
-    function ($scope, $urlMatcherFactory, $location, translate, CapsuleContent, AggregateTask, CurrentOrganization, syncState, Notification) {
+    ['$scope', '$urlMatcherFactory', '$location', '$window', 'translate', 'CapsuleContent', 'AggregateTask', 'CurrentOrganization', 'syncState', 'Notification',
+    function ($scope, $urlMatcherFactory, $location, $window, translate, CapsuleContent, AggregateTask, CurrentOrganization, syncState, Notification) {
 
         var refreshSyncStatus;
         var urlMatcher = $urlMatcherFactory.compile("/smart_proxies/:capsuleId");
         var capsuleId = urlMatcher.exec($location.path()).capsuleId;
+
+        // Event name must match SMART_PROXY_CONTENT_TASK_EVENT in SmartProxyContentConstants.js
+        function notifyCapsuleContentTask(task) {
+            if (task && task.id) {
+                $window.dispatchEvent(new CustomEvent('katello:capsuleContentTask', {
+                    detail: { taskId: task.id }
+                }));
+            }
+        }
 
         function processError(response, prependMsg) {
             var msg = '';
@@ -61,7 +70,7 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
         }
 
         function taskUpdated() {
-            if (!angular.isUndefined($scope.syncTask.result) && $scope.syncTask.result !== 'pending') {
+            if (!angular.isUndefined($scope.syncTask.result) && !isTaskInProgress($scope.syncTask)) {
                 $scope.syncTask.unregisterAll();
                 refreshSyncStatus();
             }
@@ -173,6 +182,7 @@ angular.module('Bastion.capsule-content').controller('CapsuleContentController',
                 $scope.syncState.set(syncState.SYNC_TRIGGERED);
 
                 CapsuleContent.sync({id: capsuleId, 'skip_metadata_check': skipMetadataCheck}).$promise.then(function (task) {
+                    notifyCapsuleContentTask(task);
                     $scope.syncStatus['active_sync_tasks'].push(task);
                     $scope.syncTask = aggregateTasks($scope.syncStatus['active_sync_tasks']);
                     $scope.syncState.set(syncState.SYNCING);

--- a/webpack/scenes/SmartProxy/Content.js
+++ b/webpack/scenes/SmartProxy/Content.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SmartProxyExpandableTable from './SmartProxyExpandableTable';
+import useSmartProxyContentRefresh from './useSmartProxyContentRefresh';
 
-const Content = ({ smartProxyId, organizationId }) => (
-  <SmartProxyExpandableTable smartProxyId={smartProxyId} organizationId={organizationId} />
-);
+const Content = ({ smartProxyId, organizationId }) => {
+  useSmartProxyContentRefresh({ smartProxyId, organizationId });
+
+  return (
+    <SmartProxyExpandableTable smartProxyId={smartProxyId} organizationId={organizationId} />
+  );
+};
 
 Content.propTypes = {
   smartProxyId: PropTypes.oneOfType([

--- a/webpack/scenes/SmartProxy/SmartProxyContentActions.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentActions.js
@@ -1,15 +1,43 @@
 import { API_OPERATIONS, get, post } from 'foremanReact/redux/API';
 import { translate as __ } from 'foremanReact/common/I18n';
 import api, { foremanApi, orgId } from '../../services/api';
-import SMART_PROXY_CONTENT_KEY, { SMART_PROXY_COUNTS_UPDATE_KEY, SMART_PROXY_REPAIR_CONTENT_KEY, SMART_PROXY_KEY } from './SmartProxyContentConstants';
+import SMART_PROXY_CONTENT_KEY, {
+  SMART_PROXY_COUNTS_UPDATE_KEY,
+  SMART_PROXY_REPAIR_CONTENT_KEY,
+  SMART_PROXY_KEY,
+  SMART_PROXY_CONTENT_TASK_KEY,
+  SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY,
+  SMART_PROXY_UPDATE_COUNTS_LABEL,
+} from './SmartProxyContentConstants';
 import { renderTaskStartedToast } from '../Tasks/helpers';
 import { getResponseErrorMsgs } from '../../utils/helpers';
+import { startPollingTask, startPollingTasks, stopPollingTasks } from '../Tasks/TaskActions';
 
 const getSmartProxyContent = ({ smartProxyId, organizationId }) => get({
   type: API_OPERATIONS.GET,
   key: SMART_PROXY_CONTENT_KEY,
-  url: api.getApiUrl(organizationId ? `/capsules/${smartProxyId}/content/sync?organization_id=${organizationId}` : `/capsules/${smartProxyId}/content/sync`),
+  url: api.getApiUrl(organizationId ?
+    `/capsules/${smartProxyId}/content/sync?organization_id=${organizationId}` :
+    `/capsules/${smartProxyId}/content/sync`),
 });
+
+export const pollSmartProxyContentTask = task => (dispatch) => {
+  if (task?.id) {
+    dispatch(startPollingTask(SMART_PROXY_CONTENT_TASK_KEY, task));
+  }
+};
+
+export const searchPendingContentCountsTask = () => (dispatch) => {
+  dispatch(stopPollingTasks(SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY));
+  dispatch(startPollingTasks(SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY, {
+    label: SMART_PROXY_UPDATE_COUNTS_LABEL,
+    result: 'pending',
+  }));
+};
+
+export const stopContentCountsTaskSearch = () => (dispatch) => {
+  dispatch(stopPollingTasks(SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY));
+};
 
 export const getSmartProxies = () => get({
   type: API_OPERATIONS.GET,
@@ -18,16 +46,20 @@ export const getSmartProxies = () => get({
   params: { organization_id: orgId(), per_page: 'all' },
 });
 
-export const updateSmartProxyContentCounts = (smartProxyId, params) => post({
-  type: API_OPERATIONS.POST,
-  key: SMART_PROXY_COUNTS_UPDATE_KEY,
-  url: api.getApiUrl(`/capsules/${smartProxyId}/content/update_counts`),
-  params,
-  handleSuccess: (response) => {
-    renderTaskStartedToast(response?.data, __('Smart proxy content count refresh has started in the background'));
-  },
-  errorToast: error => __(`Something went wrong while refreshing content counts: ${getResponseErrorMsgs(error?.response)}`),
-});
+export const updateSmartProxyContentCounts = (smartProxyId, params) => (dispatch) => {
+  dispatch(post({
+    type: API_OPERATIONS.POST,
+    key: SMART_PROXY_COUNTS_UPDATE_KEY,
+    url: api.getApiUrl(`/capsules/${smartProxyId}/content/update_counts`),
+    params,
+    handleSuccess: (response) => {
+      const task = response?.data;
+      renderTaskStartedToast(task, __('Smart proxy content count refresh has started in the background'));
+      dispatch(pollSmartProxyContentTask(task));
+    },
+    errorToast: error => __(`Something went wrong while refreshing content counts: ${getResponseErrorMsgs(error?.response)}`),
+  }));
+};
 
 export const repairSmartProxyContent = (smartProxyId, params) => post({
   type: API_OPERATIONS.POST,

--- a/webpack/scenes/SmartProxy/SmartProxyContentConstants.js
+++ b/webpack/scenes/SmartProxy/SmartProxyContentConstants.js
@@ -2,4 +2,13 @@ const SMART_PROXY_CONTENT_KEY = 'SMART_PROXY_CONTENT';
 export const SMART_PROXY_KEY = 'SMART_PROXY';
 export const SMART_PROXY_COUNTS_UPDATE_KEY = 'SMART_PROXY_COUNTS_UPDATE_KEY';
 export const SMART_PROXY_REPAIR_CONTENT_KEY = 'SMART_PROXY_REPAIR_CONTENT_KEY';
+export const SMART_PROXY_CONTENT_TASK_KEY = 'SMART_PROXY_CONTENT_TASK';
+export const SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY = 'SMART_PROXY_CONTENT_COUNTS_SEARCH';
+
+// Must match the string in capsule-content.controller.js (Angular cannot import this module).
+export const SMART_PROXY_CONTENT_TASK_EVENT = 'katello:capsuleContentTask';
+
+export const SMART_PROXY_SYNC_TASK_LABEL = 'Actions::Katello::CapsuleContent::Sync';
+export const SMART_PROXY_UPDATE_COUNTS_LABEL = 'Actions::Katello::CapsuleContent::UpdateContentCounts';
+
 export default SMART_PROXY_CONTENT_KEY;

--- a/webpack/scenes/SmartProxy/useSmartProxyContentRefresh.js
+++ b/webpack/scenes/SmartProxy/useSmartProxyContentRefresh.js
@@ -1,0 +1,130 @@
+import { useEffect, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { selectAPIResponse } from 'foremanReact/redux/API/APISelectors';
+import getSmartProxyContent, {
+  pollSmartProxyContentTask,
+  searchPendingContentCountsTask,
+  stopContentCountsTaskSearch,
+} from './SmartProxyContentActions';
+import {
+  SMART_PROXY_CONTENT_TASK_EVENT,
+  SMART_PROXY_SYNC_TASK_LABEL,
+  SMART_PROXY_CONTENT_TASK_KEY,
+  SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY,
+} from './SmartProxyContentConstants';
+import { bulkSearchKey, pollTaskKey } from '../Tasks/helpers';
+import { stopPollingTask, clearPollTaskData } from '../Tasks/TaskActions';
+import { selectIsPollingTask, selectIsPollingTasks } from '../Tasks/TaskSelectors';
+
+const MAX_EMPTY_COUNTS_SEARCH_POLLS = 3;
+
+const isTaskRunning = task =>
+  task && (task.state === 'pending' || task.state === 'running');
+
+const isTaskCompleted = task =>
+  task && (task.state === 'stopped');
+
+const useSmartProxyContentRefresh = ({ smartProxyId, organizationId }) => {
+  const dispatch = useDispatch();
+  const [task, setTask] = useState(null);
+  const resolvedRef = useRef(false);
+  const lastCountsSearchTaskIdRef = useRef(null);
+  const emptyCountsSearchPollsRef = useRef(0);
+
+  const isPolling = useSelector(state =>
+    selectIsPollingTask(state, SMART_PROXY_CONTENT_TASK_KEY));
+  const pollResponse = useSelector(state =>
+    selectAPIResponse(state, pollTaskKey(SMART_PROXY_CONTENT_TASK_KEY)));
+  const isSearchingCountsTasks = useSelector(state =>
+    selectIsPollingTasks(state, SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY));
+  const countsSearchResponse = useSelector(state =>
+    selectAPIResponse(state, bulkSearchKey(SMART_PROXY_CONTENT_COUNTS_SEARCH_KEY)));
+
+  useEffect(() => {
+    const onTask = (event) => {
+      const taskId = event && event.detail && event.detail.taskId;
+      if (taskId) {
+        resolvedRef.current = false;
+        setTask({ id: taskId });
+      }
+    };
+
+    window.addEventListener(SMART_PROXY_CONTENT_TASK_EVENT, onTask);
+    return () => {
+      window.removeEventListener(SMART_PROXY_CONTENT_TASK_EVENT, onTask);
+      dispatch(stopContentCountsTaskSearch());
+      dispatch(stopPollingTask(SMART_PROXY_CONTENT_TASK_KEY));
+    };
+  }, [dispatch]);
+
+  useEffect(() => {
+    if (task && task.id) {
+      dispatch(pollSmartProxyContentTask(task));
+    }
+  }, [dispatch, task]);
+
+  useEffect(() => {
+    if (!pollResponse) return;
+
+    const { state, result, label } = pollResponse;
+
+    if (!isPolling || resolvedRef.current || state !== 'stopped') {
+      return;
+    }
+
+    resolvedRef.current = true;
+    dispatch(stopPollingTask(SMART_PROXY_CONTENT_TASK_KEY));
+    dispatch(stopContentCountsTaskSearch()); // Also stop bulk search if running
+    dispatch(getSmartProxyContent({ smartProxyId, organizationId }));
+
+    if (result === 'success' && label === SMART_PROXY_SYNC_TASK_LABEL) {
+      dispatch(searchPendingContentCountsTask());
+    }
+
+    setTask(null);
+  }, [dispatch, isPolling, organizationId, pollResponse, smartProxyId]);
+
+  useEffect(() => {
+    if (!isSearchingCountsTasks) {
+      emptyCountsSearchPollsRef.current = 0;
+      return;
+    }
+
+    const tasks = (countsSearchResponse && countsSearchResponse.results) || [];
+    const filteredTasks = tasks.filter(t =>
+      t.input?.smart_proxy_id === Number(smartProxyId));
+    const activeTask = [...filteredTasks].reverse().find(isTaskRunning);
+
+    if (activeTask && activeTask.id && activeTask.id !== lastCountsSearchTaskIdRef.current) {
+      lastCountsSearchTaskIdRef.current = activeTask.id;
+      emptyCountsSearchPollsRef.current = 0;
+      dispatch(stopContentCountsTaskSearch());
+      dispatch(stopPollingTask(SMART_PROXY_CONTENT_TASK_KEY));
+      dispatch(clearPollTaskData(SMART_PROXY_CONTENT_TASK_KEY));
+      resolvedRef.current = false;
+      setTask(activeTask);
+      return;
+    }
+
+    // If no active task found, check for recently completed tasks and refresh immediately
+    if (countsSearchResponse && countsSearchResponse.results !== undefined && !activeTask) {
+      const completedTask = [...filteredTasks].reverse().find(isTaskCompleted);
+
+      if (completedTask && completedTask.id !== lastCountsSearchTaskIdRef.current) {
+        // Found a recently completed task, refresh UI immediately
+        lastCountsSearchTaskIdRef.current = completedTask.id;
+        dispatch(stopContentCountsTaskSearch());
+        dispatch(getSmartProxyContent({ smartProxyId, organizationId }));
+        return;
+      }
+
+      // No completed task found either, increment empty poll counter
+      emptyCountsSearchPollsRef.current += 1;
+      if (emptyCountsSearchPollsRef.current >= MAX_EMPTY_COUNTS_SEARCH_POLLS) {
+        dispatch(stopContentCountsTaskSearch());
+      }
+    }
+  }, [countsSearchResponse, dispatch, isSearchingCountsTasks, organizationId, smartProxyId]);
+};
+
+export default useSmartProxyContentRefresh;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Auto-refreshes the Capsule Content tab when Sync or UpdateContentCounts tasks complete. Uses Foreman task polling to detect task completion and refresh data without manual page reload.

#### Considerations taken when implementing this change?
  - Follows TaskPresenter.js pattern for task polling (no arbitrary timers)
  - Uses DOM events to bridge Angular (sync operations) and React (UI display)
  - After Sync completes, searches for and polls pending UpdateCounts tasks
  - Addresses all reviewer feedback from PR #11769

#### What are the testing steps for this pull request?
  1. Navigate to Infrastructure > Capsules > [Select Capsule] > Content tab
  2. Click "Synchronize Capsule"
  3. Verify tab auto-refreshes showing updated "Last sync" and counts
  4. Click "Update Content Counts"
  5. Verify counts refresh automatically when task completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart Proxy content pages now automatically refresh by reacting to capsule-content task activity and triggering follow-up content-count searches until updates are ready.
  * Content count updates now use background-task polling, improving responsiveness while tasks run.
* **Bug Fixes**
  * Improved capsule task progress handling so both queued and active states are treated as “in progress.”
  * Capsule sync now broadcasts task activity earlier and coordinates polling so subsequent refresh/count flows start reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->