### PR TITLE
Fixes #39581 - Fix sporadic test failure for epoch filter tests

### DIFF
--- a/test/fixtures/models/katello_repository_rpms.yml
+++ b/test/fixtures/models/katello_repository_rpms.yml
@@ -37,3 +37,15 @@ fedora_one_i686:
 fedora_one_i686_two:
   rpm_id: <%= ActiveRecord::FixtureSet.identify(:one_i686_two) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+fedora_openssl_epoch0:
+  rpm_id: <%= ActiveRecord::FixtureSet.identify(:openssl_epoch0) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+fedora_openssl_epoch1:
+  rpm_id: <%= ActiveRecord::FixtureSet.identify(:openssl_epoch1) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+fedora_openssl_epoch1_diff_version:
+  rpm_id: <%= ActiveRecord::FixtureSet.identify(:openssl_epoch1_diff_version) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -10,6 +10,9 @@ module Katello
       @rpm_one_two = katello_rpms(:one_two)
       @rpm_one_i686 = katello_rpms(:one_i686)
       @rpm_one_i686_two = katello_rpms(:one_i686_two)
+      @rpm_openssl_epoch0 = katello_rpms(:openssl_epoch0)
+      @rpm_openssl_epoch1 = katello_rpms(:openssl_epoch1)
+      @rpm_openssl_epoch1_diff_version = katello_rpms(:openssl_epoch1_diff_version)
 
       Rpm.any_instance.stubs(:backend_data).returns({})
     end
@@ -48,28 +51,31 @@ module Katello
 
     def test_search_version_greater_than_or_equal
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version >= 1.0')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_version_greater_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version > 1.0')
-      expected = [@rpm_three]
+      expected = [@rpm_three, @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_version_less_than_or_equal
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version <= 99')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_version_less_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version < 99')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
@@ -83,21 +89,24 @@ module Katello
 
     def test_search_release_greater_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('release > 1.el7')
-      expected = [@rpm_one_i686_two, @rpm_one_two, @rpm_three]
+      expected = [@rpm_one_i686_two, @rpm_one_two, @rpm_three,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_release_less_than_or_equal
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('release <= 2.el7')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_release_less_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('release < 2.el7')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The openssl epoch RPM fixtures (`openssl_epoch0`, `openssl_epoch1`, `openssl_epoch1_diff_version`) added in #39535 were missing join table entries in `katello_repository_rpms.yml`. Without these entries, the RPMs had no repository association at the fixture level. When the epoch filter tests called `@repo.rpms << [openssl_epoch0, ...]`, the `<<` operator would try to look up the RPM record, but because Rails' `disable_referential_integrity` disables all triggers (including the `evr_trigger`) during fixture loading, the composite `evr` column was left `NULL`. This caused sporadic `ActiveRecord::RecordNotFound` errors depending on database state.

Adding the missing join table entries ensures the `openssl` RPM fixtures are properly associated with the `fedora_17_x86_64 `repository, consistent with all other RPM fixtures.



#### Considerations taken when implementing this change?

#### What are the testing steps for this pull request?

-  All 17 `ContentViewPackageFilterTest` tests pass locally
-  Previously failing `tests test_version_filter_greater_than_without_epoch` and `test_version_filter_less_than_without_epoch` now pass consistently

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Expanded RPM search coverage for OpenSSL packages with different epochs, versions, and releases.
  * Added Fedora x86_64 package scenarios to verify accurate matching across varied RPM metadata.
  * Confirmed version- and release-based searches return the appropriate packages, including packages with differing epochs and versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->