### PR TITLE
Update GitHub Actions and Packit for KATELLO-5.0

### DIFF
--- a/.github/workflows/dependent_plugins.yml
+++ b/.github/workflows/dependent_plugins.yml
@@ -21,6 +21,6 @@ jobs:
     with:
       plugin: foreman_rh_cloud
       plugin_repository: theforeman/foreman_rh_cloud
-      foreman_version: develop
+      foreman_version: 5.0-stable
       environment_variables: |
         KATELLO_REF=${{ github.ref }}

--- a/.github/workflows/react_tests.yml
+++ b/.github/workflows/react_tests.yml
@@ -13,4 +13,4 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin_js.yml@v0
     with:
       plugin: katello
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: 5.0-stable # set to the Foreman release branch after branching :)

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
     uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
     with:
       plugin: katello
-      foreman_version: develop # set to the Foreman release branch after branching :)
+      foreman_version: 5.0-stable # set to the Foreman release branch after branching :)
 
   angular:
     name: Angular ${{ matrix.engine }} - NodeJS ${{ matrix.node }}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -17,7 +17,7 @@ upstream_tag_template: "{version}"
 
 actions:
   post-upstream-clone:
-    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/katello/rubygem-katello/rubygem-katello.spec -O rubygem-katello.spec"
+    - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/5.0/packages/katello/rubygem-katello/rubygem-katello.spec -O rubygem-katello.spec"
   get-current-version:
     - ruby -rrubygems -e 'puts Gem::Specification::load(Dir.glob("*.gemspec").first).version'
   create-archive:
@@ -35,21 +35,15 @@ jobs:
       rhel-9:
         additional_modules: "foreman-devel:el9"
         additional_repos:
-          - https://yum.theforeman.org/releases/nightly/el9/x86_64/
-          - https://yum.theforeman.org/plugins/nightly/el9/x86_64/
-          - https://yum.theforeman.org/katello/nightly/katello/el9/x86_64/
+          - https://yum.theforeman.org/releases/5.0/el9/x86_64/
+          - https://yum.theforeman.org/plugins/5.0/el9/x86_64/
+          - https://yum.theforeman.org/katello/5.0/katello/el9/x86_64/
       rhel-10:
         additional_repos:
-          - https://yum.theforeman.org/releases/nightly/el10/x86_64/
-          - https://yum.theforeman.org/plugins/nightly/el10/x86_64/
-          - https://yum.theforeman.org/katello/nightly/katello/el10/x86_64/
+          - https://yum.theforeman.org/releases/5.0/el10/x86_64/
+          - https://yum.theforeman.org/plugins/5.0/el10/x86_64/
+          - https://yum.theforeman.org/katello/5.0/katello/el10/x86_64/
     module_hotfixes: true
-
-  - <<: *copr
-    trigger: commit
-    branch: master
-    owner: '@theforeman'
-    project: develop
 
 srpm_build_deps:
   - wget


### PR DESCRIPTION
## Summary
- Set foreman_version to 5.0-stable in GitHub Actions workflows
- Update Packit to use rpm/5.0 spec and 5.0 repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)