### PR TITLE
Fixes #39599 - Validate content_source_id on host create/update

### DIFF
--- a/app/models/katello/concerns/content_facet_host_extensions.rb
+++ b/app/models/katello/concerns/content_facet_host_extensions.rb
@@ -74,10 +74,10 @@ module Katello
         def content_facet_ignore_update?(attributes)
           attrs = attributes.with_indifferent_access
           cvenv_ids = attrs[:content_view_environment_ids]&.reject(&:blank?)
-          self.content_facet.blank? && (
-            attributes.values.all?(&:blank?) ||
-            cvenv_ids.blank?
-          )
+          self.content_facet.blank? &&
+            cvenv_ids.blank? &&
+            attrs[:content_source_id].blank? &&
+            attrs[:kickstart_repository_id].blank?
         end
 
         apipie :class do

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -233,6 +233,35 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     host_show(host, smart_proxy)
   end
 
+  def test_create_with_invalid_content_source_id
+    cvenv = ::Katello::ContentViewEnvironment.where(
+      :content_view_id => @content_view.id,
+      :environment_id => @environment.id
+    ).first
+    cf_attrs = {:content_source_id => 99_999, :content_view_environment_ids => [cvenv.id]}
+    attrs = @host.clone.attributes.merge(
+      "name" => "invalidcs.example.com",
+      "content_facet_attributes" => cf_attrs
+    ).compact
+
+    assert_no_difference('Host.unscoped.count') do
+      post :create, params: attrs, session: set_session_user
+    end
+    assert_response :unprocessable_entity
+  end
+
+  def test_update_with_invalid_content_source_id
+    host = FactoryBot.create(:host, :with_content, :with_operatingsystem,
+                              :content_view => @content_view, :lifecycle_environment => @environment)
+    put :update, params: {
+      :id => host.id,
+      :content_facet_attributes => {
+        :content_source_id => 99_999,
+      },
+    }, session: set_session_user
+    assert_response :unprocessable_entity
+  end
+
   def test_create_with_permitted_attributes
     cf_attrs = {:content_view_id => @content_view.id, :lifecycle_environment_id => @environment.id}
     sf_attrs = {:purpose_role => "MyRole"}

--- a/test/models/host/content_facet_test.rb
+++ b/test/models/host/content_facet_test.rb
@@ -184,6 +184,40 @@ module Katello
     end
   end
 
+  class ContentFacetIgnoreUpdateTest < ContentFacetBase
+    def test_rejects_when_no_meaningful_attributes
+      assert empty_host.content_facet_ignore_update?({})
+    end
+
+    def test_rejects_when_only_blank_cvenv_ids
+      assert empty_host.content_facet_ignore_update?({'content_view_environment_ids' => ['']})
+    end
+
+    def test_does_not_reject_when_content_source_id_present
+      refute empty_host.content_facet_ignore_update?({'content_source_id' => 1})
+    end
+
+    def test_rejects_when_content_source_id_is_blank
+      assert empty_host.content_facet_ignore_update?({'content_source_id' => ''})
+    end
+
+    def test_does_not_reject_when_kickstart_repository_id_present
+      refute empty_host.content_facet_ignore_update?({'kickstart_repository_id' => 1})
+    end
+
+    def test_rejects_when_kickstart_repository_id_is_blank
+      assert empty_host.content_facet_ignore_update?({'kickstart_repository_id' => ''})
+    end
+
+    def test_does_not_reject_when_cvenv_ids_present
+      refute empty_host.content_facet_ignore_update?({'content_view_environment_ids' => ['1']})
+    end
+
+    def test_does_not_reject_when_content_facet_exists
+      refute host.content_facet_ignore_update?({})
+    end
+  end
+
   class ContentFacetErrataTest < ContentFacetBase
     let(:host) { hosts(:one) }
 


### PR DESCRIPTION
## Summary
- Fix `content_facet_ignore_update?` to not discard `content_facet_attributes` when `content_source_id` or `kickstart_repository_id` is present, even if `content_view_environment_ids` is absent
- Add controller tests for create and update with an invalid `content_source_id`
- Add unit tests for `content_facet_ignore_update?` covering all attribute combinations

## Root cause
Regression from #11753 (Fixes #39330). 
The `content_facet_ignore_update?` reject_if was updated to check `content_view_environment_ids` instead of the removed `content_view_id`/`lifecycle_environment_id`. 
When hammer sends CVE labels (`content_view_environments`), strong params strips them, 
leaving only `{ content_source_id: 99999 }`. 
The reject_if sees no `content_view_environment_ids` and discards everything - including the bogus `content_source_id` that should have triggered the existing `AssociationExistsValidator`.

The fix also includes `kickstart_repository_id` in the check, as it is another permitted `content_facet_attributes` field subject to the same silent discard when passed without `content_view_environment_ids`.

## Test plan
- [ ] `hammer host create` with `--content-source-id 99999` returns "Content source with given ID not found"
- [ ] `hammer host update` with `--content-source-id 99999` returns "Content source with given ID not found"
- [ ] `hammer host create` with a valid `--content-source-id` still succeeds
- [ ] Existing tests pass: `test/controllers/api/v2/hosts_controller_test.rb`, `test/models/host/content_facet_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host updates now preserve valid content-facet changes when a content source or kickstart repository is provided.
  * Invalid content source associations are rejected consistently during host creation and updates.
  * Empty or non-meaningful content-facet updates are correctly ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->