### PR TITLE
Fixes #39535 - add warning to dependency solving checkbox

### DIFF
--- a/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
+++ b/engines/bastion_katello/app/assets/javascripts/bastion_katello/errata/views/apply-errata-confirm.html
@@ -119,7 +119,7 @@
     <div class="checkbox" ng-show="updates.length > 0">
       <label>
         <input name="depSolve" ng-model="depSolve" type="checkbox"/>
-        <b><span translate>Enable dependency solving to automatically include dependencies. This will significantly increase the time to publish.</span></b>
+        <span translate>Enable dependency solving. Significantly increases publishing time. Do not enable unless package dependency issues are found first. Refer to the <a href="/links/docs/Managing_Content?chapter=dependency-solving-for-content-views" target="_blank" rel="noopener noreferrer">documentation</a> for more information.</span>
       </label>
     </div>
 


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
Add warning to dependency solving checkbox, following up on discussion on this PR which disable dependency solving by default 
https://github.com/Katello/katello/pull/11799.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the “Enable dependency resolution” option on the errata confirmation form.
  * Added guidance on when to enable it, the potential impact on publishing time, and an inline link to dependency-solving documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->