### PR TITLE
Fixes #39577 - Use valid PEM for HttpProxy cacert in yum test

### DIFF
--- a/test/services/katello/pulp3/repository/yum/yum_test.rb
+++ b/test/services/katello/pulp3/repository/yum/yum_test.rb
@@ -43,13 +43,14 @@ module Katello
 
           def test_append_proxy_cacert_with_nil_ca_cert
             service = Katello::Pulp3::Repository::Yum.new(@repo, @proxy)
+            proxy_cacert = File.read("#{Katello::Engine.root}/test/fixtures/certs/real-ca.crt").strip
             http_proxy = FactoryBot.create(:http_proxy, :url => 'http://foo.com:1000',
                               :username => 'admin',
                               :password => 'password',
-                              :cacert => "proxy cert")
+                              :cacert => proxy_cacert)
             ::Katello::RootRepository.any_instance.stubs(:http_proxy).returns(http_proxy)
             options = service.append_proxy_cacert(ca_cert: nil)
-            assert_equal "proxy cert", options[:ca_cert]
+            assert_equal proxy_cacert, options[:ca_cert]
           end
 
           def test_append_proxy_cacert


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Foreman now validates HttpProxy#cacert as PEM, so tests must not create proxies with placeholder certificate strings (https://github.com/theforeman/foreman/pull/11107).

#### Considerations taken when implementing this change?

The test needs a real cacert fixture to pass.

#### What are the testing steps for this pull request?

The green CI is sufficient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated proxy certificate coverage to use a real CA certificate fixture.
  * Verified that the configured certificate is returned when no replacement certificate is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->