### PR TITLE
fixes #39578 - duplicate content view environments on hosts and activation keys

### DIFF
--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -83,7 +83,17 @@ module Katello
       with_environments(envs)
     end
 
+    def content_view_environment_ids=(ids)
+      ids = Array(ids).reject(&:blank?)
+      if ids.empty?
+        self.content_view_environments = []
+      else
+        self.content_view_environments = ContentViewEnvironment.find(ids.uniq)
+      end
+    end
+
     def content_view_environments=(new_cvenvs)
+      new_cvenvs = Array(new_cvenvs).uniq(&:id)
       if new_cvenvs.length > 1 && !Setting['allow_multiple_content_views']
         fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
         _("Assigning an activation key to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")

--- a/app/models/katello/activation_key.rb
+++ b/app/models/katello/activation_key.rb
@@ -84,6 +84,7 @@ module Katello
     end
 
     def content_view_environments=(new_cvenvs)
+      new_cvenvs = Array(new_cvenvs).uniq(&:id)
       if new_cvenvs.length > 1 && !Setting['allow_multiple_content_views']
         fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
         _("Assigning an activation key to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")

--- a/app/models/katello/content_view_environment.rb
+++ b/app/models/katello/content_view_environment.rb
@@ -102,6 +102,7 @@ module Katello
     def self.fetch_content_view_environments(organization:, labels: [], ids: [])
       # Must ensure content view environments remain in the same order.
       # Using ActiveRecord .where will return them in a different order.
+      # Duplicate labels/ids are ignored while preserving first-occurrence order.
       id_errors = []
       label_errors = []
       cvenvs = []
@@ -125,12 +126,12 @@ module Katello
           end
         end
       end
-      if labels.present? && labels.length != cvenvs.length
-        fail HttpErrors::UnprocessableEntity, _("No content view environments found with names: %{names}") % {names: label_errors.join(', ')} if label_errors.present?
-      elsif ids.present? && ids.length != cvenvs.length
-        fail HttpErrors::UnprocessableEntity, _("No content view environments found with ids: %{ids}") % {ids: id_errors.join(', ')} if id_errors.present?
+      if label_errors.present?
+        fail HttpErrors::UnprocessableEntity, _("No content view environments found with names: %{names}") % {names: label_errors.join(', ')}
+      elsif id_errors.present?
+        fail HttpErrors::UnprocessableEntity, _("No content view environments found with ids: %{ids}") % {ids: id_errors.join(', ')}
       end
-      cvenvs
+      cvenvs.uniq(&:id)
     end
 
     private

--- a/app/models/katello/content_view_environment_activation_key.rb
+++ b/app/models/katello/content_view_environment_activation_key.rb
@@ -5,7 +5,8 @@ module Katello
 
     default_scope { order(:priority => :asc) }
 
-    validates :content_view_environment_id, presence: true
+    validates :content_view_environment_id, presence: true,
+              uniqueness: { scope: :activation_key_id, message: N_("has already been taken for this activation key") }
     validates :activation_key_id, presence: true, unless: :new_record?
 
     def self.reprioritize_for_activation_key(activation_key, new_cvenvs)

--- a/app/models/katello/content_view_environment_content_facet.rb
+++ b/app/models/katello/content_view_environment_content_facet.rb
@@ -5,7 +5,8 @@ module Katello
 
     default_scope { order(:priority => :asc) }
 
-    validates :content_view_environment_id, presence: true
+    validates :content_view_environment_id, presence: true,
+              uniqueness: { scope: :content_facet_id, message: N_("has already been taken for this host") }
     validates :content_facet_id, presence: true, unless: :new_record?
     validate :ensure_valid_content_source, if: proc { Setting['validate_host_lce_content_source_coherence'] }
 

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -145,6 +145,7 @@ module Katello
       end
 
       def content_view_environments=(new_cvenvs)
+        new_cvenvs = Array(new_cvenvs).uniq(&:id)
         if new_cvenvs.length > 1 && !Setting['allow_multiple_content_views']
           fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
           _("Assigning a host to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -86,12 +86,9 @@ module Katello
 
       def initialize(*args)
         init_args = args.first || {}
-        cvenv_ids = init_args.delete(:content_view_environment_ids)&.reject(&:blank?)
+        cvenv_ids = init_args.delete(:content_view_environment_ids)
         super(*args)
-        if cvenv_ids.present?
-          # find() preserves input order and raises on missing IDs, unlike where()
-          self.content_view_environments = ContentViewEnvironment.find(cvenv_ids)
-        end
+        self.content_view_environment_ids = cvenv_ids if cvenv_ids.present?
         self.cvenvs_changed = false
       end
 
@@ -144,7 +141,18 @@ module Katello
         content_view_environments&.first&.lifecycle_environment
       end
 
+      def content_view_environment_ids=(ids)
+        ids = Array(ids).reject(&:blank?)
+        if ids.empty?
+          self.content_view_environments = []
+        else
+          # find() preserves input order and raises on missing IDs, unlike where()
+          self.content_view_environments = ContentViewEnvironment.find(ids.uniq)
+        end
+      end
+
       def content_view_environments=(new_cvenvs)
+        new_cvenvs = Array(new_cvenvs).uniq(&:id)
         if new_cvenvs.length > 1 && !Setting['allow_multiple_content_views']
           fail ::Katello::Errors::MultiEnvironmentNotSupportedError,
           _("Assigning a host to multiple content view environments is not enabled. To enable, set the allow_multiple_content_views setting.")

--- a/db/migrate/20260731120000_add_unique_index_to_content_view_environment_joins.rb
+++ b/db/migrate/20260731120000_add_unique_index_to_content_view_environment_joins.rb
@@ -1,0 +1,54 @@
+class AddUniqueIndexToContentViewEnvironmentJoins < ActiveRecord::Migration[6.1]
+  def up
+    remove_duplicate_content_view_environment_content_facets
+    remove_duplicate_content_view_environment_activation_keys
+
+    add_index :katello_content_view_environment_content_facets,
+              [:content_facet_id, :content_view_environment_id],
+              :unique => true,
+              :name => :index_cvenv_content_facets_on_facet_and_cvenv
+
+    add_index :katello_content_view_environment_activation_keys,
+              [:activation_key_id, :content_view_environment_id],
+              :unique => true,
+              :name => :index_cvenv_activation_keys_on_key_and_cvenv
+  end
+
+  def down
+    remove_index :katello_content_view_environment_content_facets,
+                 :name => :index_cvenv_content_facets_on_facet_and_cvenv
+    remove_index :katello_content_view_environment_activation_keys,
+                 :name => :index_cvenv_activation_keys_on_key_and_cvenv
+  end
+
+  private
+
+  def remove_duplicate_content_view_environment_content_facets
+    remove_duplicates(
+      Katello::ContentViewEnvironmentContentFacet,
+      :content_facet_id,
+      :content_view_environment_id
+    )
+  end
+
+  def remove_duplicate_content_view_environment_activation_keys
+    remove_duplicates(
+      Katello::ContentViewEnvironmentActivationKey,
+      :activation_key_id,
+      :content_view_environment_id
+    )
+  end
+
+  # Keep the row with the lowest priority (id as tie-breaker); delete the rest.
+  # unscoped avoids default_scope ORDER BY priority leaking into GROUP BY on PostgreSQL.
+  def remove_duplicates(model, *group_columns)
+    model.unscoped.group(*group_columns).having('COUNT(*) > 1').pluck(*group_columns).each do |group_values|
+      group_values = Array(group_values)
+      ids = model.unscoped
+                 .where(group_columns.zip(group_values).to_h)
+                 .order(:priority, :id)
+                 .pluck(:id)
+      model.unscoped.where(id: ids.drop(1)).delete_all
+    end
+  end
+end

--- a/db/migrate/20260731120000_add_unique_index_to_content_view_environment_joins.rb
+++ b/db/migrate/20260731120000_add_unique_index_to_content_view_environment_joins.rb
@@ -1,0 +1,61 @@
+class AddUniqueIndexToContentViewEnvironmentJoins < ActiveRecord::Migration[6.1]
+  def up
+    remove_duplicate_content_view_environment_content_facets
+    remove_duplicate_content_view_environment_activation_keys
+
+    add_index :katello_content_view_environment_content_facets,
+              [:content_facet_id, :content_view_environment_id],
+              :unique => true,
+              :name => :index_cve_content_facets_on_facet_and_cve
+
+    add_index :katello_content_view_environment_activation_keys,
+              [:activation_key_id, :content_view_environment_id],
+              :unique => true,
+              :name => :index_cve_activation_keys_on_key_and_cve
+  end
+
+  def down
+    remove_index :katello_content_view_environment_content_facets,
+                 :name => :index_cve_content_facets_on_facet_and_cve
+    remove_index :katello_content_view_environment_activation_keys,
+                 :name => :index_cve_activation_keys_on_key_and_cve
+  end
+
+  private
+
+  def remove_duplicate_content_view_environment_content_facets
+    execute(<<~SQL.squish)
+      DELETE FROM katello_content_view_environment_content_facets
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY content_facet_id, content_view_environment_id
+                   ORDER BY id
+                 ) AS duplicate_rank
+          FROM katello_content_view_environment_content_facets
+        ) duplicate_rows
+        WHERE duplicate_rank > 1
+      )
+    SQL
+  end
+
+  def remove_duplicate_content_view_environment_activation_keys
+    execute(<<~SQL.squish)
+      DELETE FROM katello_content_view_environment_activation_keys
+      WHERE id IN (
+        SELECT id
+        FROM (
+          SELECT id,
+                 ROW_NUMBER() OVER (
+                   PARTITION BY activation_key_id, content_view_environment_id
+                   ORDER BY id
+                 ) AS duplicate_rank
+          FROM katello_content_view_environment_activation_keys
+        ) duplicate_rows
+        WHERE duplicate_rank > 1
+      )
+    SQL
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -121,6 +121,28 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal_arrays target_cvenvs_ids, host.content_facet.content_view_environments.ids
   end
 
+  def test_host_contents_cvenv_ids_param_deduplicates
+    Setting[:allow_multiple_content_views] = true
+    ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+    host = FactoryBot.create(:host, :with_content, :with_subscription, :with_operatingsystem,
+                              :content_view => @content_view, :lifecycle_environment => @environment)
+    Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
+    target_cvenvs_ids = [::Katello::ContentViewEnvironment.where(:content_view_id => @cv4.id,
+      :environment_id => @dev.id).first, ::Katello::ContentViewEnvironment.where(:content_view_id => @cv3.id,
+      :environment_id => @dev.id).first].map(&:id)
+    put :update, params: {
+      :id => host.id,
+      :content_facet_attributes => {
+        :content_view_environment_ids => target_cvenvs_ids + [target_cvenvs_ids.first],
+      },
+    }, session: set_session_user
+    assert_response :success
+    host.content_facet.reload
+
+    assert_equal 2, host.content_facet.content_view_environment_ids.count
+    assert_equal_arrays target_cvenvs_ids, host.content_facet.content_view_environments.ids
+  end
+
   def test_set_content_view_environments_with_valid_content_view_environs_param
     # Updating content_view_environments sets cvenvs_changed=true, which makes backend_update_needed? return true,
     # which triggers the update_candlepin_associations callback

--- a/test/models/content_view_environment_activation_key_test.rb
+++ b/test/models/content_view_environment_activation_key_test.rb
@@ -26,5 +26,24 @@ module Katello
       assert_equal 1, cve1.priority(@activation_key)
       assert_equal 0, cve2.priority(@activation_key)
     end
+
+    def test_content_view_environments_deduplicates
+      Setting['allow_multiple_content_views'] = true
+      cve1 = katello_content_view_environments(:library_dev_view_dev)
+      cve2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      @activation_key.content_view_environments = [cve1, cve2, cve1]
+      assert_equal [cve1, cve2], @activation_key.content_view_environments.reload.to_a
+    end
+
+    def test_uniqueness_of_content_view_environment_per_activation_key
+      cve = katello_content_view_environments(:library_dev_view_dev)
+      @activation_key.content_view_environments = [cve]
+      duplicate = ContentViewEnvironmentActivationKey.new(
+        activation_key: @activation_key,
+        content_view_environment: cve
+      )
+      refute duplicate.valid?
+      assert_includes duplicate.errors[:content_view_environment_id], "has already been taken for this activation key"
+    end
   end
 end

--- a/test/models/content_view_environment_activation_key_test.rb
+++ b/test/models/content_view_environment_activation_key_test.rb
@@ -26,5 +26,41 @@ module Katello
       assert_equal 1, cve1.priority(@activation_key)
       assert_equal 0, cve2.priority(@activation_key)
     end
+
+    def test_content_view_environments_deduplicates
+      Setting['allow_multiple_content_views'] = true
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      @activation_key.content_view_environments = [cvenv1, cvenv2, cvenv1]
+      assert_equal [cvenv1, cvenv2], @activation_key.content_view_environments.reload.to_a
+    end
+
+    def test_content_view_environments_deduplicates_preserves_order
+      Setting['allow_multiple_content_views'] = true
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      # uniq keeps first occurrence, so reversed duplicates keep cvenv2 first
+      @activation_key.content_view_environments = [cvenv2, cvenv1, cvenv2]
+      assert_equal [cvenv2, cvenv1], @activation_key.content_view_environments.reload.to_a
+    end
+
+    def test_content_view_environment_ids_deduplicates
+      Setting['allow_multiple_content_views'] = true
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      @activation_key.content_view_environment_ids = [cvenv1.id, cvenv2.id, cvenv1.id]
+      assert_equal [cvenv1, cvenv2], @activation_key.content_view_environments.reload.to_a
+    end
+
+    def test_uniqueness_of_content_view_environment_per_activation_key
+      cvenv = katello_content_view_environments(:library_dev_view_dev)
+      @activation_key.content_view_environments = [cvenv]
+      duplicate = ContentViewEnvironmentActivationKey.new(
+        activation_key: @activation_key,
+        content_view_environment: cvenv
+      )
+      refute duplicate.valid?
+      assert_includes duplicate.errors[:content_view_environment_id], "has already been taken for this activation key"
+    end
   end
 end

--- a/test/models/content_view_environment_content_facet_test.rb
+++ b/test/models/content_view_environment_content_facet_test.rb
@@ -25,5 +25,15 @@ module Katello
       assert_equal 1, cve1.priority(@content_facet)
       assert_equal 0, cve2.priority(@content_facet)
     end
+
+    def test_uniqueness_of_content_view_environment_per_content_facet
+      cvenv = @content_facet.content_view_environments.first
+      duplicate = ContentViewEnvironmentContentFacet.new(
+        content_facet: @content_facet,
+        content_view_environment: cvenv
+      )
+      refute duplicate.valid?
+      assert_includes duplicate.errors[:content_view_environment_id], "has already been taken for this host"
+    end
   end
 end

--- a/test/models/content_view_environment_content_facet_test.rb
+++ b/test/models/content_view_environment_content_facet_test.rb
@@ -25,5 +25,15 @@ module Katello
       assert_equal 1, cve1.priority(@content_facet)
       assert_equal 0, cve2.priority(@content_facet)
     end
+
+    def test_uniqueness_of_content_view_environment_per_content_facet
+      cve = @content_facet.content_view_environments.first
+      duplicate = ContentViewEnvironmentContentFacet.new(
+        content_facet: @content_facet,
+        content_view_environment: cve
+      )
+      refute duplicate.valid?
+      assert_includes duplicate.errors[:content_view_environment_id], "has already been taken for this host"
+    end
   end
 end

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -75,5 +75,38 @@ module Katello
         ContentViewEnvironment.fetch_content_view_environments(ids: [cve.id, 9999], organization: dev.organization)
       end
     end
+
+    def test_fetch_content_view_environments_deduplicates_labels
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cvenv = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      result = ContentViewEnvironment.fetch_content_view_environments(
+        labels: ['published_dev_view_dev', 'published_dev_view_dev'],
+        organization: dev.organization
+      )
+      assert_equal [cvenv], result
+    end
+
+    def test_fetch_content_view_environments_deduplicates_ids
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cvenv = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      result = ContentViewEnvironment.fetch_content_view_environments(
+        ids: [cvenv.id, cvenv.id],
+        organization: dev.organization
+      )
+      assert_equal [cvenv], result
+    end
+
+    def test_fetch_content_view_environments_preserves_order_when_deduplicating
+      org = katello_environments(:dev).organization
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      result = ContentViewEnvironment.fetch_content_view_environments(
+        ids: [cvenv1.id, cvenv2.id, cvenv1.id],
+        organization: org
+      )
+      assert_equal [cvenv1, cvenv2], result
+    end
   end
 end

--- a/test/models/content_view_environment_test.rb
+++ b/test/models/content_view_environment_test.rb
@@ -75,5 +75,38 @@ module Katello
         ContentViewEnvironment.fetch_content_view_environments(ids: [cve.id, 9999], organization: dev.organization)
       end
     end
+
+    def test_fetch_content_view_environments_deduplicates_labels
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      result = ContentViewEnvironment.fetch_content_view_environments(
+        labels: ['published_dev_view_dev', 'published_dev_view_dev'],
+        organization: dev.organization
+      )
+      assert_equal [cve], result
+    end
+
+    def test_fetch_content_view_environments_deduplicates_ids
+      dev = katello_environments(:dev)
+      view = katello_content_views(:library_dev_view)
+      cve = Katello::ContentViewEnvironment.where(:environment_id => dev, :content_view_id => view).first
+      result = ContentViewEnvironment.fetch_content_view_environments(
+        ids: [cve.id, cve.id],
+        organization: dev.organization
+      )
+      assert_equal [cve], result
+    end
+
+    def test_fetch_content_view_environments_preserves_order_when_deduplicating
+      org = katello_environments(:dev).organization
+      cve1 = katello_content_view_environments(:library_dev_view_dev)
+      cve2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      result = ContentViewEnvironment.fetch_content_view_environments(
+        ids: [cve1.id, cve2.id, cve1.id],
+        organization: org
+      )
+      assert_equal [cve1, cve2], result
+    end
   end
 end

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -123,6 +123,15 @@ module Katello
       assert_equal 2, content_facet.content_view_environments.length
     end
 
+    def test_content_view_environments_deduplicates
+      Setting['allow_multiple_content_views'] = true
+      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+      cve1 = katello_content_view_environments(:library_dev_view_dev)
+      cve2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      content_facet.content_view_environments = [cve1, cve2, cve1]
+      assert_equal [cve1, cve2], content_facet.content_view_environments.reload.to_a
+    end
+
     def test_multi_cv_not_enabled
       Setting['allow_multiple_content_views'] = false
       assert_equal 1, content_facet.content_view_environments.length

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -123,6 +123,43 @@ module Katello
       assert_equal 2, content_facet.content_view_environments.length
     end
 
+    def test_content_view_environments_deduplicates
+      Setting['allow_multiple_content_views'] = true
+      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      content_facet.content_view_environments = [cvenv1, cvenv2, cvenv1]
+      assert_equal [cvenv1, cvenv2], content_facet.content_view_environments.reload.to_a
+    end
+
+    def test_content_view_environments_deduplicates_preserves_order
+      Setting['allow_multiple_content_views'] = true
+      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      # uniq keeps first occurrence, so reversed duplicates keep cvenv2 first
+      content_facet.content_view_environments = [cvenv2, cvenv1, cvenv2]
+      assert_equal [cvenv2, cvenv1], content_facet.content_view_environments.reload.to_a
+    end
+
+    def test_content_view_environment_ids_deduplicates
+      Setting['allow_multiple_content_views'] = true
+      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      content_facet.content_view_environment_ids = [cvenv1.id, cvenv2.id, cvenv1.id]
+      assert_equal [cvenv1, cvenv2], content_facet.content_view_environments.reload.to_a
+    end
+
+    def test_content_view_environment_ids_deduplicates_preserves_order
+      Setting['allow_multiple_content_views'] = true
+      ::Host::Managed.any_instance.stubs(:update_candlepin_associations)
+      cvenv1 = katello_content_view_environments(:library_dev_view_dev)
+      cvenv2 = katello_content_view_environments(:library_dev_staging_view_dev)
+      content_facet.content_view_environment_ids = [cvenv2.id, cvenv1.id, cvenv2.id]
+      assert_equal [cvenv2, cvenv1], content_facet.content_view_environments.reload.to_a
+    end
+
     def test_multi_cv_not_enabled
       Setting['allow_multiple_content_views'] = false
       assert_equal 1, content_facet.content_view_environments.length


### PR DESCRIPTION
### What are the changes introduced in this pull request?
When allow_multiple_content_views is enabled, callers can pass the same content view environment more than once (for example hammer host update --content-view-environments "A,B,A"). Previously those duplicates were kept, written into the join tables, and could leave duplicate rows even when the overall host update later failed (HTTP 500).

This PR:

- Deduplicates labels/ids in ContentViewEnvironment.fetch_content_view_environments, preserving first-occurrence order
- Deduplicates again in ContentFacet#content_view_environments= and ActivationKey#content_view_environments=
- Adds uniqueness validations on ContentViewEnvironmentContentFacet (scoped to content facet) and ContentViewEnvironmentActivationKey (scoped to activation key)
- Adds a migration that deletes existing duplicate join rows, then creates unique indexes on those pairs
-

### Considerations taken when implementing this change?

- Defense in depth: Fix at fetch (API/Hammer entry), at the association setters (any internal caller), and at the DB (constraint) so duplicates cannot land even if a path bypasses the Ruby setters
- Order preserved: Multi-CV priority depends on order; uniq keeps the first occurrence so "A,B,A" becomes A,B, not a reordered set
- Hosts and activation keys: Same bug pattern exists for both join models, so both were covered
- Existing data: Unique indexes alone would fail on environments that already have duplicates; the migration cleans those first
- Error behavior: Missing labels/ids still raise UnprocessableEntity; only true duplicates are dropped, not treated as “not found”

### What are the testing steps for this pull request?
Unit tests

cd ~/foreman
/usr/local/bin/ktest ../katello/test/models/content_view_environment_test.rb
/usr/local/bin/ktest ../katello/test/models/content_view_environment_content_facet_test.rb
/usr/local/bin/ktest ../katello/test/models/content_view_environment_activation_key_test.rb
/usr/local/bin/ktest ../katello/test/models/host/content_facet_test.rb -n "/content_view_environments/"
Migration

cd ~/foreman
bundle exec rake db:migrate
Manual (Hammer)

Enable allow_multiple_content_views
Pick two valid CVEnv labels for a host’s org (A, B)
Run:

- hammer host update --name <host> --content-view-environments "A,B,A"
- Confirm the update succeeds (no HTTP 500)
- Confirm the host shows A,B once (not A,B,A) in Hammer / host details
- Optionally repeat for an activation key with duplicate CVEnv labels/ids
- Optionally try inserting a duplicate join row in the console and confirm validation/unique index rejects it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Prevented duplicate content view environment assignments across hosts, activation keys, and content facets.
* Preserved the original order when duplicate environments or IDs are removed.
* Improved validation and error reporting for unresolved or duplicate environments.
* Ensured empty environment selections clear existing associations correctly.
* Cleaned up existing duplicate associations and added safeguards to prevent them from recurring.

## Tests

* Added coverage for deduplication, ordering, API updates, and duplicate-association validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->