### PR TITLE
Fixes #39607 - Clean up Container Images page spacing and layout

### DIFF
--- a/webpack/scenes/ContainerImages/Booted/BootedContainerImagesPage.js
+++ b/webpack/scenes/ContainerImages/Booted/BootedContainerImagesPage.js
@@ -109,7 +109,7 @@ const BootedContainerImagesPage = () => {
       controller="/katello/api/v2/host_bootc_images"
     >
       <>
-        <Table variant="compact" ouiaId="booted-containers-table" isStriped>
+        <Table variant="compact" ouiaId="booted-containers-table" isStriped className="katello-pf4-table">
           <Thead>
             <Tr ouiaId="table-header">
               <>
@@ -165,7 +165,7 @@ const BootedContainerImagesPage = () => {
                     <Td />
                     <Td colSpan={3}>
                       <ExpandableRowContent>
-                        <Table variant="compact" isStriped ouiaId={`table-composable-expanded-${rowIndex}`}>
+                        <Table variant="compact" isStriped ouiaId={`table-composable-expanded-${rowIndex}`} className="katello-pf4-table">
                           <Thead>
                             <Tr ouiaId={`table-row-inner-expandable-${rowIndex}`}>
                               <Th width={55}>{__('Image digest')}</Th>

--- a/webpack/scenes/ContainerImages/ContainerImagesPage.js
+++ b/webpack/scenes/ContainerImages/ContainerImagesPage.js
@@ -3,8 +3,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import {
   Title,
   PageSection,
-  Stack,
-  StackItem,
+  PageSectionVariants,
   Tabs,
   Tab,
   TabTitleText,
@@ -30,57 +29,65 @@ const ContainerImagesPage = () => {
   };
 
   return (
-    <PageSection variant="light" className="container-images-page">
-      <Stack hasGutter>
-        <StackItem>
-          <Title headingLevel="h1" size="2xl" ouiaId="container-images-title">
-            {__('Container images')}
-            <Popover
-              headerContent={<div>{__('Container images')}</div>}
-              bodyContent={
-                <div>
-                  {__('View container images in the local registry using the Synced tab. View container images booted by image mode hosts using the Booted tab. The Booted tab also shows images outside of the local container registry.')}
-                </div>
-              }
-            >
-              <Button variant="plain" aria-label="Help" isInline icon={<OutlinedQuestionCircleIcon size="sm" />} ouiaId="container-images-help-button" />
-            </Popover>
-          </Title>
-        </StackItem>
-        <StackItem>
-          <Tabs
-            activeKey={activeTabKey}
-            onSelect={handleTabClick}
-            ouiaId="container-images-tabs"
+    <>
+      <PageSection
+        id="container-images-title-section"
+        variant={PageSectionVariants.light}
+      >
+        <Title headingLevel="h1" size="2xl" ouiaId="container-images-title">
+          {__('Container Images')}
+          <Popover
+            headerContent={<div>{__('Container Images')}</div>}
+            bodyContent={
+              <div>
+                {__('View container images in the local registry using the Synced tab. View container images booted by image mode hosts using the Booted tab. The Booted tab also shows images outside of the local container registry.')}
+              </div>
+            }
           >
-            <Tab
-              eventKey={0}
-              title={
-                <>
-                  <TabTitleIcon><SyncAltIcon /></TabTitleIcon>
-                  <TabTitleText>{__('Synced')}</TabTitleText>
-                </>
-              }
-              ouiaId="container-images-synced-tab"
-            />
-            <Tab
-              eventKey={1}
-              title={
-                <>
-                  <TabTitleIcon><FontAwesomeImageModeIcon /></TabTitleIcon>
-                  <TabTitleText>{__('Booted')}</TabTitleText>
-                </>
-              }
-              ouiaId="container-images-booted-tab"
-            />
-          </Tabs>
-        </StackItem>
-        <StackItem>
-          {activeTabKey === 0 && <SyncedContainerImagesPage />}
-          {activeTabKey === 1 && <BootedContainerImagesPage />}
-        </StackItem>
-      </Stack>
-    </PageSection>
+            <Button variant="plain" aria-label="Help" isInline icon={<OutlinedQuestionCircleIcon size="sm" />} ouiaId="container-images-help-button" />
+          </Popover>
+        </Title>
+      </PageSection>
+      <PageSection
+        id="container-images-tabs-section"
+        variant={PageSectionVariants.light}
+      >
+        <Tabs
+          activeKey={activeTabKey}
+          onSelect={handleTabClick}
+          ouiaId="container-images-tabs"
+        >
+          <Tab
+            eventKey={0}
+            title={
+              <>
+                <TabTitleIcon><SyncAltIcon /></TabTitleIcon>
+                <TabTitleText>{__('Synced')}</TabTitleText>
+              </>
+            }
+            ouiaId="container-images-synced-tab"
+          />
+          <Tab
+            eventKey={1}
+            title={
+              <>
+                <TabTitleIcon><FontAwesomeImageModeIcon /></TabTitleIcon>
+                <TabTitleText>{__('Booted')}</TabTitleText>
+              </>
+            }
+            ouiaId="container-images-booted-tab"
+          />
+        </Tabs>
+      </PageSection>
+      <PageSection
+        id="container-images-content-section"
+        variant={PageSectionVariants.light}
+        className="container-images-page"
+      >
+        {activeTabKey === 0 && <SyncedContainerImagesPage />}
+        {activeTabKey === 1 && <BootedContainerImagesPage />}
+      </PageSection>
+    </>
   );
 };
 

--- a/webpack/scenes/ContainerImages/ContainerImagesPage.scss
+++ b/webpack/scenes/ContainerImages/ContainerImagesPage.scss
@@ -1,6 +1,29 @@
-.container-images-page {
-  // Remove gap below tabs
-  .pf-v5-c-tabs__list {
-    margin-bottom: 0;
+#container-images-title-section {
+  padding-block: 24px 16px;
+
+  .pf-v5-c-title {
+    margin: 0;
+  }
+}
+
+#container-images-tabs-section {
+  padding-block: 0;
+
+  .pf-v5-c-tabs__list { 
+    margin-bottom: 0; 
+  }
+}
+
+#container-images-content-section {
+  padding-top: 0;
+
+  .table-index-page #page-layout-title-section {
+    display: none;
+  }
+
+  .table-index-page #page-layout-toolbar-section,
+  .table-index-page #page-layout-content-section {
+    padding-left: 0;
+    padding-right: 0;
   }
 }

--- a/webpack/scenes/ContainerImages/Synced/SyncedContainerImagesPage.js
+++ b/webpack/scenes/ContainerImages/Synced/SyncedContainerImagesPage.js
@@ -249,7 +249,7 @@ const SyncedContainerImagesPage = () => {
       ouiaId="synced-container-images-table-index"
     >
       <>
-        <Table variant="compact" ouiaId="synced-container-images-table">
+        <Table variant="compact" ouiaId="synced-container-images-table" isStriped className="katello-pf4-table">
           <Thead>
             <Tr ouiaId="table-header">
               <Th />


### PR DESCRIPTION
## Summary
- Remove top/bottom padding from the Container Images page section to reduce excess whitespace
- Collapse title margin for tighter layout
- Hide empty title sections rendered by nested TableIndexPage components in Synced and Booted tabs

## Test plan
- [ ] Navigate to Content > Container Images page
- [ ] Verify the page title and tabs render without excessive vertical spacing
- [ ] Switch between Synced and Booted tabs and confirm no empty title sections appear above the table toolbars
- [ ] Confirm search, pagination, and table functionality remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the Container Images page layout with a more compact presentation and reduced spacing.
  * Improved table styling for booted container images, including expandable digest details.
  * Added striped row styling to synced container image tables for improved readability.
  * Standardized the “Container Images” page title and section presentation for a clearer, more consistent experience.
  * Refined toolbar and content spacing for improved use of available screen space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->