### PR TITLE
Fixes #39484 - Pin foreman-tasks upper bound to < 13.0.0

### DIFF
--- a/katello.gemspec
+++ b/katello.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rest-client"
 
   gem.add_dependency "rabl"
-  gem.add_dependency "foreman-tasks", ">= 12.0.0"
+  gem.add_dependency "foreman-tasks", ">= 12.0.0", "< 13.0.0"
   gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
   gem.add_dependency "dynflow", ">= 2.0.0"
   gem.add_dependency "activerecord-import"


### PR DESCRIPTION
foreman-tasks 13.0.0 requires Foreman >= 5.0. Without an upper bound, Bundler resolves to 13.0.0 on KATELLO-4.21 (Foreman 3.19), breaking all Katello CI jobs with PluginRequirementError.