### PR TITLE
Fixes #39579 - Return inherited content attributes in hostgroup API

### DIFF
--- a/app/models/katello/concerns/hostgroup_extensions.rb
+++ b/app/models/katello/concerns/hostgroup_extensions.rb
@@ -27,7 +27,6 @@ module Katello
 
         before_validation :correct_kickstart_repository
 
-        delegate :content_source_name, to: :content_facet, allow_nil: true
         delegate :content_source_id, :kickstart_repository_id, :content_view_id, :lifecycle_environment_id, :content_view_environment_id, to: :content_facet, allow_nil: true
         delegate :'content_source_id=', :'kickstart_repository_id=', :'content_view_environment_id=', to: :safe_content_facet, allow_nil: true
 
@@ -105,12 +104,20 @@ module Katello
         inherited_ancestry_attribute(:kickstart_repository_id, :content_facet)
       end
 
+      def content_source_name
+        content_source&.name
+      end
+
       def content_view_name
         content_view&.name
       end
 
       def lifecycle_environment_name
         lifecycle_environment&.name
+      end
+
+      def kickstart_repository_name
+        kickstart_repository&.name
       end
 
       def rhsm_organization_label

--- a/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
+++ b/app/views/katello/api/v2/hostgroups_extensions/show.json.rabl
@@ -1,4 +1,11 @@
 object @hostgroup
 extends 'api/v2/hostgroups/show'
-attributes :content_source_id, :content_source_name, :content_view_id, :content_view_name, :lifecycle_environment_id, :lifecycle_environment_name, :content_view_environment_id
-attributes :kickstart_repository_id, :kickstart_repository_name
+node(:content_source_id) { |hg| hg.content_source_id || hg.inherited_content_source_id }
+node(:content_source_name) { |hg| hg.content_source&.name }
+node(:content_view_id) { |hg| hg.content_view_id || hg.inherited_content_view_id }
+node(:content_view_name) { |hg| hg.content_view&.name }
+node(:lifecycle_environment_id) { |hg| hg.lifecycle_environment_id || hg.inherited_lifecycle_environment_id }
+node(:lifecycle_environment_name) { |hg| hg.lifecycle_environment&.name }
+node(:content_view_environment_id) { |hg| hg.content_view_environment_id || hg.inherited_content_view_environment_id }
+node(:kickstart_repository_id) { |hg| hg.kickstart_repository_id || hg.inherited_kickstart_repository_id }
+node(:kickstart_repository_name) { |hg| hg.kickstart_repository&.name }

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -140,6 +140,36 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_equal cvenv.id, response['content_view_environment_id']
   end
 
+  def test_show_child_hostgroup_inherits_content_attributes
+    org = FactoryBot.create(:katello_organization)
+    library = FactoryBot.create(:katello_environment, :library, organization: org)
+    view = FactoryBot.create(:katello_content_view, organization: org)
+    view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
+    cvenv = FactoryBot.create(:katello_content_view_environment,
+                            content_view_version: view_version,
+                            environment: library)
+    content_source = FactoryBot.create(:smart_proxy, :with_pulp3)
+
+    parent = ::Hostgroup.create!(name: 'InheritTestParent')
+    parent.content_view_environment_id = cvenv.id
+    parent.content_source_id = content_source.id
+    parent.save!
+
+    child = ::Hostgroup.create!(name: 'InheritTestChild', parent: parent)
+
+    get :show, params: { :id => child.id }
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_nil response['content_source_id']
+    assert_equal content_source.name, response['content_source_name']
+    assert_nil response['content_view_id']
+    assert_equal view.name, response['content_view_name']
+    assert_nil response['lifecycle_environment_id']
+    assert_equal library.name, response['lifecycle_environment_name']
+    assert_nil response['content_view_environment_id']
+  end
+
   def test_create_with_content_view_environment_id
     org = FactoryBot.create(:katello_organization)
     library = FactoryBot.create(:katello_environment, :library, organization: org)

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -140,6 +140,36 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_equal cvenv.id, response['content_view_environment_id']
   end
 
+  def test_show_child_hostgroup_inherits_content_attributes
+    org = FactoryBot.create(:katello_organization)
+    library = FactoryBot.create(:katello_environment, :library, organization: org)
+    view = FactoryBot.create(:katello_content_view, organization: org)
+    view_version = FactoryBot.create(:katello_content_view_version, content_view: view)
+    cvenv = FactoryBot.create(:katello_content_view_environment,
+                            content_view_version: view_version,
+                            environment: library)
+    content_source = FactoryBot.create(:smart_proxy, :with_pulp3)
+
+    parent = ::Hostgroup.create!(name: 'Parent')
+    parent.content_view_environment_id = cvenv.id
+    parent.content_source_id = content_source.id
+    parent.save!
+
+    child = ::Hostgroup.create!(name: 'Child', parent: parent)
+
+    get :show, params: { :id => child.id }
+
+    assert_response :success
+    response = JSON.parse(@response.body)
+    assert_equal content_source.id, response['content_source_id']
+    assert_equal content_source.name, response['content_source_name']
+    assert_equal view.id, response['content_view_id']
+    assert_equal view.name, response['content_view_name']
+    assert_equal library.id, response['lifecycle_environment_id']
+    assert_equal library.name, response['lifecycle_environment_name']
+    assert_equal cvenv.id, response['content_view_environment_id']
+  end
+
   def test_create_with_content_view_environment_id
     org = FactoryBot.create(:katello_organization)
     library = FactoryBot.create(:katello_environment, :library, organization: org)


### PR DESCRIPTION
## Summary
- Child hostgroups now return inherited `content_source_id`, `content_view_id`,
  `lifecycle_environment_id`, `content_view_environment_id`, and
  `kickstart_repository_id` (plus their `_name` counterparts) when queried via API
- Previously these fields returned `null` because the RABL view used `attributes`
  which called delegated methods that only returned the child's own facet values
  without walking the hostgroup ancestry tree
- Changed the RABL view from `attributes` to `node()` blocks that fall back to
  `inherited_*` methods when the child's own value is nil

## Root Cause
The `delegate :content_source_id, :kickstart_repository_id, ...` in
`HostgroupExtensions` returns only the child hostgroup's own content facet values.
The association methods (`content_source`, `kickstart_repository`, etc.) already had
ancestry-walking overrides, but the `_id` accessors did not. The RABL view called
the `_id` methods directly, producing `null` in the API response.

This also caused an inconsistency: `content_view_name` and
`lifecycle_environment_name` returned inherited values (because their methods go
through ancestry-aware associations), while `content_source_name` returned `null`
(because it was explicitly delegated to the facet, bypassing the ancestry-aware
`content_source` method).

## Test plan
- [x] Added `test_show_child_hostgroup_inherits_content_attributes` controller test
- [x] Existing hostgroup API controller tests pass (10 tests, 54 assertions, 0 failures)
### Manual verification
```
curl -s -k -u usr:psw https://localhost/api/v2/hostgroups/4 | python3 -c "import json,sys; d=json.load(sys.stdin); print('Hostgroup:', d.get('title'), '| Parent:', d.get('parent_name')); [print(k,':',d.get(k)) for k in ['content_source_id','content_source_name','content_view_id','content_view_name','lifecycle_environment_id','lifecycle_environment_name','content_view_environment_id','kickstart_repository_id','kickstart_repository_name']]"
```

Before fix:
```
Hostgroup: bug-parent/bug-child | Parent: bug-parent
content_source_id : None
content_source_name : None
content_view_id : None
content_view_name : cv1
lifecycle_environment_id : None
lifecycle_environment_name : Library
content_view_environment_id : None
kickstart_repository_id : None
kickstart_repository_name : None
```

After fix:
```
Hostgroup: bug-parent/bug-child | Parent: bug-parent
content_source_id : 1
content_source_name : content-source.redhat.com
content_view_id : 2
content_view_name : cv1
lifecycle_environment_id : 1
lifecycle_environment_name : Library
content_view_environment_id : 2
kickstart_repository_id : 14
kickstart_repository_name : Red Hat Enterprise Linux 10 for x86_64 - BaseOS Kickstart 10.0
```

Co-Authored-By: [Claude](noreply@anthropic.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hostgroup inheritance in API responses.
  * Child hostgroups now correctly display inherited content source, content view, lifecycle environment, and content view environment names.
  * Added reliable display of content source and kickstart repository names, including when these associations are unavailable.
  * Child-specific identifiers remain unset when inherited values are shown, providing clearer and more accurate API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->