### PR TITLE
Fixes #39493 - Fix duplicate Candlepin PUT requests during registration

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -152,7 +152,10 @@ module Katello
         super(new_cvenvs)
         Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cvenvs)
         self.content_view_environments.reload unless self.new_record?
-        self.host&.update_candlepin_associations unless self.host&.new_record?
+        # Mark as changed to ensure the before_update callback triggers Candlepin update.
+        # Don't call update_candlepin_associations directly - the callback handles it and
+        # prevents duplicate requests when called during host.save!
+        self.cvenvs_changed = true unless self.new_record?
       end
 
       def content_view_environment_labels

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -136,6 +136,28 @@ module Katello
         assert_response 400
       end
 
+      it "should return Candlepin validation error when name is invalid" do
+        # SAT-36519: Test that Candlepin validation errors (400) are returned correctly,
+        # not masked by 404 from spurious PUT requests during error cleanup
+        error_body = '{"displayMessage":"System name cannot begin with # character"}'
+        cp_response = stub(code: 400, body: error_body)
+        ::Katello::RegistrationManager.expects(:process_registration).raises(
+          RestClient::BadRequest.new(cp_response, 400)
+        )
+
+        post(:consumer_create,
+             params: {
+               :organization_id => @content_view_environment.content_view.organization.label,
+               :environment_id => @content_view_environment.cp_id,
+               :name => '#invalidname',
+               :facts => @facts,
+             })
+
+        body = JSON.parse(response.body)
+        assert_includes body['displayMessage'], 'System name cannot begin with # character'
+        assert_response 400
+      end
+
       it "should return displayMessage instead of message for RHSM error responses" do
         ::Katello::RegistrationManager.expects(:process_registration).never
 

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -122,7 +122,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_set_content_view_environments_with_valid_content_view_environs_param
-    Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
+    # Updating content_view_environments sets cvenvs_changed=true, which makes backend_update_needed? return true,
+    # which triggers the update_candlepin_associations callback
     ::Host::Managed.any_instance.expects(:update_candlepin_associations)
     host = FactoryBot.create(:host, :with_content, :with_subscription,
                               :content_view => @content_view, :lifecycle_environment => @environment)
@@ -137,7 +138,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_set_content_view_environments_with_valid_ids_param
-    Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
+    # Updating content_view_environments sets cvenvs_changed=true, which makes backend_update_needed? return true,
+    # which triggers the update_candlepin_associations callback
     ::Host::Managed.any_instance.expects(:update_candlepin_associations)
     host = FactoryBot.create(:host, :with_content, :with_subscription,
                               :content_view => @content_view, :lifecycle_environment => @environment)

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -6,7 +6,6 @@ module Katello
       @repo = katello_repositories(:rhel_6_x86_64)
       @host = hosts(:one)
       @host.content_facet.content_source = smart_proxies(:one)
-      @host.expects(:update_candlepin_associations)
       @host.content_facet.content_source.lifecycle_environments << katello_environments(:library)
       @host.operatingsystem = operatingsystems(:redhat)
       @host.content_facet.kickstart_repository = @repo

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -35,20 +35,23 @@ module Katello
 
     def test_action_triggered_on_facet_cvenv_update
       host.reload
-      host.expects(:update_candlepin_associations).twice
+      # Only called once from before_update callback, not from setter (SAT-36519 fix)
+      host.expects(:update_candlepin_associations).once
       cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, dev.id)
       host.content_facet.content_view_environments = [cvenv]
       host.save!
 
       host.reload
-      host.expects(:update_candlepin_associations).twice
+      # Only called once from before_update callback, not from setter (SAT-36519 fix)
+      host.expects(:update_candlepin_associations).once
       cvenv2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
       host.content_facet.content_view_environments = [cvenv2]
       host.save!
     end
 
     def test_content_facet_cvenv_update
-      host.expects(:update_candlepin_associations).twice
+      # Only called once from before_update callback, not from setter (SAT-36519 fix)
+      host.expects(:update_candlepin_associations).once
       cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
       host.content_facet.content_view_environments = [cvenv]
       host.save!

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -163,7 +163,6 @@ module Katello
     def setup
       super
       @host = hosts(:one)
-      @host.expects(:update_candlepin_associations)
       cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
         katello_content_views(:library_dev_view).id,
         katello_environments(:library).id
@@ -222,7 +221,6 @@ module Katello
       @repo = katello_repositories(:rhel_6_x86_64)
       @security = katello_errata(:security)
       @host = hosts(:one)
-      @host.expects(:update_candlepin_associations)
       cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
         katello_content_views(:library_dev_view).id,
         katello_environments(:library).id

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -278,7 +278,8 @@ module Katello
       end
 
       def test_registration_existing_host
-        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(2)
+        # Only called once from before_update callback, not from setter (SAT-36519 fix)
+        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(1)
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
@@ -293,7 +294,9 @@ module Katello
       end
 
       def test_force_registration_existing_host
-        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(1)
+        # When unregister_host raises RestClient::Gone, the consumer is already gone from Candlepin
+        # so update_candlepin_associations should NOT be called (there's nothing to update)
+        ::Host::Managed.any_instance.expects(:update_candlepin_associations).never
         ::Katello::RegistrationManager.expects(:unregister_host).raises(RestClient::Gone)
         ::Katello::RegistrationManager.expects(:create_in_candlepin)
         ::Katello::RegistrationManager.expects(:finalize_registration)
@@ -551,7 +554,8 @@ module Katello
 
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
       def test_registration_existing_host_dead_backend_service
-        ::Host::Managed.any_instance.stubs(:update_candlepin_associations).twice
+        # Only called once from before_update callback, not from setter (SAT-36519 fix)
+        ::Host::Managed.any_instance.stubs(:update_candlepin_associations).once
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
         @host.content_facet.expects(:destroy).never


### PR DESCRIPTION
When host registration fails due to Candlepin validation errors (e.g., invalid hostname starting with `#`), the error response is masked by a spurious 404 error. This occurs because a duplicate Candlepin PUT request is made during cleanup, attempting to update a consumer that doesn't exist yet.

#### Root Cause

The `content_view_environments=` setter in `ContentFacet` calls `update_candlepin_associations` immediately when CVEnvs are assigned:

```ruby
def content_view_environments=(new_cvenvs)
  super(new_cvenvs)
  Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cvenvs)
  self.content_view_environments.reload unless self.new_record?
  self.host&.update_candlepin_associations unless self.host&.new_record?  # ❌ Duplicate call
end
```

This causes **duplicate** Candlepin update requests:

1. **First call**: From the setter during `host.content_facet.content_view_environments = [cvenv]` → calls `update_candlepin_associations` → `PUT /candlepin/consumers/:uuid`
2. **Second call**: From the `before_update` callback on the host when `host.save!` is called → same `PUT /candlepin/consumers/:uuid`

During registration, the sequence is:
1. `Consumer.create` → **POST** to Candlepin (creates consumer)
2. Setter calls `update_candlepin_associations` → **PUT** to Candlepin (but consumer may not exist yet if POST failed!)

If the POST fails with a validation error (400), the cleanup code still tries the PUT, which fails with 404 (consumer doesn't exist), masking the original validation error.


### What are the testing steps for this pull request?
```bash
subscription-manager register --org=ACME --name='#invalidname'

# Expected: 400 Bad Request - "System name cannot begin with # character"
# Actual:   404 Not Found - Consumer does not exist
```
#### Before Fix:
- Registration with invalid hostname returns 404 (from spurious PUT during cleanup)
- Original validation error (400) is masked
- Duplicate Candlepin PUT requests on every CVEnv assignment (check `/var/log/candlepin/candlepin.log`)

#### After Fix:
- Registration with invalid hostname returns 400 (correct validation error)
- Error message correctly shows: `"System name cannot begin with # character"`
- No spurious Candlepin PUT during failed registration
- Only one Candlepin PUT per CVEnv update on existing hosts (from the `before_update` callback, not the setter)
- No functional regression - all registration/re-registration/unregistration flows should work correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content view environment updates so changes are applied once at the right time, preventing duplicate backend requests.
  * Improved registration error handling to return clearer validation details when a host name is invalid.
  * Updated related behavior so host/content updates are processed more consistently during save and reload flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->