### PR TITLE
Fixes #39571 - Show content view environment on host edit page

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -47,6 +47,10 @@
     <% host_cvenv_ids.each do |cvenv_id| %>
       <%= hidden_field_tag 'host[content_facet_attributes][content_view_environment_ids][]', cvenv_id, :id => nil %>
     <% end %>
+
+    <%= field(f, 'content_facet.content_view_environment', {:label => _("Content View Environment")}) do %>
+      <%= select_tag :host_content_view_environment_id, content_view_environment_options(@host, :selected_host_group => @hostgroup || @host&.hostgroup), :class => 'form-control', :disabled => true %>
+    <% end %>
   <% else %>
     <%# On host create, show a CVEnv dropdown %>
     <% host_cv_env_select_id = :host_content_view_environment_id %>


### PR DESCRIPTION
## Summary
- The content view environment field was removed from the host edit page
  as part of #39330 (PR #11753), which replaced the old separate LCE/CV
  dropdowns with hidden fields only.
- This PR adds a disabled select showing the host's current content view
  environment assignment, matching the style of the existing disabled
  Content Source select.
- The CVEnv select options are generated via the existing
  `content_view_environment_options` helper.
- The disabled select is display-only — form submission is still handled
  by the existing hidden fields, so multi-CV hosts are preserved and
  there is no risk of reintroducing SAT-42732.

## Testing steps I did
- [x] Host edit — form shows currently assigned CVEnv
- [x] Host edit — resubmitting host edit page does not change unchanged form values
- [x] Regression check for SAT-42732: multi-CV hosts not reset after edit

Co-authored with [Claude Code](https://claude.ai/claude-code)


Before LCE/CV dropdowns removal:
<img width="400" height="300" alt="before" src="https://github.com/user-attachments/assets/a319c2a8-4a90-49a0-8701-3f3f90f5306a" />
After LCE/CV dropdowns removal:
<img width="400" height="300" alt="after" src="https://github.com/user-attachments/assets/80acffd6-dc3b-4346-aa1d-165266aac09e" />
Now with this PR:
<img width="400" height="300" alt="now" src="https://github.com/user-attachments/assets/fec913cc-c81a-4e2b-b89a-cfbad8fd7758" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a disabled **Content View Environment** field when editing hosts with content view environments unavailable.
  * Preserved the current content view environment selection during host edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->