### PR TITLE
Fixes #39539 - Host actions are disabled after bulk action

### DIFF
--- a/webpack/components/extensions/Hosts/BulkActions/BulkAssignCVEnvsModal/BulkAssignCVEnvsModal.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkAssignCVEnvsModal/BulkAssignCVEnvsModal.js
@@ -6,9 +6,6 @@ import { Modal, Button, TextContent, Text, TextVariants } from '@patternfly/reac
 import { PlusCircleIcon } from '@patternfly/react-icons';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
-import { foremanUrl } from 'foremanReact/common/helpers';
-import { APIActions } from 'foremanReact/redux/API';
-import { HOSTS_API_PATH, API_REQUEST_KEY } from 'foremanReact/routes/Hosts/constants';
 import { useAPI } from 'foremanReact/common/hooks/API/APIHooks';
 import { selectAPIStatus } from 'foremanReact/redux/API/APISelectors';
 import { ENVIRONMENT_PATHS_KEY } from '../../../../../scenes/ContentViews/components/EnvironmentPaths/EnvironmentPathConstants';
@@ -28,6 +25,7 @@ const BulkAssignCVEnvsModal = ({
   orgId,
   fetchBulkParams,
   allowMultipleContentViews,
+  refreshTableData,
 }) => {
   const [assignments, setAssignments] = useState([]);
   const dispatch = useDispatch();
@@ -42,11 +40,7 @@ const BulkAssignCVEnvsModal = ({
   };
 
   const handleSuccess = () => {
-    // Refresh the hosts table to show updated content view environments
-    dispatch(APIActions.get({
-      key: API_REQUEST_KEY,
-      url: foremanUrl(HOSTS_API_PATH),
-    }));
+    refreshTableData();
     handleModalClose();
   };
 
@@ -178,12 +172,14 @@ BulkAssignCVEnvsModal.propTypes = {
   orgId: PropTypes.number.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
   allowMultipleContentViews: PropTypes.bool,
+  refreshTableData: PropTypes.func,
 };
 
 BulkAssignCVEnvsModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
   allowMultipleContentViews: true,
+  refreshTableData: () => {},
 };
 
 export default BulkAssignCVEnvsModal;

--- a/webpack/components/extensions/Hosts/BulkActions/BulkAssignCVEnvsModal/index.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkAssignCVEnvsModal/index.js
@@ -6,7 +6,7 @@ import BulkAssignCVEnvsModal from './BulkAssignCVEnvsModal';
 
 const BulkAssignCVEnvsModalScene = () => {
   const orgId = useForemanOrganization()?.id;
-  const { selectedCount, fetchBulkParams } = useContext(ForemanActionsBarContext);
+  const { selectedCount, fetchBulkParams, refreshTableData } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen('bulk-assign-cves-modal');
   const foremanContext = useForemanContext();
   const allowMultipleContentViews =
@@ -24,6 +24,7 @@ const BulkAssignCVEnvsModalScene = () => {
       closeModal={closeModal}
       orgId={orgId}
       allowMultipleContentViews={allowMultipleContentViews}
+      refreshTableData={refreshTableData}
     />
   );
 };

--- a/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCollectionsModal/BulkChangeHostCollectionsModal.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCollectionsModal/BulkChangeHostCollectionsModal.js
@@ -22,12 +22,7 @@ import { ExclamationTriangleIcon, PlusCircleIcon } from '@patternfly/react-icons
 import { addToast } from 'foremanReact/components/ToastsList';
 import { translate as __ } from 'foremanReact/common/I18n';
 import { STATUS } from 'foremanReact/constants';
-import { foremanUrl, noop } from 'foremanReact/common/helpers';
-import { APIActions } from 'foremanReact/redux/API';
-import {
-  HOSTS_API_PATH,
-  API_REQUEST_KEY,
-} from 'foremanReact/routes/Hosts/constants';
+import { noop } from 'foremanReact/common/helpers';
 import { useForemanOrganization } from 'foremanReact/Root/Context/ForemanContext';
 import { useTableIndexAPIResponse, useSetParamsAndApiAndSearch } from 'foremanReact/components/PF4/TableIndexPage/Table/TableIndexHooks';
 import { useBulkSelect } from 'foremanReact/components/PF4/TableIndexPage/Table/TableHooks';
@@ -46,6 +41,7 @@ const BulkChangeHostCollectionsModal = ({
   closeModal,
   fetchBulkParams,
   selectedCount: selectedHostsCount,
+  refreshTableData,
 }) => {
   const dispatch = useDispatch();
   const [addRadioChecked, setAddRadioChecked] = useState(true);
@@ -165,10 +161,7 @@ const BulkChangeHostCollectionsModal = ({
       : __('Host collections updated');
 
     dispatch(addToast({ type: 'success', message }));
-    dispatch(APIActions.get({
-      key: API_REQUEST_KEY,
-      url: foremanUrl(HOSTS_API_PATH),
-    }));
+    refreshTableData();
     handleModalClose();
   };
 
@@ -417,6 +410,7 @@ BulkChangeHostCollectionsModal.propTypes = {
   closeModal: PropTypes.func,
   fetchBulkParams: PropTypes.func,
   selectedCount: PropTypes.number,
+  refreshTableData: PropTypes.func,
 };
 
 BulkChangeHostCollectionsModal.defaultProps = {
@@ -424,6 +418,7 @@ BulkChangeHostCollectionsModal.defaultProps = {
   closeModal: () => {},
   fetchBulkParams: () => '',
   selectedCount: 0,
+  refreshTableData: () => {},
 };
 
 export default BulkChangeHostCollectionsModal;

--- a/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCollectionsModal/__tests__/BulkChangeHostCollectionsModal.test.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCollectionsModal/__tests__/BulkChangeHostCollectionsModal.test.js
@@ -64,6 +64,7 @@ const defaultProps = {
   closeModal: jest.fn(),
   fetchBulkParams: jest.fn(() => 'name ~ test'),
   selectedCount: 5,
+  refreshTableData: jest.fn(),
 };
 
 beforeEach(() => {
@@ -351,11 +352,6 @@ test('shows success toast notification on successful save', async () => {
     .put('/api/v2/hosts/bulk/add_host_collections')
     .reply(200, { displayMessages: ['Host collections updated'] });
 
-  const hostsRefreshScope = nockInstance
-    .get('/api/hosts')
-    .query(true)
-    .reply(200, { results: [] });
-
   const { getAllByRole, getByText } = renderWithRedux(
     <BulkChangeHostCollectionsModal {...defaultProps} />,
     renderOptions(),
@@ -387,10 +383,13 @@ test('shows success toast notification on successful save', async () => {
 
   await patientlyWaitFor(() => {
     expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+    expect(defaultProps.refreshTableData).toHaveBeenCalledTimes(1);
+    expect(defaultProps.closeModal).toHaveBeenCalledTimes(1);
+    expect(defaultProps.refreshTableData.mock.invocationCallOrder[0])
+      .toBeLessThan(defaultProps.closeModal.mock.invocationCallOrder[0]);
   });
 
   assertNockRequest(saveScope, false);
-  assertNockRequest(hostsRefreshScope, false);
   assertNockRequest(hostCollectionsScope, false);
   assertNockRequest(autocompleteScope, false);
 });
@@ -444,6 +443,7 @@ test('shows error toast notification on failed save', async () => {
 
   await patientlyWaitFor(() => {
     expect(addToast).toHaveBeenCalledWith(expect.objectContaining({ type: 'danger' }));
+    expect(defaultProps.refreshTableData).not.toHaveBeenCalled();
   });
 
   assertNockRequest(saveScope, false);
@@ -468,11 +468,6 @@ test('makes correct API call when Add action is selected', async () => {
   const saveScope = nockInstance
     .put('/api/v2/hosts/bulk/add_host_collections')
     .reply(200, { displayMessages: ['Host collections updated'] });
-
-  const hostsRefreshScope = nockInstance
-    .get('/api/hosts')
-    .query(true)
-    .reply(200, { results: [] });
 
   const { getAllByRole, getByText, getByLabelText } = renderWithRedux(
     <BulkChangeHostCollectionsModal {...defaultProps} />,
@@ -510,7 +505,6 @@ test('makes correct API call when Add action is selected', async () => {
 
   assertNockRequest(hostCollectionsScope, false);
   assertNockRequest(autocompleteScope, false);
-  assertNockRequest(hostsRefreshScope, false);
 });
 
 // Test for Remove action API call
@@ -530,11 +524,6 @@ test('makes correct API call when Remove action is selected', async () => {
   const saveScope = nockInstance
     .put('/api/v2/hosts/bulk/remove_host_collections')
     .reply(200, { displayMessages: ['Host collections updated'] });
-
-  const hostsRefreshScope = nockInstance
-    .get('/api/hosts')
-    .query(true)
-    .reply(200, { results: [] });
 
   const { getAllByRole, getByText, getByLabelText } = renderWithRedux(
     <BulkChangeHostCollectionsModal {...defaultProps} />,
@@ -579,7 +568,6 @@ test('makes correct API call when Remove action is selected', async () => {
 
   assertNockRequest(hostCollectionsScope, false);
   assertNockRequest(autocompleteScope, false);
-  assertNockRequest(hostsRefreshScope, false);
 });
 
 // Test for multiple host collections selected
@@ -599,11 +587,6 @@ test('makes correct API call with multiple host collections', async () => {
   const saveScope = nockInstance
     .put('/api/v2/hosts/bulk/add_host_collections')
     .reply(200, { displayMessages: ['Host collections updated'] });
-
-  const hostsRefreshScope = nockInstance
-    .get('/api/hosts')
-    .query(true)
-    .reply(200, { results: [] });
 
   const { getAllByRole, getByText } = renderWithRedux(
     <BulkChangeHostCollectionsModal {...defaultProps} />,
@@ -639,7 +622,6 @@ test('makes correct API call with multiple host collections', async () => {
 
   assertNockRequest(hostCollectionsScope, false);
   assertNockRequest(autocompleteScope, false);
-  assertNockRequest(hostsRefreshScope, false);
 });
 
 const emptyHostCollections = {

--- a/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCollectionsModal/index.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkChangeHostCollectionsModal/index.js
@@ -52,7 +52,7 @@ BulkChangeHostCollectionsMenuItem.defaultProps = {
 // This component renders only the modal (for the _all-hosts-modals slot)
 const BulkChangeHostCollectionsModalScene = () => {
   const orgId = useForemanOrganization()?.id;
-  const { selectedCount, fetchBulkParams } = useContext(ForemanActionsBarContext);
+  const { selectedCount, fetchBulkParams, refreshTableData } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen('bulk-change-host-collections-modal');
 
   if (!orgId) return null;
@@ -64,6 +64,7 @@ const BulkChangeHostCollectionsModalScene = () => {
       selectedCount={selectedCount}
       isOpen={isOpen}
       closeModal={closeModal}
+      refreshTableData={refreshTableData}
     />
   );
 };

--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/04_ReviewFooter.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/04_ReviewFooter.js
@@ -19,6 +19,7 @@ export const BulkErrataReviewFooter = () => {
     setFinishButtonLoading,
     selectedRexOption,
     closeModal,
+    refreshTableData,
     errataBulkSelect: {
       fetchBulkParams: getErrataBulkParams,
       selectedCount: errataSelectedCount,
@@ -55,6 +56,7 @@ export const BulkErrataReviewFooter = () => {
   const handleFinishButtonClick = () => {
     setFinishButtonLoading(true);
     triggerBulkErrataInstall();
+    refreshTableData();
     closeModal();
   };
 

--- a/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkErrataWizard/BulkErrataWizard.js
@@ -54,7 +54,7 @@ export const useErrataHostsBulkSelect = ({ initialSelectedHosts, modalIsOpen }) 
 export const ERRATA_URL = `${katelloApi.getApiUrl('/errata')}?per_page=7&include_permissions=true&errata_restrict_installable=true`;
 
 const BulkErrataWizard = ({ isOpen: modalOpen, closeModal }) => {
-  const { selectedCount: initialSelectedHostCount, fetchBulkParams }
+  const { selectedCount: initialSelectedHostCount, fetchBulkParams, refreshTableData }
     = useContext(ForemanActionsBarContext);
 
   const [shouldValidateStep2, setShouldValidateStep2] = useState(false);
@@ -112,6 +112,7 @@ const BulkErrataWizard = ({ isOpen: modalOpen, closeModal }) => {
     selectedRexOption,
     setSelectedRexOption,
     closeModal,
+    refreshTableData,
     errataBulkSelect,
     errataResults,
     errataMetadata,

--- a/webpack/components/extensions/Hosts/BulkActions/BulkManageTracesModal/BulkManageTracesModal.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkManageTracesModal/BulkManageTracesModal.js
@@ -73,6 +73,7 @@ const BulkManageTracesModal = ({
   selectedCount: hostsSelectedCount,
   orgId,
   fetchBulkParams,
+  refreshTableData,
 }) => {
   const dispatch = useDispatch();
   const [isBulkActionOpen, setIsBulkActionOpen] = useState(false);
@@ -193,6 +194,7 @@ const BulkManageTracesModal = ({
         },
       },
     }));
+    refreshTableData();
     handleModalClose();
   };
 
@@ -410,11 +412,13 @@ BulkManageTracesModal.propTypes = {
   selectedCount: PropTypes.number.isRequired,
   orgId: PropTypes.number.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
+  refreshTableData: PropTypes.func,
 };
 
 BulkManageTracesModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
+  refreshTableData: () => {},
 };
 
 export default BulkManageTracesModal;

--- a/webpack/components/extensions/Hosts/BulkActions/BulkManageTracesModal/index.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkManageTracesModal/index.js
@@ -7,7 +7,7 @@ import BulkManageTracesModal from './BulkManageTracesModal';
 const BulkManageTracesModalScene = () => {
   const orgId = useForemanOrganization()?.id;
   const contextValue = useContext(ForemanActionsBarContext);
-  const { selectedCount, fetchBulkParams } = contextValue || {};
+  const { selectedCount, fetchBulkParams, refreshTableData } = contextValue || {};
   const { isOpen, close: closeModal } = useBulkModalOpen('bulk-manage-traces-modal');
 
   if (!orgId) return null;
@@ -25,6 +25,7 @@ const BulkManageTracesModalScene = () => {
       isOpen={isOpen}
       closeModal={closeModal}
       orgId={orgId}
+      refreshTableData={refreshTableData}
     />
   );
 };

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_ReviewFooter.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/04_ReviewFooter.js
@@ -19,6 +19,7 @@ export const BulkPackagesReviewFooter = () => {
     setFinishButtonLoading,
     selectedRexOption,
     closeModal,
+    refreshTableData,
     packagesBulkSelect: {
       fetchBulkParams: getPackagesBulkParams,
       selectedCount: packagesSelectedCount,
@@ -94,6 +95,7 @@ export const BulkPackagesReviewFooter = () => {
     if (selectedAction === REMOVE) {
       triggerBulkPackageRemove();
     }
+    refreshTableData();
     closeModal();
   };
 

--- a/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkPackagesWizard/BulkPackagesWizard.js
@@ -77,7 +77,7 @@ const BulkPackagesWizard = () => {
 
   const [selectedAction, setSelectedAction] = useState(UPGRADE_ALL);
 
-  const { selectedCount: initialSelectedHostCount, fetchBulkParams }
+  const { selectedCount: initialSelectedHostCount, fetchBulkParams, refreshTableData }
     = useContext(ForemanActionsBarContext);
 
   const [shouldValidateStep2, setShouldValidateStep2] = useState(false);
@@ -158,6 +158,7 @@ const BulkPackagesWizard = () => {
     selectedRexOption,
     setSelectedRexOption,
     closeModal,
+    refreshTableData,
     packagesBulkSelect,
     packagesResults,
     packagesMetadata,

--- a/webpack/components/extensions/Hosts/BulkActions/BulkRepositorySetsWizard/03_ReviewFooter.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkRepositorySetsWizard/03_ReviewFooter.js
@@ -18,6 +18,7 @@ export const BulkRepositorySetsReviewFooter = () => {
     finishButtonLoading,
     setFinishButtonLoading,
     closeModal,
+    refreshTableData,
     hostsBulkSelect,
   } = useContext(BulkRepositorySetsWizardContext);
 
@@ -45,6 +46,7 @@ export const BulkRepositorySetsReviewFooter = () => {
   const handleFinishButtonClick = () => {
     setFinishButtonLoading(true);
     saveContentOverrides();
+    refreshTableData();
     closeModal();
   };
   return (

--- a/webpack/components/extensions/Hosts/BulkActions/BulkRepositorySetsWizard/BulkRepositorySetsWizard.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkRepositorySetsWizard/BulkRepositorySetsWizard.js
@@ -43,7 +43,7 @@ const BulkRepositorySetsWizard = () => {
 
   const finishButtonText = __('Set content overrides');
   const replacementResponse = !modalOpen ? { response: {} } : false;
-  const { selectedCount: initialSelectedHostCount, fetchBulkParams }
+  const { selectedCount: initialSelectedHostCount, fetchBulkParams, refreshTableData }
       = useContext(ForemanActionsBarContext);
   const repoSetsResponse = useTableIndexAPIResponse({
     replacementResponse, // don't fetch data if modal is closed
@@ -109,6 +109,7 @@ const BulkRepositorySetsWizard = () => {
     finishButtonLoading,
     setFinishButtonLoading,
     closeModal,
+    refreshTableData,
     repoSetsBulkSelect,
     repoSetsResults,
     repoSetsMetadata,

--- a/webpack/components/extensions/Hosts/BulkActions/BulkSystemPurposeModal/BulkSystemPurposeModal.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkSystemPurposeModal/BulkSystemPurposeModal.js
@@ -43,6 +43,7 @@ const BulkSystemPurposeModal = ({
   selectedCount,
   orgId,
   fetchBulkParams,
+  refreshTableData,
 }) => {
   const [selectedRole, setSelectedRole] = useState(NO_CHANGE);
   const [selectedUsage, setSelectedUsage] = useState(NO_CHANGE);
@@ -121,6 +122,7 @@ const BulkSystemPurposeModal = ({
       !releaseVersionDispatched || releaseVersionStatus !== STATUS.PENDING;
 
     if (sysPurposeComplete && releaseVersionComplete) {
+      refreshTableData();
       handleModalClose();
     }
   }, [
@@ -130,6 +132,7 @@ const BulkSystemPurposeModal = ({
     sysPurposeStatus,
     releaseVersionStatus,
     handleModalClose,
+    refreshTableData,
   ]);
 
   const roleOptions = buildSystemPurposeOptions(
@@ -348,10 +351,12 @@ BulkSystemPurposeModal.propTypes = {
   selectedCount: PropTypes.number.isRequired,
   orgId: PropTypes.number.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
+  refreshTableData: PropTypes.func,
 };
 
 BulkSystemPurposeModal.defaultProps = {
   isOpen: false,
+  refreshTableData: () => {},
 };
 
 export default BulkSystemPurposeModal;

--- a/webpack/components/extensions/Hosts/BulkActions/BulkSystemPurposeModal/index.js
+++ b/webpack/components/extensions/Hosts/BulkActions/BulkSystemPurposeModal/index.js
@@ -6,7 +6,7 @@ import BulkSystemPurposeModal from './BulkSystemPurposeModal';
 
 const BulkSystemPurposeModalScene = () => {
   const orgId = useForemanOrganization()?.id;
-  const { selectedCount, fetchBulkParams } = useContext(ForemanActionsBarContext);
+  const { selectedCount, fetchBulkParams, refreshTableData } = useContext(ForemanActionsBarContext);
   const { isOpen, close: closeModal } = useBulkModalOpen('bulk-system-purpose-modal');
 
   if (!orgId) return null;
@@ -19,6 +19,7 @@ const BulkSystemPurposeModalScene = () => {
       isOpen={isOpen}
       closeModal={closeModal}
       orgId={orgId}
+      refreshTableData={refreshTableData}
     />
   );
 };

--- a/webpack/components/extensions/Hosts/BulkActions/__tests__/bulkSystemPurposeModal.test.js
+++ b/webpack/components/extensions/Hosts/BulkActions/__tests__/bulkSystemPurposeModal.test.js
@@ -232,6 +232,7 @@ test('Handles API failure gracefully when releases endpoint fails', async () => 
 
 test('Submitting multiple changed fields triggers correct API calls', async () => {
   const closeModal = jest.fn();
+  const refreshTableData = jest.fn();
   const releasesScope = nockInstance
     .get(orgReleases)
     .reply(200, mockOrgReleases);
@@ -251,6 +252,7 @@ test('Submitting multiple changed fields triggers correct API calls', async () =
       selectedCount={5}
       fetchBulkParams={() => 'id ^ (1,2,3,4,5)'}
       orgId={1}
+      refreshTableData={refreshTableData}
     />
   );
   const { getAllByRole, getByLabelText } = renderWithRedux(jsx, renderOptions());
@@ -291,7 +293,10 @@ test('Submitting multiple changed fields triggers correct API calls', async () =
     assertNockRequest(releasesScope);
     assertNockRequest(systemPurposeScope);
     assertNockRequest(releaseVersionScope);
-    expect(closeModal).toHaveBeenCalled();
+    expect(refreshTableData).toHaveBeenCalledTimes(1);
+    expect(closeModal).toHaveBeenCalledTimes(1);
+    expect(refreshTableData.mock.invocationCallOrder[0])
+      .toBeLessThan(closeModal.mock.invocationCallOrder[0]);
   });
 });
 


### PR DESCRIPTION
depends on https://github.com/theforeman/foreman/pull/11110
to test: 
user has permissions to edit hosts
go to new host index
click on host kebab - edit is enabled
run X action
edit is still enabled. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host lists now refresh automatically after completing bulk actions, including package, errata, repository, collection, trace, and system-purpose operations.
  * Updated host data appears immediately after bulk changes without requiring a manual page refresh.
  * Refresh behavior is applied consistently across bulk action dialogs and multi-step workflows, ensuring completed changes are reflected as soon as the operation finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->