### PR TITLE
Fixes #39569 - fix registration for separate Registration and Pulpcore proxies

### DIFF
--- a/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
+++ b/app/controllers/katello/concerns/api/v2/registration_controller_extensions.rb
@@ -20,7 +20,7 @@ module Katello
       end
 
       def context_urls
-        super.merge(rhsm_url: smart_proxy.rhsm_url, pulp_content_url: smart_proxy.pulp_content_url)
+        super.merge(rhsm_url: pulpcore_proxy.rhsm_url, pulp_content_url: pulpcore_proxy.pulp_content_url)
       end
 
       def default_location
@@ -29,12 +29,17 @@ module Katello
 
       private
 
-      def smart_proxy
-        @smart_proxy ||= begin
+      def pulpcore_proxy
+        @pulpcore_proxy ||= begin
           proxy = params[:url] ? find_smart_proxy : SmartProxy.pulp_primary
 
           fail Foreman::Exception, _('Smart proxy content source not found!') unless proxy
-          fail Foreman::Exception, _('Pulp 3 is not enabled on Smart proxy!') unless proxy.pulp3_enabled?
+
+          unless proxy.pulp3_enabled?
+            proxy = proxy.self_or_colocated_with_feature(SmartProxy::PULP3_FEATURE)
+          end
+
+          fail Foreman::Exception, _('Pulp 3 is not enabled on Smart proxy!') unless proxy&.pulp3_enabled?
 
           proxy
         end

--- a/test/controllers/foreman/registration_controller_test.rb
+++ b/test/controllers/foreman/registration_controller_test.rb
@@ -1,0 +1,65 @@
+require 'katello_test_helper'
+
+class Api::V2::RegistrationControllerTest < ActionController::TestCase
+  def setup
+    setup_controller_defaults(false)
+    setup_foreman_routes
+    login_user(User.find(users(:admin).id))
+    Setting[:foreman_url] = 'https://foreman.example.com'
+  end
+
+  def remove_pulpcore_feature(proxy)
+    pulpcore = Feature.find_by(name: SmartProxy::PULP3_FEATURE)
+    proxy.smart_proxy_features.where(feature: pulpcore).destroy_all
+    proxy.reload
+  end
+
+  def test_global_without_proxy_uses_pulp_primary
+    proxy = SmartProxy.pulp_primary
+    assert proxy.pulp3_enabled?, 'Pulp primary should have Pulpcore'
+
+    get :global, params: { organization_id: taxonomies(:organization1).id }
+    vars = assigns(:global_registration_vars)
+    assert_equal proxy.rhsm_url, vars[:rhsm_url]
+    assert_equal proxy.pulp_content_url, vars[:pulp_content_url]
+  end
+
+  def test_global_with_proxy_that_has_pulpcore
+    proxy = FactoryBot.create(:smart_proxy, :with_pulp3, url: 'https://capsule.example.com:9090')
+
+    @controller.stubs(:find_smart_proxy).returns(proxy)
+
+    get :global, params: { url: proxy.url, organization_id: taxonomies(:organization1).id }
+    vars = assigns(:global_registration_vars)
+    assert_equal proxy.rhsm_url, vars[:rhsm_url]
+    assert_equal proxy.pulp_content_url, vars[:pulp_content_url]
+  end
+
+  def test_global_with_proxy_lacking_pulpcore_falls_back_to_pulpcore_on_same_host
+    registration_proxy = FactoryBot.create(:smart_proxy, url: 'https://capsule.example.com:8443')
+    remove_pulpcore_feature(registration_proxy)
+    refute registration_proxy.pulp3_enabled?, 'Registration proxy should not have Pulpcore'
+
+    pulpcore_proxy = FactoryBot.create(:smart_proxy, :with_pulp3, url: 'https://capsule.example.com/pulp/api/v3/smart_proxy')
+    assert pulpcore_proxy.pulp3_enabled?, 'Pulpcore proxy should have Pulpcore'
+
+    @controller.stubs(:find_smart_proxy).returns(registration_proxy)
+
+    get :global, params: { url: registration_proxy.url, organization_id: taxonomies(:organization1).id }
+    vars = assigns(:global_registration_vars)
+    assert_equal pulpcore_proxy.rhsm_url, vars[:rhsm_url]
+    assert_equal pulpcore_proxy.pulp_content_url, vars[:pulp_content_url]
+  end
+
+  def test_global_with_proxy_lacking_pulpcore_and_no_fallback_raises_error
+    registration_proxy = FactoryBot.create(:smart_proxy, url: 'https://lonely-capsule.example.com:8443')
+    remove_pulpcore_feature(registration_proxy)
+    refute registration_proxy.pulp3_enabled?, 'Registration proxy should not have Pulpcore'
+
+    @controller.stubs(:find_smart_proxy).returns(registration_proxy)
+
+    get :global, params: { url: registration_proxy.url, organization_id: taxonomies(:organization1).id }
+    assert_response :error
+    assert_match(/Pulp 3 is not enabled/, response.body)
+  end
+end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Fixes host registration when using foremanctl external smart proxies where the Registration and Pulpcore features are configured on separate smart proxy records. The registration controller now properly finds the Pulpcore proxy when the Registration proxy doesn't have Pulp3 enabled.

**Depends on:** https://github.com/theforeman/foreman/pull/11124
Related foremanctl PR: https://github.com/theforeman/foremanctl/pull/675

#### Considerations taken when implementing this change?

- Renamed `smart_proxy` method to `pulpcore_proxy` for clarity
- Uses `find_colocated_with_feature` from Foreman core to locate the Pulpcore-enabled proxy on the same host
- Maintains backward compatibility for standard deployments where features are on the same proxy

#### What are the testing steps for this pull request?

1. Set up foremanctl external smart proxies with Registration and Pulpcore features on separate smart proxy records
2. Attempt to register a host using the registration endpoint
3. Verify that registration completes successfully and the host receives correct RHSM and Pulp content URLs
4. Run the new test: `foreman-test test/controllers/foreman/registration_controller_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now selects the appropriate content proxy, including a compatible fallback on the same host.
  * Registration returns a clear error when no suitable content proxy is available.
  * Registration URLs now consistently reflect the selected proxy’s available services, improving reliability when multiple proxies are configured.

* **Tests**
  * Added coverage for primary proxy selection, explicit proxy use, fallback behavior, generated registration URLs, and unavailable proxy errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->