### PR TITLE
Fixes #39551 - make subscription api respond with subtotal as the number of filtered items in the set, make page, per_page numbers

### DIFF
--- a/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
+++ b/app/controllers/katello/api/v2/upstream_subscriptions_controller.rb
@@ -24,14 +24,13 @@ module Katello
     def index
       index_params = upstream_pool_params
       pools = UpstreamPool.fetch_pools(index_params)
-      page = index_params[:page] || 1
 
       collection = scoped_search_results(
         query: pools[:pools],
         subtotal: pools[:subtotal],
         total: pools[:total],
-        page: page,
-        per_page: index_params[:per_page])
+        page: metadata_page,
+        per_page: metadata_per_page)
       respond(collection: collection)
     end
 

--- a/app/models/katello/upstream_pool.rb
+++ b/app/models/katello/upstream_pool.rb
@@ -17,14 +17,14 @@ module Katello
         pools = response_to_pools(upstream_response, pool_id_map: pool_id_map)
         total = upstream_response.headers[total_count_header] || pools.count
 
-        respond(pools, total)
+        respond(pools, total.to_i)
       end
 
       def respond(pools, total)
         {
           pools: pools,
           total: total,
-          subtotal: pools.count,
+          subtotal: total,
         }
       end
 

--- a/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
+++ b/test/controllers/api/v2/upstream_subscriptions_controller_test.rb
@@ -23,10 +23,15 @@ module Katello
 
     def test_index
       params = { page: '3', per_page: '7', organization_id: @organization.id }
-      UpstreamPool.expects(:fetch_pools).with({ 'page' => '3', 'per_page' => '7' }).returns(pools: [{}], total: nil)
+      UpstreamPool.expects(:fetch_pools).with({ 'page' => '3', 'per_page' => '7' }).returns(pools: [{}], total: 1, subtotal: 1)
       get :index, params: params
 
       assert_response :success
+      body = JSON.parse(response.body)
+      assert_equal 3, body['page']
+      assert_equal 7, body['per_page']
+      assert_equal 1, body['subtotal']
+      assert_equal 1, body['total']
     end
 
     def test_index_full_result

--- a/test/models/upstream_pool_test.rb
+++ b/test/models/upstream_pool_test.rb
@@ -65,6 +65,19 @@ module Katello
       pools = UpstreamPool.fetch_pools({})
 
       assert_equal 4, pools[:total]
+      assert_equal 4, pools[:subtotal]
+    end
+
+    def test_fetch_pools_subtotal_reflects_filtered_total_not_page_size
+      raw_pools = Array.new(20) { @raw_pool.first.dup }
+      response = stub(to_str: raw_pools.to_json, headers: {x_total_count: 47})
+      stub_fetch_pools(response, base_params: { per_page: 20 })
+
+      pools = UpstreamPool.fetch_pools({ per_page: 20 })
+
+      assert_equal 20, pools[:pools].count
+      assert_equal 47, pools[:total]
+      assert_equal 47, pools[:subtotal]
     end
 
     def test_fetch_pools_with_pool_ids


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Previously subtotal was responding with the number of items per page:
<img width="2666" height="890" alt="image" src="https://github.com/user-attachments/assets/895201d3-9c24-4ec5-9e24-b54cc810a6ca" />

Now it's the number of filtered items in the set, so if we have 47 items, it's still 47 if there is no filter applied

<img width="1295" height="346" alt="image" src="https://github.com/user-attachments/assets/96253fe9-f25b-4ca3-8be5-d02e58517f79" />

Also made per_page and page numbers, as they were strings previously

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected upstream pool count reporting so both `total` and `subtotal` consistently reflect the full filtered total from the upstream `x_total_count` header.
  * Improved pagination behavior for upstream subscription listings so API responses return pagination fields aligned with requested values.
* **Tests**
  * Expanded upstream pool tests to verify `subtotal` matches `x_total_count`, including when pagination is applied.
  * Updated controller tests to assert `page`, `per_page`, `subtotal`, and `total` in the JSON response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->