### PR TITLE
Fixes #39514 - Record errata from package update jobs

### DIFF
--- a/app/lib/actions/middleware/record_errata_application.rb
+++ b/app/lib/actions/middleware/record_errata_application.rb
@@ -1,7 +1,15 @@
 module Actions
   module Middleware
-    # Records errata applications to database when errata installation tasks complete
+    # Records errata applications to database when errata install or package update tasks complete
     class RecordErrataApplication < Dynflow::Middleware
+      TRACKED_FEATURES = %w[
+        katello_errata_install
+        katello_errata_install_by_search
+        katello_package_update
+        katello_packages_update_by_search
+        katello_package_update_by_search
+      ].freeze
+
       def finalize
         pass
       ensure
@@ -13,7 +21,7 @@ module Actions
       def record_if_errata_job
         task = find_task
         return unless task
-        return unless errata_install_job?(task)
+        return unless tracked_content_job?(task)
 
         ::Katello::ErrataApplication.record_from_task(task, action)
       rescue StandardError => e
@@ -25,7 +33,7 @@ module Actions
         return nil unless action.execution_plan_id
 
         features = action.input['job_features']
-        return nil unless features && (features & ['katello_errata_install', 'katello_errata_install_by_search']).any?
+        return nil unless features && (features & TRACKED_FEATURES).any?
 
         ::ForemanTasks::Task.where(
           external_id: action.execution_plan_id,
@@ -33,12 +41,12 @@ module Actions
         ).first
       end
 
-      def errata_install_job?(task)
+      def tracked_content_job?(task)
         return false unless task.template_invocation
         return false unless task.template_invocation.template
 
         task.template_invocation.template.remote_execution_features
-          .where(label: ['katello_errata_install', 'katello_errata_install_by_search'])
+          .where(label: TRACKED_FEATURES)
           .exists?
       end
     end

--- a/app/models/katello/errata_application.rb
+++ b/app/models/katello/errata_application.rb
@@ -40,7 +40,7 @@ module Katello
       host = ::Host::Managed.find_by(id: host_id)
       return nil unless host
 
-      errata_string_ids = extract_errata_ids_from_task(task)
+      errata_string_ids = extract_errata_ids_from_task(task, host: host)
       return nil if errata_string_ids.blank?
 
       # Reload task to get the latest result status
@@ -91,7 +91,8 @@ module Katello
 
     # Extract errata IDs from task
     # @param task [ForemanTasks::Task] The task to extract from
-    def self.extract_errata_ids_from_task(task)
+    # @param host [Host::Managed] The host (used for package update errata resolution)
+    def self.extract_errata_ids_from_task(task, host: nil)
       if dynflow_initialized?
         begin
           input = task.input
@@ -104,6 +105,10 @@ module Katello
             # Check job_features to decide extraction method
             if input['job_features']&.include?('katello_errata_install_by_search')
               return extract_from_script(task)
+            end
+
+            if package_update_job?(input['job_features'])
+              return extract_errata_for_package_update(task, host)
             end
           end
         rescue StandardError
@@ -135,17 +140,7 @@ module Katello
     end
 
     def self.extract_from_template_input(task)
-      # Search-based template (katello_errata_install_by_search) stores search query in template input,
-      # not errata IDs. Only list-based template (katello_errata_install) stores comma-separated IDs.
-      # This method should only be called for list-based templates when Dynflow is not available.
-
-      value = ::TemplateInvocationInputValue
-        .joins(:template_input)
-        .where(template_invocation_id: task.template_invocation.id)
-        .where("template_inputs.name = ?", 'errata')
-        .first&.value
-
-      parse_comma_separated_errata_ids(value)
+      parse_comma_separated_errata_ids(template_input_value(task, 'errata'))
     end
 
     def self.parse_comma_separated_errata_ids(value)
@@ -153,6 +148,59 @@ module Katello
       value.split(',').map(&:strip).reject(&:blank?)
     end
     private_class_method :parse_comma_separated_errata_ids
+
+    PACKAGE_UPDATE_FEATURES = %w[
+      katello_package_update
+      katello_packages_update_by_search
+      katello_package_update_by_search
+    ].freeze
+
+    def self.package_update_job?(features)
+      return false unless features
+      (features & PACKAGE_UPDATE_FEATURES).any?
+    end
+    private_class_method :package_update_job?
+
+    def self.extract_errata_for_package_update(task, host)
+      return [] unless host&.content_facet
+
+      package_names = extract_package_names_from_task(task, host)
+      errata_scope = ::Katello::Erratum.installable_for_hosts([host])
+
+      if package_names.present?
+        errata_scope.joins(:packages)
+          .where(katello_erratum_packages: { name: package_names })
+          .distinct.pluck(:errata_id)
+      else
+        errata_scope.pluck(:errata_id)
+      end
+    end
+    private_class_method :extract_errata_for_package_update
+
+    def self.extract_package_names_from_task(task, host)
+      return [] unless task.template_invocation
+
+      value = template_input_value(task, 'package')
+      if value.present?
+        return value.split(/[\s,]+/).map(&:strip).reject(&:blank?)
+      end
+
+      search = template_input_value(task, 'Packages search query')
+      return [] if search.blank?
+      return [] unless host
+
+      host.installed_packages.search_for(search).distinct.pluck(:name)
+    end
+    private_class_method :extract_package_names_from_task
+
+    def self.template_input_value(task, input_name)
+      ::TemplateInvocationInputValue
+        .joins(:template_input)
+        .where(template_invocation_id: task.template_invocation.id)
+        .where("template_inputs.name = ?", input_name)
+        .first&.value
+    end
+    private_class_method :template_input_value
 
     # Determine application status from task and action
     def self.determine_status(task, action)

--- a/test/models/katello/errata_application_test.rb
+++ b/test/models/katello/errata_application_test.rb
@@ -187,6 +187,72 @@ module Katello
       assert_equal 'success', status
     end
 
+    def test_record_from_task_with_package_update_job
+      task = create_task_for_package_update(@host, 'foobar')
+
+      erratum_scope = Katello::Erratum.where(errata_id: @erratum.errata_id)
+      Katello::Erratum.stubs(:installable_for_hosts).with([@host]).returns(erratum_scope)
+
+      application = ErrataApplication.record_from_task(task, nil)
+
+      assert_not_nil application
+      assert_equal @host.id, application.host_id
+      assert_includes application.errata_ids, @erratum.errata_id
+      assert_equal 'success', application.status
+    end
+
+    def test_record_from_task_with_package_update_no_matching_errata
+      task = create_task_for_package_update(@host, 'nonexistent-package')
+
+      erratum_scope = Katello::Erratum.where(errata_id: @erratum.errata_id)
+      Katello::Erratum.stubs(:installable_for_hosts).with([@host]).returns(erratum_scope)
+
+      application = ErrataApplication.record_from_task(task, nil)
+
+      assert_nil application
+    end
+
+    def test_record_from_task_with_package_update_all
+      task = create_task_for_package_update(@host, '')
+
+      erratum_scope = Katello::Erratum.where(errata_id: [@erratum.errata_id])
+      Katello::Erratum.stubs(:installable_for_hosts).with([@host]).returns(erratum_scope)
+
+      application = ErrataApplication.record_from_task(task, nil)
+
+      assert_not_nil application
+      assert_includes application.errata_ids, @erratum.errata_id
+    end
+
+    def test_record_from_task_with_package_update_no_content_facet
+      host_without_facet = ::Host::Managed.create!(name: 'no-facet-host', managed: false)
+      task = create_task_for_package_update(host_without_facet, 'foobar')
+
+      application = ErrataApplication.record_from_task(task, nil)
+
+      assert_nil application
+    ensure
+      host_without_facet&.destroy
+    end
+
+    def test_record_from_task_with_package_update_by_search
+      task = create_task_for_package_update_by_search(@host, 'name = foobar')
+
+      erratum_scope = Katello::Erratum.where(errata_id: @erratum.errata_id)
+      Katello::Erratum.stubs(:installable_for_hosts).with([@host]).returns(erratum_scope)
+
+      installed_scope = mock('installed_scope')
+      installed_scope.stubs(:distinct).returns(installed_scope)
+      installed_scope.stubs(:pluck).with(:name).returns(['foobar'])
+      @host.stubs(:installed_packages).returns(mock('packages_assoc'))
+      @host.installed_packages.stubs(:search_for).with('name = foobar').returns(installed_scope)
+
+      application = ErrataApplication.record_from_task(task, nil)
+
+      assert_not_nil application
+      assert_includes application.errata_ids, @erratum.errata_id
+    end
+
     private
 
     def create_task_with_errata(host, errata_ids)
@@ -212,6 +278,73 @@ module Katello
       ErrataApplication.stubs(:dynflow_initialized?).returns(true)
 
       task
+    end
+
+    def create_task_for_package_update(host, package_input)
+      input = {}
+      input['host'] = { 'id' => host.id } if host
+      input['job_features'] = ['katello_package_update']
+
+      task = create_base_task(input)
+      stub_template_invocation(task, host)
+      stub_template_input_values(998, 'package' => package_input.presence, 'Packages search query' => nil)
+
+      ErrataApplication.stubs(:dynflow_initialized?).returns(true)
+
+      task
+    end
+
+    def create_task_for_package_update_by_search(host, search_query)
+      input = {}
+      input['host'] = { 'id' => host.id } if host
+      input['job_features'] = ['katello_packages_update_by_search']
+
+      task = create_base_task(input)
+      stub_template_invocation(task, host)
+      stub_template_input_values(998, 'package' => nil, 'Packages search query' => search_query)
+
+      ErrataApplication.stubs(:dynflow_initialized?).returns(true)
+
+      task
+    end
+
+    def create_base_task(input)
+      task = ForemanTasks::Task.create!(
+        label: 'Actions::RemoteExecution::RunHostJob',
+        state: 'stopped',
+        result: 'success',
+        started_at: Time.zone.now,
+        ended_at: Time.zone.now,
+        type: 'ForemanTasks::Task::DynflowTask'
+      )
+
+      task.stubs(:input).returns(input)
+      task.stubs(:user).returns(@user)
+      task
+    end
+
+    def stub_template_invocation(task, host)
+      template_invocation = mock('template_invocation')
+      template_invocation.stubs(:id).returns(998)
+      template_invocation.stubs(:host_id).returns(host&.id)
+      task.stubs(:template_invocation).returns(template_invocation)
+    end
+
+    def stub_template_input_values(invocation_id, inputs)
+      ::TemplateInvocationInputValue.stubs(:joins).returns(::TemplateInvocationInputValue)
+      ::TemplateInvocationInputValue.stubs(:where).with(template_invocation_id: invocation_id).returns(::TemplateInvocationInputValue)
+
+      inputs.each do |name, value|
+        query = mock("query_#{name}")
+        if value
+          result = mock("result_#{name}")
+          result.stubs(:value).returns(value)
+          query.stubs(:first).returns(result)
+        else
+          query.stubs(:first).returns(nil)
+        end
+        ::TemplateInvocationInputValue.stubs(:where).with("template_inputs.name = ?", name).returns(query)
+      end
     end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Extended the `RecordErrataApplication` middleware to also fire for package update REX jobs (`katello_package_update`, `katello_packages_update_by_search`, `katello_package_update_by_search`). When a package update job completes, the model now resolves which installable errata correspond to the updated packages by joining on `katello_erratum_packages` by package name. If any matching errata are found, they're recorded in `katello_errata_applications` so the "Host - Applied Errata" report can display them. If the updated packages have no associated errata, no record is created. Added tests for package update with matching errata, no matching errata, update all, host without content facet, and search-based package update.

#### Considerations taken when implementing this change?

The errata resolution is done in the model rather than in the job templates to avoid requiring template changes. The code runs right after the package update finishes but before the host reports its new package versions back to Satellite, so the installable errata still reflect the pre-update state which is exactly the set we want to record. The existing errata install flow is untouched.

#### What are the testing steps for this pull request?

1. Register any new host to Red Hat Satellite.
2. Create and add the host to a Host Collection (Test).
3. Review the Installable Errata for the registered host.
4. Apply Errata via Host Collection: Hosts > Hosts Collection > Test > Action > Package Installation, Removal, and Update > Update > 'Are you sure you want to update on the system(s) selected?' > Yes > Done.
5. Host - Applied Errata report should list the errata applied using Remote Execution jobs performed on host collection via Satellite web UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Errata application tracking now supports package update workflows, including updates performed through package searches.
  * Errata IDs can be identified from selected packages or, when no packages are specified, all applicable errata.

* **Bug Fixes**
  * Improved handling of host-specific package and errata data.
  * Jobs without matching errata or required host content are no longer recorded incorrectly.

* **Tests**
  * Added coverage for package updates, package searches, empty package inputs, unmatched errata, and hosts without content support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->