### PR TITLE
Fixes #39603 - Add content view environment show API and hostgroup details

### DIFF
--- a/app/controllers/katello/api/v2/content_view_environments_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_environments_controller.rb
@@ -1,11 +1,13 @@
 module Katello
   class Api::V2::ContentViewEnvironmentsController < Api::V2::ApiController
     before_action :find_optional_organization, :only => [:index, :auto_complete_search]
-    before_action :find_environment
-    before_action :find_content_view
-    before_action :find_activation_key
-    before_action :find_host
-    before_action :find_content_source
+    before_action :find_authorized_katello_resource, :only => [:show]
+    before_action :find_environment, :only => [:index]
+    before_action :find_content_view, :only => [:index]
+    before_action :find_activation_key, :only => [:index]
+    before_action :find_host, :only => [:index]
+    before_action :find_content_source, :only => [:index]
+    before_action :find_hostgroup, :only => [:index]
 
     resource_description do
       api_version "v2"
@@ -17,10 +19,19 @@ module Katello
     param :content_view_id, :number, :desc => N_("Content view identifier"), :required => false
     param :activation_key_id, :number, :desc => N_("Activation key identifier"), :required => false
     param :host_id, :number, :desc => N_("Host identifier"), :required => false
+    param :hostgroup_id, :number, :desc => N_("Host group identifier"), :required => false
     param :content_source_id, :number, :desc => N_("Content source identifier to filter by available lifecycle environments"), :required => false
     param_group :search, Api::V2::ApiController
     def index
-      respond(:collection => scoped_search(index_relation.distinct, :id, :asc, resource_class: ContentViewEnvironment))
+      respond(:collection => scoped_search(index_relation.distinct, :id, :asc,
+                                           :resource_class => ContentViewEnvironment,
+                                           :includes => {:hostgroup_content_facets => :hostgroup}))
+    end
+
+    api :GET, "/content_view_environments/:id", N_("Show a content view environment")
+    param :id, :number, :desc => N_("Content view environment identifier"), :required => true
+    def show
+      respond_for_show(:resource => @content_view_environment)
     end
 
     def index_relation
@@ -30,6 +41,7 @@ module Katello
       content_view_environments = content_view_environments.where(content_view: @content_view) if @content_view
       content_view_environments = content_view_environments.where(id: @activation_key.content_view_environments) if @activation_key
       content_view_environments = content_view_environments.where(id: @host.content_view_environments) if @host
+      content_view_environments = content_view_environments.where(id: @hostgroup.content_view_environment) if @hostgroup
 
       # Filter by content source if provided (only show CVEnvs from environments on that capsule)
       if @content_source.present? && !@content_source.pulp_primary?
@@ -63,6 +75,11 @@ module Katello
     def find_content_source
       return unless params.key?(:content_source_id)
       @content_source = SmartProxy.authorized(:view_smart_proxies).find(params[:content_source_id])
+    end
+
+    def find_hostgroup
+      return unless params.key?(:hostgroup_id)
+      @hostgroup = ::Hostgroup.authorized(:view_hostgroups).find(params[:hostgroup_id])
     end
   end
 end

--- a/app/views/katello/api/v2/content_view_environments/show.json.rabl
+++ b/app/views/katello/api/v2/content_view_environments/show.json.rabl
@@ -31,3 +31,11 @@ end
 node :hosts_count do |cve|
   cve.hosts.count
 end
+
+child :hostgroups => :hostgroups do
+  attributes :id, :name, :title
+end
+
+node :hostgroups_count do |cvenv|
+  cvenv.hostgroups.size
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -83,7 +83,7 @@ Katello::Engine.routes.draw do
         match '/content_views/:composite_content_view_id/content_view_components/remove' => 'content_view_components#remove_components', :via => :put
         match '/content_views/:composite_content_view_id/content_view_components/:id' => 'content_view_components#update', :via => :put
 
-        api_resources :content_view_environments, :only => [:index]
+        api_resources :content_view_environments, :only => [:index, :show]
 
         api_resources :content_views do
           get :auto_complete_search, :on => :collection

--- a/lib/katello/permission_creator.rb
+++ b/lib/katello/permission_creator.rb
@@ -83,7 +83,7 @@ module Katello
                    'katello/api/v2/content_view_repositories' => [:show_all],
                    'katello/api/v2/content_view_versions' => [:index, :show, :auto_complete_search],
                    'katello/api/v2/content_view_components' => [:index, :show, :show_all],
-                   'katello/api/v2/content_view_environments' => [:index],
+                   'katello/api/v2/content_view_environments' => [:index, :show],
                    'katello/api/v2/debs' => [:index],
                    'katello/api/v2/packages' => [:index],
                    'katello/api/v2/package_groups' => [:index, :show, :auto_complete_search, :compare],
@@ -217,7 +217,7 @@ module Katello
                          {
                            'katello/api/v2/environments' => [:index, :show, :paths, :repositories, :auto_complete_search],
                            'katello/api/rhsm/candlepin_proxies' => [:rhsm_index],
-                           'katello/api/v2/content_view_environments' => [:index],
+                           'katello/api/v2/content_view_environments' => [:index, :show],
                          },
                          :resource_type => 'Katello::KTEnvironment',
                          :finder_scope => :readable

--- a/test/controllers/api/v2/content_view_environments_controller_test.rb
+++ b/test/controllers/api/v2/content_view_environments_controller_test.rb
@@ -70,10 +70,50 @@ module Katello
       assert_template 'api/v2/content_view_environments/index'
     end
 
+    def test_index_for_hostgroup
+      hostgroup = FactoryBot.create(:hostgroup)
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      hostgroup.organizations = [cvenv.organization]
+      hostgroup.save!
+      Katello::Hostgroup::ContentFacet.create!(
+        :hostgroup => hostgroup,
+        :content_view_environment => cvenv
+      )
+
+      get :index, params: { :hostgroup_id => hostgroup.id }
+
+      assert_response :success
+      assert resp.total > 0
+      assert(resp.results.all? { |result| result.id == cvenv.id })
+      assert_template 'api/v2/content_view_environments/index'
+    end
+
     def test_index_protected
       allowed_perms = [@view_cv_permission, @view_lce_permission]
       assert_protected_action(:index, allowed_perms, @denied_perms, [@organization]) do
         get :index, params: {}
+      end
+    end
+
+    def test_show
+      cve = katello_content_view_environments(:library_dev_view_library)
+      get :show, params: { :id => cve.id }
+
+      assert_response :success
+      assert_equal cve.id, resp.id
+      assert_equal cve.label, resp.label
+      assert_equal cve.hostgroups.pluck(:id).sort, resp.hostgroups.map(&:id).sort
+      assert_equal cve.hostgroups.pluck(:name).sort, resp.hostgroups.map(&:name).sort
+      assert_equal cve.hostgroups.count, resp.hostgroups_count
+      assert_template 'api/v2/content_view_environments/show'
+    end
+
+    def test_show_protected
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      # ContentViewEnvironment.readable requires both CV and LCE view permissions
+      allowed_perms = [[@view_cv_permission, @view_lce_permission]]
+      assert_protected_action(:show, allowed_perms, @denied_perms, [@organization]) do
+        get :show, params: { :id => cvenv.id }
       end
     end
   end


### PR DESCRIPTION
## Summary
- Add `GET /katello/api/content_view_environments/:id` (`show` action + route + permissions)
- Include hostgroups list and `hostgroups_count` in CVE JSON (also used by index via `show` template)

## What are the changes introduced in this pull request?
Previously content view environments only had an index endpoint. Clients could not fetch a single CVEnv by id. The list/show payload also did not expose hostgroup usage the way it already exposes activation keys and host counts.

## Considerations taken when implementing this change?
- Reused existing `show.json.rabl` for both index and show so payloads stay consistent
- Hostgroups association already existed on the model; only API/permission/route wiring was needed
- Added `:show` under both `view_content_views` and `view_lifecycle_environments`, matching index

## What are the testing steps for this pull request?
1. Run controller tests:
   ```bash
   cd ~/foreman
   /usr/local/bin/ktest ../katello/test/controllers/api/v2/content_view_environments_controller_test.rb
   ```
2. Restart Foreman, then:
   ```bash
   curl -sk -u admin:changeme "https://$(hostname -f)/katello/api/content_view_environments?per_page=1"
   curl -sk -u admin:changeme "https://$(hostname -f)/katello/api/content_view_environments/<id>" | python3 -m json.tool
   ```
3. Confirm response includes `hostgroups` and `hostgroups_count`, and unknown id returns 404

Companion Hammer PR will surface `hostgroups_count` in `hammer content-view-environment list`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for retrieving individual content view environments.
  * Added host group filtering when listing content view environments.
  * Responses now include associated host groups and the total host group count.

* **Permissions**
  * Added authorization support for viewing individual content view environments.

* **Bug Fixes**
  * Improved resource lookup and authorization for environment details.

* **Tests**
  * Added coverage for filtering, retrieval, response details, and permission enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->