### PR TITLE
Fixes #39503 - Fix CVEnv priorities during initial host registration

### DIFF
--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -318,8 +318,12 @@ module Katello
 
       def populate_content_facet(host, content_view_environments)
         content_facet = host.content_facet || ::Katello::Host::ContentFacet.new(:host => host)
+        new_content_facet = content_facet.new_record?
         content_facet.content_view_environments = content_view_environments
         content_facet.save!
+        if new_content_facet
+          Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(content_facet, content_view_environments)
+        end
         content_facet
       end
 

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -31,6 +31,7 @@ module Katello
 
       after do
         Setting[:retain_build_profile_upon_unregistration] = false
+        Setting['allow_multiple_content_views'] = true
       end
 
       let(:rhsm_params) { {:name => 'foobar.example.com', :facts => @facts, :type => 'system'} }
@@ -243,6 +244,28 @@ module Katello
         assert_equal @activation_key.single_content_view, new_host_cvenv.content_view
 
         assert_includes new_host.host_collections, @host_collection
+      end
+
+      def test_registration_sets_priorities_for_new_content_facet_with_multiple_cvenvs
+        Setting['allow_multiple_content_views'] = true
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @library.organization)
+        cvenvs = [
+          katello_content_view_environments(:library_dev_view_dev),
+          katello_content_view_environments(:library_dev_staging_view_dev),
+        ]
+
+        ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).with(cvenvs.map(&:cp_id), rhsm_params, [], @library.organization).returns('uuid' => 'fake-uuid-from-candlepin')
+        ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_hypervisor).twice
+        ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_guests).twice
+        ::Host::Managed.any_instance.stubs(:refresh_statuses)
+
+        ::Katello::RegistrationManager.register_host(new_host, rhsm_params, cvenvs)
+
+        priorities = new_host.content_facet.content_view_environment_content_facets.
+          reorder(:priority).
+          pluck(:content_view_environment_id, :priority)
+        assert_equal [[cvenvs[0].id, 0], [cvenvs[1].id, 1]], priorities
       end
 
       def test_registration_with_host_collection_max_hosts_exceeded


### PR DESCRIPTION
When a new host content facet is assigned multiple CVEnvs, reprioritization runs before CVECF join rows are persisted, leaving all priorities at 0. Re-run reprioritize_for_content_facet in populate_content_facet after save! for new facets, and add a regression test to verify persisted priorities are 0,1,... in the expected order.

#### What are the changes introduced in this pull request?
- Fixed initial host registration ordering for multiple CVEnvs by updating `populate_content_facet` in `registration_manager`.
- Added a `new_content_facet` check and re-ran `ContentViewEnvironmentContentFacet.reprioritize_for_content_facet` after `content_facet.save!` when the facet is newly created.
- Added a regression test in `test/services/katello/registration_manager_test.rb`:
  - `test_registration_sets_priorities_for_new_content_facet_with_multiple_cvenvs`
  - Verifies persisted CVECF priorities are 0, 1, ... in the same order as input CVEnvs.
- Reset `Setting['allow_multiple_content_views']` in test teardown to avoid cross-test leakage.

#### Considerations taken when implementing this change?
- The bug is specific to the new content facet path: reprioritization runs too early (before CVECF rows are persisted), so post-save reprioritization is required.
- The fix is intentionally scoped to new facets only, so existing host/re-registration behavior is not altered.

#### What are the testing steps for this pull request?
- Run the automated regression test
- Manual verification:
  - Create an activation key with multiple CVEnvs.
  - Register a new host using that AK.
  - In console, check:
  - myhost.content_view_environment_content_facets.pluck(:content_view_environment_id, :priority)
  - Verify priorities are unique and ordered (0, 1, ...) and UI order matches `subscription-manager environments --list-enabled`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now sets content view environment priorities correctly when a new content facet is created.
  * Existing content facets are updated without altering their current priority order.
* **Tests**
  * Added coverage for registering a host with multiple content view environments and verifying ascending priority assignment.
  * Improved test cleanup to restore the content view setting after each test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->