### PR TITLE
Fixes #38746 - fix find_by_installable finding hosts with only applicable packages

### DIFF
--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -45,8 +45,8 @@ module Katello
         scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :applicable_errata, :complete_value => true, :ext_method => :find_by_applicable_errata, :only_explicit => true
         scoped_search :relation => :applicable_errata, :on => :errata_id, :rename => :installable_errata, :complete_value => true, :ext_method => :find_by_installable_errata, :only_explicit => true
         scoped_search :relation => :applicable_errata, :on => :issued, :rename => :applicable_errata_issued, :complete_value => true, :only_explicit => true
-        scoped_search :relation => :applicable_debs, :on => :nav, :rename => :applicable_debs, :complete_value => true, :ext_method => :find_by_applicable_debs, :only_explicit => true, :operators => ['=']
-        scoped_search :relation => :applicable_debs, :on => :nav, :rename => :upgradable_debs, :complete_value => true, :ext_method => :find_by_installable_debs, :only_explicit => true, :operators => ['=']
+        scoped_search :relation => :applicable_debs, :on => :name, :rename => :applicable_debs, :complete_value => true, :ext_method => :find_by_applicable_debs, :only_explicit => true, :operators => ['=']
+        scoped_search :relation => :applicable_debs, :on => :name, :rename => :upgradable_debs, :complete_value => true, :ext_method => :find_by_installable_debs, :only_explicit => true, :operators => ['=']
         scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :applicable_rpms, :complete_value => true, :ext_method => :find_by_applicable_rpms, :only_explicit => true
         scoped_search :relation => :applicable_rpms, :on => :nvra, :rename => :upgradable_rpms, :complete_value => true, :ext_method => :find_by_installable_rpms, :only_explicit => true
         scoped_search :relation => :content_source, :on => :name, :complete_value => true, :rename => :content_source
@@ -89,6 +89,11 @@ module Katello
       end
 
       module ClassMethods
+        def build_condition(operator, subquery)
+          sql_in = operator == 'IS NULL' ? 'NOT IN' : 'IN'
+          { :conditions => "#{::Host::Managed.table_name}.id #{sql_in} (#{subquery.to_sql})" }
+        end
+
         def find_by_image_mode(_key, _operator, value)
           # operator is always '='
           state = ::Foreman::Cast.to_bool(value)
@@ -102,18 +107,24 @@ module Katello
         end
 
         def find_by_applicable_errata(_key, operator, value)
+          hosts = ::Host::Managed.joins(:applicable_errata).select(:id)
+          return build_condition(operator, hosts) if value.nil?
           conditions = sanitize_sql_for_conditions(["#{Katello::Erratum.table_name}.errata_id #{operator} ?", value_to_sql(operator, value)])
-          hosts = ::Host::Managed.joins(:applicable_errata).select(:id).where(conditions)
-          { :conditions => "#{::Host::Managed.table_name}.id IN (#{hosts.to_sql})" }
+          { :conditions => "#{::Host::Managed.table_name}.id IN (#{hosts.where(conditions).to_sql})" }
         end
 
         def find_by_installable_errata(_key, operator, value)
+          facets = Katello::Host::ContentFacet.joins_installable_errata.select(:host_id)
+          return build_condition(operator, facets) if value.nil?
           conditions = sanitize_sql_for_conditions(["#{Katello::Erratum.table_name}.errata_id #{operator} ?", value_to_sql(operator, value)])
-          facets = Katello::Host::ContentFacet.joins_installable_errata.select(:host_id).where(conditions)
-          { :conditions => "#{::Host::Managed.table_name}.id IN (#{facets.to_sql})" }
+          { :conditions => "#{::Host::Managed.table_name}.id IN (#{facets.where(conditions).to_sql})" }
         end
 
         def find_by_applicable_debs(_key, operator, value)
+          if value.nil?
+            hosts = ::Host::Managed.joins(:applicable_debs).select(:id)
+            return build_condition(operator, hosts)
+          end
           hosts = find_by_debs(::Host::Managed.joins(:applicable_debs), operator, value)
           if hosts.empty?
             { :conditions => "1=0" }
@@ -123,6 +134,10 @@ module Katello
         end
 
         def find_by_installable_debs(_key, operator, value)
+          if value.nil?
+            facets = Katello::Host::ContentFacet.joins_installable_debs.select(:host_id)
+            return build_condition(operator, facets)
+          end
           facets = find_by_debs(Katello::Host::ContentFacet.joins_installable_debs, operator, value)
           if facets.empty?
             { :conditions => "1=0" }
@@ -132,15 +147,17 @@ module Katello
         end
 
         def find_by_applicable_rpms(_key, operator, value)
+          hosts = ::Host::Managed.joins(:applicable_rpms).select(:id)
+          return build_condition(operator, hosts) if value.nil?
           conditions = sanitize_sql_for_conditions(["#{Katello::Rpm.table_name}.nvra #{operator} ?", value_to_sql(operator, value)])
-          hosts = ::Host::Managed.joins(:applicable_rpms).select(:id).where(conditions)
-          { :conditions => "#{::Host::Managed.table_name}.id IN (#{hosts.to_sql})" }
+          { :conditions => "#{::Host::Managed.table_name}.id IN (#{hosts.where(conditions).to_sql})" }
         end
 
         def find_by_installable_rpms(_key, operator, value)
+          facets = Katello::Host::ContentFacet.joins_installable_rpms.select(:host_id)
+          return build_condition(operator, facets) if value.nil?
           conditions = sanitize_sql_for_conditions(["#{Katello::Rpm.table_name}.nvra #{operator} ?", value_to_sql(operator, value)])
-          facets = Katello::Host::ContentFacet.joins_installable_rpms.select(:host_id).where(conditions)
-          { :conditions => "#{::Host::Managed.table_name}.id IN (#{facets.to_sql})" }
+          { :conditions => "#{::Host::Managed.table_name}.id IN (#{facets.where(conditions).to_sql})" }
         end
 
         def find_by_repository_content_label(_key, operator, value)

--- a/katello.gemspec
+++ b/katello.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "foreman_remote_execution", ">= 7.1.0"
   gem.add_dependency "dynflow", ">= 2.0.0"
   gem.add_dependency "activerecord-import"
-  gem.add_dependency "scoped_search", ">= 4.1.9"
+  gem.add_dependency "scoped_search", ">= 5.0", "< 6.0"
 
   gem.add_dependency "apipie-rails", ">= 0.5.14"
 

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -215,6 +215,36 @@ module Katello
       refute_includes found, other_host
     end
 
+    def test_has_installable_errata
+      errata = katello_errata(:security)
+      host.content_facet.bound_repositories << errata.repositories.first
+
+      assert_includes ::Host.search_for("has installable_errata"), host
+    end
+
+    def test_has_installable_errata_excludes_only_applicable
+      refute_empty content_facet.applicable_errata
+
+      content_facet.bound_repositories = []
+      content_facet.save!
+
+      assert_empty content_facet.installable_errata
+
+      refute_includes ::Host.search_for("has installable_errata"), host
+      assert_includes ::Host.search_for("has applicable_errata"), host
+    end
+
+    def test_not_has_installable_errata
+      refute_empty content_facet.applicable_errata
+
+      content_facet.bound_repositories = []
+      content_facet.save!
+
+      assert_empty content_facet.installable_errata
+
+      assert_includes ::Host.search_for("not has installable_errata"), host
+    end
+
     def test_installable_errata_search
       content_facet.bound_repositories = [Katello::Repository.find(katello_repositories(:rhel_6_x86_64_library_view_1).id)]
       content_facet.save!
@@ -330,6 +360,36 @@ module Katello
       refute_includes ::Host.search_for("upgradable_debs = \"#{deb_two.nav}\""), host_one
     end
 
+    def test_has_upgradable_debs
+      assert_includes deb_one.repositories, repo
+      host_one.content_facet.bound_repositories << repo
+
+      assert_includes ::Host.search_for("has upgradable_debs"), host_one
+    end
+
+    def test_has_upgradable_debs_excludes_only_applicable
+      assert_includes deb_one.repositories, repo
+      host_one.content_facet.bound_repositories = []
+      host_one.content_facet.save!
+
+      refute_empty host_one.applicable_debs
+      assert_empty host_one.content_facet.installable_debs
+
+      refute_includes ::Host.search_for("has upgradable_debs"), host_one
+      assert_includes ::Host.search_for("has applicable_debs"), host_one
+    end
+
+    def test_not_has_upgradable_debs
+      assert_includes deb_one.repositories, repo
+      host_one.content_facet.bound_repositories = []
+      host_one.content_facet.save!
+
+      refute_empty host_one.applicable_debs
+      assert_empty host_one.content_facet.installable_debs
+
+      assert_includes ::Host.search_for("not has upgradable_debs"), host_one
+    end
+
     def test_update_applicability_counts
       assert_includes deb_one.repositories, repo
       deb_two.repositories = []
@@ -387,6 +447,36 @@ module Katello
 
       assert_includes ::Host.search_for("upgradable_rpms = #{rpm_one.nvra}"), host_one
       refute_includes ::Host.search_for("upgradable_rpms = #{rpm_two.nvra}"), host_one
+    end
+
+    def test_has_upgradable_rpms
+      assert_includes rpm_one.repositories, repo
+      host_one.content_facet.bound_repositories << repo
+
+      assert_includes ::Host.search_for("has upgradable_rpms"), host_one
+    end
+
+    def test_has_upgradable_rpms_excludes_only_applicable
+      assert_includes rpm_one.repositories, repo
+      host_one.content_facet.bound_repositories = []
+      host_one.content_facet.save!
+
+      refute_empty host_one.applicable_rpms
+      assert_empty host_one.content_facet.installable_rpms
+
+      refute_includes ::Host.search_for("has upgradable_rpms"), host_one
+      assert_includes ::Host.search_for("has applicable_rpms"), host_one
+    end
+
+    def test_not_has_upgradable_rpms
+      assert_includes rpm_one.repositories, repo
+      host_one.content_facet.bound_repositories = []
+      host_one.content_facet.save!
+
+      refute_empty host_one.applicable_rpms
+      assert_empty host_one.content_facet.installable_rpms
+
+      assert_includes ::Host.search_for("not has upgradable_rpms"), host_one
     end
 
     def test_update_applicability_counts


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The `has` operator in `scoped_search` bypasses `ext_method` and uses the raw ActiveRecord relation, so `has upgradable_rpms` was functionally equivalent to `has applicable_rpms`, returning hosts that had applicable but not installable content.

This PR patches scoped_search's null operator to delegate to ext_method for `upgradable_rpms`, `upgradable_debs`, and `installable_errata`. It adds nil-value handling to `find_by_installable_rpms`, `find_by_installable_debs`, and `find_by_installable_errata` so they can serve the `has`/`not has` case using `joins_installable_*`, which correctly filters to content present in the host's bound repositories.

This PR also changes the deb `scoped_search` definitions from `:on => :nav` to `:on => :name`. Since `nav` is a computed Ruby method, not a database column, this was causing a PG::UndefinedColumn error when scoped_search tried to reference it in the SQL query for `has applicable_debs`.



#### What are the testing steps for this pull request?

The issue fixed by this PR manifests when searching for hosts that have applicable but not installable package updates. I found that the most straightforward way to reproduce this was by using an exclude filter to keep an upgradable package out of a content view version. Note that the OS and repos used here are arbitrary. Full testing steps:

0. Deploy a foreman server.
1. Upload a manifest to the foreman server.
2. Enable and sync the RHEL 10 BaseOS and AppStream repos
3. Deploy a host, ensuring that it has at least one package with an update available in BaseOS or AppStream (I installed an old version of `mariadb`).
4. Create a new lifecycle environment.
5. Create a new content view. Add the repos synced in step 2 to the content view and publish a new version. Do not promote it.
6. Add an exclude filter to the content view.
7. Add filter rules to the exclude filter for the package chosen in step 3 and any of its dependencies (e.g. if using mariadb, add filter rules for `mariadb`, `mariadb-common`, and `mariadb-client-utils`).
8. Publish a new version of the content view and promote it to the LCE created in step 4.
9. Promote the original version of the content view to the Library LCE.
10. Create an activation key associated with the LCE and content view created in steps 4 and 5.
11. Create a global registration command using the activation key created in the previous step.
12. Register a RHEL 10 host using the global registration command created in the previous step.
13. On the RHEL 10 host, run `dnf check-update`. Ensure that the package from step 3 and its dependencies are not included in the list of packages that can be updated.
14. On the RHEL 10 host, run `dnf upgrade` to ensure that the only applicable packages are the ones excluded by the content filter.
15. After the dnf transaction completes, navigate to Hosts > All Hosts in the foreman webUI.
16. In the search field on the hosts page, search for both `has upgradable_rpms` and `has applicable_rpms`.

Expected Results:

The host is present in the search results for `has applicable_rpms`. It is not present in the results for `has upgradable_rpms`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved host searches for applicable and installable errata, Debian packages, and RPM packages.
  * Searches now correctly handle hosts with no applicable repositories, including “is null” and “is not null” conditions.
  * Debian package searches now match package names more accurately.
  * Corrected results when repositories are removed while applicable packages or errata remain.
  * Improved “not has” searches for hosts without matching repositories or package associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->