### PR TITLE
Fixes #39519 - Disable dependency solving default for incremental update

### DIFF
--- a/app/controllers/katello/api/v2/content_view_versions_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_versions_controller.rb
@@ -113,7 +113,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. New ver
       param :environment_ids, Array, :desc => N_("The list of environments to promote the specified Content View Version to (replacing the older version)")
     end
     param :description, String, :desc => N_("The description for the new generated Content View Versions")
-    param :resolve_dependencies, :bool, :desc => N_("If true, when adding the specified errata or packages, any needed dependencies will be copied as well. Defaults to true")
+    param :resolve_dependencies, :bool, :default => false, :desc => N_("If true, when adding the specified errata or packages, any needed dependencies will be copied as well. Defaults to false")
     param :propagate_all_composites, :bool, :desc => N_("If true, will publish a new composite version using any specified content_view_version_id that has been promoted to a lifecycle environment")
     param :add_content, Hash do
       param :errata_ids, Array, :desc => "Errata ids to copy into the new versions"
@@ -141,7 +141,7 @@ Alternatively, use the 'force' parameter to regenerate metadata locally. New ver
       end
 
       validate_content(params[:add_content])
-      resolve_dependencies = params.fetch(:resolve_dependencies, true)
+      resolve_dependencies = params.fetch(:resolve_dependencies, false)
       task = async_task(::Actions::Katello::ContentView::IncrementalUpdates, @content_view_version_environments, @composite_version_environments,
                         params[:add_content], resolve_dependencies, hosts, params[:description])
       respond_for_async :resource => task

--- a/app/lib/actions/katello/content_view_version/incremental_update.rb
+++ b/app/lib/actions/katello/content_view_version/incremental_update.rb
@@ -22,7 +22,7 @@ module Actions
         # rubocop:disable Metrics/CyclomaticComplexity
         # rubocop:disable Metrics/PerceivedComplexity
         def plan(old_version, environments, options = {})
-          dep_solve = options.fetch(:resolve_dependencies, true)
+          dep_solve = options.fetch(:resolve_dependencies, false)
           description = options.fetch(:description, '')
           content = options.fetch(:content, {})
           new_components = options.fetch(:new_components, [])

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/apply-errata.controller.js
@@ -41,6 +41,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
             }
 
             $scope.applyingErrata = false;
+            $scope.depSolve = false;
 
             // Labels so breadcrumb strings can be translated
             $scope.label = translate('Apply');
@@ -80,7 +81,7 @@ angular.module('Bastion.errata').controller('ApplyErrataController',
                 };
 
                 params['content_view_version_environments'] = [];
-                params['resolve_dependencies'] = !$scope.noDepSolve;
+                params['resolve_dependencies'] = $scope.depSolve;
 
                 //get a list of unique content view version ids with their environments
                 angular.forEach($scope.updates, function (update) {

--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -118,8 +118,8 @@
 
     <div class="checkbox" ng-show="updates.length > 0">
       <label>
-        <input name="noDepSolve" ng-model="noDepSolve" type="checkbox"/>
-        <b><span translate>Skip dependency solving for a significant speed increase. If the update cannot be applied to the host, delete the incremental content view version and retry the application with dependency solving turned on.</span></b>
+        <input name="depSolve" ng-model="depSolve" type="checkbox"/>
+        <b><span translate>Enable dependency solving to automatically include dependencies. This will significantly increase the time to publish.</span></b>
       </label>
     </div>
 

--- a/engines/bastion_katello/test/errata/apply-errata.controller.test.js
+++ b/engines/bastion_katello/test/errata/apply-errata.controller.test.js
@@ -183,7 +183,7 @@ describe('Controller: ApplyErrataController', function() {
                         'content_view_version_id': 1,
                         'environment_ids': [2]
                     }],
-                    'resolve_dependencies': true
+                    'resolve_dependencies': false
                 };
 
                 $scope.updates = [{
@@ -239,7 +239,7 @@ describe('Controller: ApplyErrataController', function() {
                         'content_view_version_id': 5,
                         'environment_ids': []
                     }],
-                    'resolve_dependencies': true
+                    'resolve_dependencies': false
                 };
 
                 $scope.updates = [{
@@ -283,7 +283,7 @@ describe('Controller: ApplyErrataController', function() {
                         'content_view_version_id': 5,
                         'environment_ids': [99]
                     }],
-                    'resolve_dependencies': true
+                    'resolve_dependencies': false
                 };
 
                 $scope.updates = [{

--- a/test/controllers/api/v2/content_view_versions_controller_test.rb
+++ b/test/controllers/api/v2/content_view_versions_controller_test.rb
@@ -295,6 +295,18 @@ module Katello
       assert_response :success
     end
 
+    def test_incremental_update_default_dep_solving
+      version = @library_dev_staging_view.versions.first
+      errata_id = Katello::Erratum.first.pulp_id
+      @controller.expects(:async_task).with(::Actions::Katello::ContentView::IncrementalUpdates,
+                [{:content_view_version => version, :environments => [@beta]}], [],
+                {'errata_ids' => [errata_id]}, false, [], nil).returns({})
+
+      put :incremental_update, params: { :content_view_version_environments => [{:content_view_version_id => version.id, :environment_ids => [@beta.id]}], :add_content => {:errata_ids => [errata_id]} }
+
+      assert_response :success
+    end
+
     def test_incremental_update_protected
       version = @library_dev_staging_view.versions.first
       errata_id = Katello::Erratum.first.pulp_id


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
- Update API to default to false for dependency solving.
- Update checkbox text to let user know checking the box will ENABLE dependency solving, and will increase publish time.
- Add test to verify default behavior
- Update js tests to match new behavior

#### What are the testing steps for this pull request?
- Running tests
- Manually checking checkbox text and workflow verifying that dependency solving is off by default now. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental content updates now disable dependency solving by default (unless explicitly enabled).
  * Errata application UI now offers an “enable dependency solving” option, explaining it may include dependencies and increase publish time.
* **Bug Fixes**
  * Updated API and errata request parameters to consistently reflect the selected dependency-solving behavior.
* **Tests**
  * Added/updated test coverage to verify the new default and parameter behavior across API and errata flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->