### PR TITLE
Fixes #39573 - Improve UX on generic content type pages

### DIFF
--- a/webpack/containers/Application/overrides.scss
+++ b/webpack/containers/Application/overrides.scss
@@ -61,6 +61,18 @@ html .pagination-pf-pagesize.btn-group {
   margin: 16px 24px;
 }
 
+.katello-page-section {
+  padding: 0 24px;
+
+  .katello-page-header {
+    padding: 24px 0 16px;
+  }
+
+  .margin-16-24 {
+    margin: 16px 0;
+  }
+}
+
 .margin-24-0 {
   margin: 24px 0;
 }

--- a/webpack/scenes/Content/GenericContentPage.js
+++ b/webpack/scenes/Content/GenericContentPage.js
@@ -70,8 +70,8 @@ const GenericContentPage = () => {
   }
 
   return (
-    <Grid>
-      <GridItem span={12} className="margin-24">
+    <Grid className="katello-page-section">
+      <GridItem span={12} className="katello-page-header">
         <TextContent>
           <Text ouiaId="page-text" component={TextVariants.h1}>{__(`${selectedContentType}`)}</Text>
         </TextContent>

--- a/webpack/scenes/Content/Table/ContentTable.js
+++ b/webpack/scenes/Content/Table/ContentTable.js
@@ -33,6 +33,7 @@ const ContentTable = ({
       ouiaId="content-table"
       key={selectedContentType}
       variant={TableVariant.compact}
+      isStriped
       autocompleteEndpoint={`/katello/api/v2/${contentTypes[selectedContentType][1]}`}
       bookmarkController="katello_generic_content_units"
       emptyContentTitle={__(`You currently don't have any ${selectedContentType}.`)}


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Updated the generic content type pages (Module Streams, Python Packages, etc.) to match UX feedback: added striped table rows for better readability, updated the header section spacing to 24px top and 16px bottom, and added 24px side padding to the page container.

#### Considerations taken when implementing this change?

The side spacing follows the same approach as Foreman's PageLayout, using padding on the container rather than margin on individual elements. The toolbar's existing margin-16-24 side margins are reset within the page scope since the container padding now provides that spacing. The CSS classes are scoped to .content-type-page so only the generic content pages are affected. No other Katello pages using TableWrapper or MainTable are impacted. The isStriped prop is added at the ContentTable level rather than MainTable to avoid affecting all tables across the application.

#### What are the testing steps for this pull request?

1. Navigate to Content -> Content Types -> Module Streams
2. Verify the table has alternating striped rows
3. Verify the header "Module Streams" has 24px top padding and 16px bottom padding
4. Verify the table and toolbar have consistent 24px side spacing, matching the Hosts page layout
5. Repeat steps 2-4 for other content type pages (Python Packages, Ansible Collections, OSTree Refs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved horizontal spacing and header alignment on generic content pages.
  * Refined page section and content spacing for a more consistent layout.
  * Enabled alternating row stripes in content tables to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->