### PR TITLE
[CP] Cherry picks for 4.21.1

### DIFF
--- a/app/controllers/katello/api/v2/content_uploads_controller.rb
+++ b/app/controllers/katello/api/v2/content_uploads_controller.rb
@@ -51,7 +51,8 @@ module Katello
     private
 
     def find_repository
-      @repository = Repository.find(params[:repository_id])
+      @repository = Repository.editable.find_by(id: params[:repository_id])
+      throw_resource_not_found(name: 'repository', id: params[:repository_id]) if @repository.nil?
     end
   end
 end

--- a/app/models/katello/concerns/organization_extensions.rb
+++ b/app/models/katello/concerns/organization_extensions.rb
@@ -21,6 +21,7 @@ module Katello
         # has_many :environments is already defined in Foreman taxonomy.rb
         has_many :kt_environments, :class_name => "Katello::KTEnvironment", :dependent => :restrict_with_exception, :inverse_of => :organization
         has_one :library, lambda { where(:library => true) }, :class_name => "Katello::KTEnvironment", :dependent => :destroy
+        before_destroy :nullify_acs_ssl_credentials
         has_many :gpg_keys, :class_name => "Katello::ContentCredential", :dependent => :destroy, :inverse_of => :organization
         has_many :sync_plans, :class_name => "Katello::SyncPlan", :dependent => :destroy, :inverse_of => :organization
         has_many :host_collections, :class_name => "Katello::HostCollection", :dependent => :destroy, :inverse_of => :organization
@@ -159,6 +160,14 @@ module Katello
             default_proxy.organizations << self
             default_proxy.save
           end
+        end
+
+        def nullify_acs_ssl_credentials
+          cc_ids = gpg_keys.pluck(:id)
+          return if cc_ids.empty?
+          Katello::AlternateContentSource.where(ssl_ca_cert_id: cc_ids).update_all(ssl_ca_cert_id: nil)
+          Katello::AlternateContentSource.where(ssl_client_cert_id: cc_ids).update_all(ssl_client_cert_id: nil)
+          Katello::AlternateContentSource.where(ssl_client_key_id: cc_ids).update_all(ssl_client_key_id: nil)
         end
 
         def validate_destroy(current_org)

--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -155,7 +155,10 @@ module Katello
         super(new_cves)
         Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(self, new_cves)
         self.content_view_environments.reload unless self.new_record?
-        self.host&.update_candlepin_associations unless self.host&.new_record?
+        # Mark as changed to ensure the before_update callback triggers Candlepin update.
+        # Don't call update_candlepin_associations directly - the callback handles it and
+        # prevents duplicate requests when called during host.save!
+        self.cvenvs_changed = true unless self.new_record?
       end
 
       def content_view_environment_labels

--- a/app/services/katello/registration_manager.rb
+++ b/app/services/katello/registration_manager.rb
@@ -298,8 +298,12 @@ module Katello
 
       def populate_content_facet(host, content_view_environments)
         content_facet = host.content_facet || ::Katello::Host::ContentFacet.new(:host => host)
+        new_content_facet = content_facet.new_record?
         content_facet.content_view_environments = content_view_environments
         content_facet.save!
+        if new_content_facet
+          Katello::ContentViewEnvironmentContentFacet.reprioritize_for_content_facet(content_facet, content_view_environments)
+        end
         content_facet
       end
 

--- a/app/views/foreman/job_templates/resolve_traces.erb
+++ b/app/views/foreman/job_templates/resolve_traces.erb
@@ -16,6 +16,7 @@ template_inputs:
 commands = @host.traces_helpers(search: input('Traces search query'))
 reboot = commands.delete('reboot')
 -%>
+PATH="$PATH:/usr/bin:/usr/sbin:/bin:/sbin"
 <% if reboot -%>
 shutdown -r +1
 <% else -%>

--- a/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
+++ b/test/controllers/api/rhsm/candlepin_proxies_controller_test.rb
@@ -135,6 +135,41 @@ module Katello
         assert_equal 'Registering to multiple environments is not enabled.', body['displayMessage']
         assert_response 400
       end
+
+      it "should return Candlepin validation error when name is invalid" do
+        # SAT-36519: Test that Candlepin validation errors (400) are returned correctly,
+        # not masked by 404 from spurious PUT requests during error cleanup
+        error_body = '{"displayMessage":"System name cannot begin with # character"}'
+        cp_response = stub(code: 400, body: error_body)
+        ::Katello::RegistrationManager.expects(:process_registration).raises(
+          RestClient::BadRequest.new(cp_response, 400)
+        )
+
+        post(:consumer_create,
+             params: {
+               :organization_id => @content_view_environment.content_view.organization.label,
+               :environment_id => @content_view_environment.cp_id,
+               :name => '#invalidname',
+               :facts => @facts,
+             })
+
+        body = JSON.parse(response.body)
+        assert_includes body['displayMessage'], 'System name cannot begin with # character'
+        assert_response 400
+      end
+
+      it "should return displayMessage instead of message for RHSM error responses" do
+        ::Katello::RegistrationManager.expects(:process_registration).never
+
+        post(:consumer_create, params: { :organization_id => 'nonexistent_org', :facts => @facts })
+
+        assert_response :not_found
+        body = JSON.parse(response.body)
+        assert body.key?('displayMessage'), 'RHSM error responses must include displayMessage for subscription-manager compatibility'
+        assert_not_nil body['displayMessage']
+        refute_empty body['displayMessage']
+        refute body.key?('message'), 'RHSM error responses should use displayMessage, not message'
+      end
     end
 
     describe "update enabled_repos" do

--- a/test/controllers/api/v2/content_uploads_controller_test.rb
+++ b/test/controllers/api/v2/content_uploads_controller_test.rb
@@ -128,5 +128,47 @@ module Katello
         delete :destroy, params: { :id => "1", :repository_id => @repo.id }
       end
     end
+
+    def test_create_upload_cannot_access_unauthorized_repository
+      unauthorized_repo = Repository.find(katello_repositories(:uln_ovm2_2_1_1_i386_patch).id)
+      product = @repo.product
+
+      login_user(User.find(users(:restricted).id))
+      setup_current_user_with_permissions(
+        { :name => :edit_products, :search => "name=\"#{product.name}\"" },
+        organizations: [get_organization]
+      )
+
+      post :create, params: { :repository_id => unauthorized_repo.id, :size => 100 }
+      assert_response :not_found
+    end
+
+    def test_update_cannot_access_unauthorized_repository
+      unauthorized_repo = Repository.find(katello_repositories(:uln_ovm2_2_1_1_i386_patch).id)
+      product = @repo.product
+
+      login_user(User.find(users(:restricted).id))
+      setup_current_user_with_permissions(
+        { :name => :edit_products, :search => "name=\"#{product.name}\"" },
+        organizations: [get_organization]
+      )
+
+      put :update, params: { :id => "1", :offset => "0", :content => "/tmp/file.rpm", :repository_id => unauthorized_repo.id }
+      assert_response :not_found
+    end
+
+    def test_destroy_cannot_access_unauthorized_repository
+      unauthorized_repo = Repository.find(katello_repositories(:uln_ovm2_2_1_1_i386_patch).id)
+      product = @repo.product
+
+      login_user(User.find(users(:restricted).id))
+      setup_current_user_with_permissions(
+        { :name => :edit_products, :search => "name=\"#{product.name}\"" },
+        organizations: [get_organization]
+      )
+
+      delete :destroy, params: { :id => "1", :repository_id => unauthorized_repo.id }
+      assert_response :not_found
+    end
   end
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -147,7 +147,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_set_content_view_environments_with_valid_content_view_environs_param
-    Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
+    # Updating content_view_environments sets cvenvs_changed=true, which makes backend_update_needed? return true,
+    # which triggers the update_candlepin_associations callback
     ::Host::Managed.any_instance.expects(:update_candlepin_associations)
     host = FactoryBot.create(:host, :with_content, :with_subscription,
                               :content_view => @content_view, :lifecycle_environment => @environment)
@@ -162,7 +163,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   def test_set_content_view_environments_with_valid_ids_param
-    Katello::Host::SubscriptionFacet.any_instance.expects(:backend_update_needed?).returns(false)
+    # Updating content_view_environments sets cvenvs_changed=true, which makes backend_update_needed? return true,
+    # which triggers the update_candlepin_associations callback
     ::Host::Managed.any_instance.expects(:update_candlepin_associations)
     host = FactoryBot.create(:host, :with_content, :with_subscription,
                               :content_view => @content_view, :lifecycle_environment => @environment)

--- a/test/fixtures/models/katello_repository_rpms.yml
+++ b/test/fixtures/models/katello_repository_rpms.yml
@@ -37,3 +37,15 @@ fedora_one_i686:
 fedora_one_i686_two:
   rpm_id: <%= ActiveRecord::FixtureSet.identify(:one_i686_two) %>
   repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+fedora_openssl_epoch0:
+  rpm_id: <%= ActiveRecord::FixtureSet.identify(:openssl_epoch0) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+fedora_openssl_epoch1:
+  rpm_id: <%= ActiveRecord::FixtureSet.identify(:openssl_epoch1) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>
+
+fedora_openssl_epoch1_diff_version:
+  rpm_id: <%= ActiveRecord::FixtureSet.identify(:openssl_epoch1_diff_version) %>
+  repository_id: <%= ActiveRecord::FixtureSet.identify(:fedora_17_x86_64) %>

--- a/test/lib/concerns/renderer_extensions_test.rb
+++ b/test/lib/concerns/renderer_extensions_test.rb
@@ -6,7 +6,6 @@ module Katello
       @repo = katello_repositories(:rhel_6_x86_64)
       @host = hosts(:one)
       @host.content_facet.content_source = smart_proxies(:one)
-      @host.expects(:update_candlepin_associations)
       @host.content_facet.content_source.lifecycle_environments << katello_environments(:library)
       @host.operatingsystem = operatingsystems(:redhat)
       @host.content_facet.kickstart_repository = @repo

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -35,28 +35,25 @@ module Katello
 
     def test_action_triggered_on_facet_cve_update
       host.reload
-      host.expects(:update_candlepin_associations).twice
-      host.content_facet.assign_single_environment(
-        :content_view => view,
-        :lifecycle_environment => dev
-      )
+      # Only called once from before_update callback, not from setter (SAT-36519 fix)
+      host.expects(:update_candlepin_associations).once
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, dev.id)
+      host.content_facet.content_view_environments = [cvenv]
       host.save!
 
       host.reload
-      host.expects(:update_candlepin_associations).twice
-      host.content_facet.assign_single_environment(
-        :content_view => view2,
-        :lifecycle_environment => dev
-      )
+      # Only called once from before_update callback, not from setter (SAT-36519 fix)
+      host.expects(:update_candlepin_associations).once
+      cvenv2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
+      host.content_facet.content_view_environments = [cvenv2]
       host.save!
     end
 
-    def test_content_facet_cve_update
-      host.expects(:update_candlepin_associations).twice
-      host.content_facet.assign_single_environment(
-        :content_view => view2,
-        :lifecycle_environment => dev
-      )
+    def test_content_facet_cvenv_update
+      # Only called once from before_update callback, not from setter (SAT-36519 fix)
+      host.expects(:update_candlepin_associations).once
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
+      host.content_facet.content_view_environments = [cvenv]
       host.save!
       host.reload.content_facet.reload
 

--- a/test/models/concerns/organization_extensions_test.rb
+++ b/test/models/concerns/organization_extensions_test.rb
@@ -22,5 +22,25 @@ module Katello
       @org.expects(:imports).returns([{'foo' => 'bar' }, {'foo' => 'bar'}])
       assert_equal 'bar', @org.manifest_history[0].foo
     end
+
+    def test_nullify_acs_ssl_credentials_clears_acs_references_before_destroy
+      cc_ids = @org.gpg_keys.pluck(:id)
+
+      assert Katello::AlternateContentSource.where(ssl_ca_cert_id: cc_ids).exists?,
+             "expected ACS fixtures to reference the org's content credentials"
+
+      @org.nullify_acs_ssl_credentials
+
+      assert_empty Katello::AlternateContentSource.where(ssl_ca_cert_id: cc_ids)
+      assert_empty Katello::AlternateContentSource.where(ssl_client_cert_id: cc_ids)
+      assert_empty Katello::AlternateContentSource.where(ssl_client_key_id: cc_ids)
+    end
+
+    def test_nullify_acs_ssl_credentials_is_noop_without_gpg_keys
+      org_without_ccs = get_organization(:organization2)
+      org_without_ccs.gpg_keys.delete_all
+
+      assert_nothing_raised { org_without_ccs.nullify_acs_ssl_credentials }
+    end
   end
 end

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -163,10 +163,9 @@ module Katello
     def setup
       super
       @host = hosts(:one)
-      @host.expects(:update_candlepin_associations)
-      @host.content_facet.assign_single_environment(
-        content_view: katello_content_views(:library_dev_view),
-        lifecycle_environment: katello_environments(:library)
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        katello_content_views(:library_dev_view).id,
+        katello_environments(:library).id
       )
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
@@ -221,10 +220,9 @@ module Katello
       @repo = katello_repositories(:rhel_6_x86_64)
       @security = katello_errata(:security)
       @host = hosts(:one)
-      @host.expects(:update_candlepin_associations)
-      @host.content_facet.assign_single_environment(
-        content_view: katello_content_views(:library_dev_view),
-        lifecycle_environment: katello_environments(:library)
+      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
+        katello_content_views(:library_dev_view).id,
+        katello_environments(:library).id
       )
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -167,6 +167,7 @@ module Katello
         katello_content_views(:library_dev_view).id,
         katello_environments(:library).id
       )
+      @host.content_facet.content_view_environments = [cvenv]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!
@@ -224,6 +225,7 @@ module Katello
         katello_content_views(:library_dev_view).id,
         katello_environments(:library).id
       )
+      @host.content_facet.content_view_environments = [cvenv]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!

--- a/test/models/rpm_test.rb
+++ b/test/models/rpm_test.rb
@@ -10,6 +10,9 @@ module Katello
       @rpm_one_two = katello_rpms(:one_two)
       @rpm_one_i686 = katello_rpms(:one_i686)
       @rpm_one_i686_two = katello_rpms(:one_i686_two)
+      @rpm_openssl_epoch0 = katello_rpms(:openssl_epoch0)
+      @rpm_openssl_epoch1 = katello_rpms(:openssl_epoch1)
+      @rpm_openssl_epoch1_diff_version = katello_rpms(:openssl_epoch1_diff_version)
 
       Rpm.any_instance.stubs(:backend_data).returns({})
     end
@@ -48,28 +51,31 @@ module Katello
 
     def test_search_version_greater_than_or_equal
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version >= 1.0')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_version_greater_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version > 1.0')
-      expected = [@rpm_three]
+      expected = [@rpm_three, @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_version_less_than_or_equal
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version <= 99')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_three, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_version_less_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('version < 99')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
@@ -83,21 +89,24 @@ module Katello
 
     def test_search_release_greater_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('release > 1.el7')
-      expected = [@rpm_one_i686_two, @rpm_one_two, @rpm_three]
+      expected = [@rpm_one_i686_two, @rpm_one_two, @rpm_three,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_release_less_than_or_equal
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('release <= 2.el7')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_one_i686_two, @rpm_one_two, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end
 
     def test_search_release_less_than
       rpms = Rpm.in_repositories(@repo).non_modular.search_for('release < 2.el7')
-      expected = [@rpm_one, @rpm_one_i686, @rpm_two]
+      expected = [@rpm_one, @rpm_one_i686, @rpm_two,
+                  @rpm_openssl_epoch0, @rpm_openssl_epoch1, @rpm_openssl_epoch1_diff_version]
       # RPMs are sorted by name, but all RPMs here have the same name. So, we need to sort by ID.
       assert_equal expected.sort_by(&:id), rpms.to_a.sort_by(&:id)
     end

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -284,7 +284,8 @@ module Katello
       end
 
       def test_registration_existing_host
-        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(2)
+        # Only called once from before_update callback, not from setter (SAT-36519 fix)
+        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(1)
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
         ::Katello::Resources::Candlepin::Consumer.expects(:destroy)
@@ -299,7 +300,9 @@ module Katello
       end
 
       def test_force_registration_existing_host
-        ::Host::Managed.any_instance.expects(:update_candlepin_associations).times(1)
+        # When unregister_host raises RestClient::Gone, the consumer is already gone from Candlepin
+        # so update_candlepin_associations should NOT be called (there's nothing to update)
+        ::Host::Managed.any_instance.expects(:update_candlepin_associations).never
         ::Katello::RegistrationManager.expects(:unregister_host).raises(RestClient::Gone)
         ::Katello::RegistrationManager.expects(:create_in_candlepin)
         ::Katello::RegistrationManager.expects(:finalize_registration)
@@ -507,7 +510,8 @@ module Katello
 
       # this case can only happen if candlepin/pulp dies after the host is unregistered, but before it's re-registered.
       def test_registration_existing_host_dead_backend_service
-        ::Host::Managed.any_instance.stubs(:update_candlepin_associations).twice
+        # Only called once from before_update callback, not from setter (SAT-36519 fix)
+        ::Host::Managed.any_instance.stubs(:update_candlepin_associations).once
         @host = FactoryBot.create(:host, :with_content, :with_subscription, :content_view => @content_view,
                                    :lifecycle_environment => @library, :organization => @content_view.organization)
         @host.content_facet.expects(:destroy).never

--- a/test/services/katello/registration_manager_test.rb
+++ b/test/services/katello/registration_manager_test.rb
@@ -30,6 +30,7 @@ module Katello
 
       after do
         Setting[:retain_build_profile_upon_unregistration] = false
+        Setting['allow_multiple_content_views'] = true
       end
 
       let(:rhsm_params) { {:name => 'foobar.example.com', :facts => @facts, :type => 'system'} }
@@ -242,6 +243,28 @@ module Katello
         assert_equal @activation_key.content_view, new_host_cve.content_view
 
         assert_includes new_host.host_collections, @host_collection
+      end
+
+      def test_registration_sets_priorities_for_new_content_facet_with_multiple_cvenvs
+        Setting['allow_multiple_content_views'] = true
+        new_host = ::Host::Managed.new(:name => 'foobar.example.com', :managed => false, :organization => @library.organization)
+        cvenvs = [
+          katello_content_view_environments(:library_dev_view_dev),
+          katello_content_view_environments(:library_dev_staging_view_dev),
+        ]
+
+        ::Katello::RegistrationManager.expects(:get_uuid).returns("fake-uuid-from-katello")
+        ::Katello::Resources::Candlepin::Consumer.expects(:create).with(cvenvs.map(&:cp_id), rhsm_params, [], @library.organization).returns('uuid' => 'fake-uuid-from-candlepin')
+        ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_hypervisor).twice
+        ::Katello::Host::SubscriptionFacet.any_instance.expects(:update_guests).twice
+        ::Host::Managed.any_instance.stubs(:refresh_statuses)
+
+        ::Katello::RegistrationManager.register_host(new_host, rhsm_params, cvenvs)
+
+        priorities = new_host.content_facet.content_view_environment_content_facets.
+          reorder(:priority).
+          pluck(:content_view_environment_id, :priority)
+        assert_equal [[cvenvs[0].id, 0], [cvenvs[1].id, 1]], priorities
       end
 
       def test_registration_with_host_collection_max_hosts_exceeded


### PR DESCRIPTION
Katello 4.21.1 Cherry Picks:

- Fixes #39441 - set PATH to run commands like shutdown
(cherry picked from commit https://github.com/Katello/katello/commit/49b74d36dc892028254e705cc02592db215474f6)
- Fixes #39433 - Nullify ACS SSL credentials before destroying organization
(cherry picked from commit https://github.com/Katello/katello/commit/fccd522dcbcf4d834d391813030e317d2d66f121)
- Fixes #39440 - filter content uploads controller repository context
(cherry picked from commit https://github.com/Katello/katello/commit/7e000dfdbf1fe84b2cb37c415aa114006c1d2b58)
- Fixes #39503 - Fix CVEnv priorities during initial host registration
(cherry picked from commit https://github.com/Katello/katello/commit/ed8b7e896ec09f5de0b03ce0c3d3c81686546ab2)
- Fixes #39493 - Fix duplicate Candlepin PUT requests during registration
(cherry picked from commit https://github.com/Katello/katello/commit/def4db08f6d57f44da5ee95e7d4f977e2e257455)
- Fixes #39581 - Fix sporadic test failure
(cherry picked from commit https://github.com/Katello/katello/commit/04a91c2934dbf8b8cacb4a5e47eb60877b511ca0)
