### PR TITLE
Fixes #39509 - migrate RSA.new to just PKey.read for PQC

### DIFF
--- a/app/lib/actions/katello/cdn_configuration/update.rb
+++ b/app/lib/actions/katello/cdn_configuration/update.rb
@@ -10,7 +10,7 @@ module Actions
             resource.validate!
             keypair = resource.debug_certificate
             cdn_configuration.ssl_cert = OpenSSL::X509::Certificate.new(keypair)
-            cdn_configuration.ssl_key = OpenSSL::PKey::RSA.new(keypair)
+            cdn_configuration.ssl_key = OpenSSL::PKey.read(keypair)
 
             cdn_configuration.save!
           end

--- a/app/lib/katello/resources/candlepin.rb
+++ b/app/lib/katello/resources/candlepin.rb
@@ -101,7 +101,7 @@ module Katello
             end
             RestClient::Resource.new(url,
                                      :ssl_client_cert => OpenSSL::X509::Certificate.new(client_cert),
-                                     :ssl_client_key => OpenSSL::PKey::RSA.new(client_key),
+                                     :ssl_client_key => OpenSSL::PKey.read(client_key),
                                      :ssl_cert_store => cert_store,
                                      :verify_ssl => ca_file ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE,
                                      :open_timeout => Setting[:manifest_refresh_timeout],

--- a/app/lib/katello/resources/candlepin/owner.rb
+++ b/app/lib/katello/resources/candlepin/owner.rb
@@ -113,7 +113,7 @@ module Katello
           def get_ueber_cert_pkcs12(key, name = nil, password = nil)
             certs = get_ueber_cert(key)
             c = OpenSSL::X509::Certificate.new certs["cert"]
-            p = OpenSSL::PKey::RSA.new certs["key"]
+            p = OpenSSL::PKey.read certs["key"]
             OpenSSL::PKCS12.create(password, name, p, c, nil, "PBE-SHA1-3DES", "PBE-SHA1-3DES")
           end
 

--- a/app/lib/katello/resources/cdn.rb
+++ b/app/lib/katello/resources/cdn.rb
@@ -56,7 +56,7 @@ module Katello
           options = {}
           if cdn_configuration.redhat_cdn?
             options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(product.certificate)
-            options[:ssl_client_key] = OpenSSL::PKey::RSA.new(product.key)
+            options[:ssl_client_key] = OpenSSL::PKey.read(product.key)
             options[:ssl_ca_file] = self.ca_file
             self.new(cdn_configuration.url, options)
           elsif cdn_configuration.custom_cdn?
@@ -67,7 +67,7 @@ module Katello
             end
             if cdn_configuration.custom_cdn_auth_enabled? || cdn_configuration.redhat_cdn_host?
               options[:ssl_client_cert] = OpenSSL::X509::Certificate.new(product.certificate)
-              options[:ssl_client_key] = OpenSSL::PKey::RSA.new(product.key)
+              options[:ssl_client_key] = OpenSSL::PKey.read(product.key)
             end
             self.new(cdn_configuration.url, options)
           else

--- a/app/services/cert/certs.rb
+++ b/app/services/cert/certs.rb
@@ -21,7 +21,7 @@ module Cert
     end
 
     def self.ssl_client_key
-      @ssl_client_key ||= OpenSSL::PKey::RSA.new(File.read(ssl_client_key_filename))
+      @ssl_client_key ||= OpenSSL::PKey.read(File.read(ssl_client_key_filename))
     end
 
     def self.ssl_client_key_filename

--- a/app/services/katello/pxe_files_downloader.rb
+++ b/app/services/katello/pxe_files_downloader.rb
@@ -16,7 +16,7 @@ module Katello
 
       ueber_cert = ::Cert::Certs.ueber_cert(repository.organization)
       cert = OpenSSL::X509::Certificate.new(ueber_cert[:cert])
-      key = OpenSSL::PKey::RSA.new(ueber_cert[:key])
+      key = OpenSSL::PKey.read(ueber_cert[:key])
 
       os.boot_file_sources(medium_provider).values.map do |source_pxe_file|
         fetch(source_pxe_file, cert, key)

--- a/test/lib/resources/candlepin_test.rb
+++ b/test/lib/resources/candlepin_test.rb
@@ -41,7 +41,7 @@ module Katello
           UpstreamCandlepinResource.stubs(:proxy).returns(proxy)
           Foreman::Util.expects(:add_ca_bundle_to_store).never
           OpenSSL::X509::Certificate.expects(:new)
-          OpenSSL::PKey::RSA.expects(:new)
+          OpenSSL::PKey.expects(:read)
           UpstreamCandlepinResource.resource(url: "http://www.foo.com", client_cert: "", client_key: "")
         end
 

--- a/test/lib/resources/cdn_test.rb
+++ b/test/lib/resources/cdn_test.rb
@@ -22,7 +22,7 @@ class CdnResourceTest < ActiveSupport::TestCase
     product.expects(:certificate).once.returns('')
     product.expects(:key).once.returns('')
     OpenSSL::X509::Certificate.expects(:new).once.returns('mock cert')
-    OpenSSL::PKey::RSA.expects(:new).once.returns('mock key')
+    OpenSSL::PKey.expects(:read).once.returns('mock key')
     cdn_resource = Katello::Resources::CDN::CdnResource.create(product: product, cdn_configuration: organization.cdn_configuration)
     cdn_resource_options = cdn_resource.instance_variable_get(:@options)
     assert_equal Katello::Resources::CDN::CdnResource.ca_file, cdn_resource_options[:ssl_ca_file]
@@ -58,7 +58,7 @@ class CdnResourceTest < ActiveSupport::TestCase
     product.expects(:certificate).once.returns('')
     product.expects(:key).once.returns('')
     OpenSSL::X509::Certificate.expects(:new).once.returns('mock cert')
-    OpenSSL::PKey::RSA.expects(:new).once.returns('mock key')
+    OpenSSL::PKey.expects(:read).once.returns('mock key')
     cdn_resource = Katello::Resources::CDN::CdnResource.create(product: product, cdn_configuration: organization.cdn_configuration)
     cdn_resource_options = cdn_resource.instance_variable_get(:@options)
     assert_equal 'mock cert', cdn_resource_options[:ssl_client_cert]

--- a/test/services/katello/pxe_files_downloader_test.rb
+++ b/test/services/katello/pxe_files_downloader_test.rb
@@ -12,7 +12,7 @@ module Katello
       )
       repository.organization.expects(:debug_cert).returns(
         cert: generate_certificate,
-        key: OpenSSL::PKey::RSA.generate(2048))
+        key: OpenSSL::PKey::RSA.generate(2048).to_pem)
       downloader = PxeFilesDownloader.new(repository, capsule)
 
       downloader.expects(:fetch).twice


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Changes `RSA.new` references to `PKey.read` for future PQC use.

Note: another fix we will need for PQC in the future is the reference to `OpenSSL::PKCS12.create` with some specific algorithms: https://github.com/katello/katello/blob/7e000dfdbf1fe84b2cb37c415aa114006c1d2b58/app/lib/katello/resources/candlepin/owner.rb#L117

This can be fixed when we address the PQC debug cert changes.

#### Considerations taken when implementing this change?

`PKey.read` should be algorithm-agnostic and "just work".

#### What are the testing steps for this pull request?

For a full test:

##### Verify existing RSA key loading still works

- **Sync a Red Hat repository** (exercises `cdn.rb` key loading)
- **Sync a custom SSL repository** with client cert auth (exercises `cdn.rb` custom CDN path)
- **Run a full content sync on a Capsule** (exercises `cert/certs.rb` for Foreman-to-Pulp communication)
- **Export a manifest / refresh subscription data** (exercises `candlepin.rb` REST client key loading)

**Or,** just verify that `PKey.read` is an actual drop-in replacement for `RSA.new`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when loading SSL/private keys across CDN configuration, upstream Candlepin connections, certificate packaging, and PXE file downloads.
  * Reduces errors by accepting a broader range of valid private-key formats during network sync and certificate generation.
* **Tests**
  * Adjusted CDN and PXE-related test stubs to provide PEM-encoded private keys and validate the updated key-parsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->