### PR TITLE
Fixes #39613 - Fix cvenvs_changed= typo introduced by cherry-pick

### DIFF
--- a/app/models/katello/host/content_facet.rb
+++ b/app/models/katello/host/content_facet.rb
@@ -158,7 +158,7 @@ module Katello
         # Mark as changed to ensure the before_update callback triggers Candlepin update.
         # Don't call update_candlepin_associations directly - the callback handles it and
         # prevents duplicate requests when called during host.save!
-        self.cvenvs_changed = true unless self.new_record?
+        self.cves_changed = true unless self.new_record?
       end
 
       def content_view_environment_labels

--- a/test/models/concerns/content_facet_host_extensions_test.rb
+++ b/test/models/concerns/content_facet_host_extensions_test.rb
@@ -37,23 +37,23 @@ module Katello
       host.reload
       # Only called once from before_update callback, not from setter (SAT-36519 fix)
       host.expects(:update_candlepin_associations).once
-      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view.id, dev.id)
-      host.content_facet.content_view_environments = [cvenv]
+      cve = Katello::ContentViewEnvironment.find_by!(content_view_id: view.id, environment_id: dev.id)
+      host.content_facet.content_view_environments = [cve]
       host.save!
 
       host.reload
       # Only called once from before_update callback, not from setter (SAT-36519 fix)
       host.expects(:update_candlepin_associations).once
-      cvenv2 = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
-      host.content_facet.content_view_environments = [cvenv2]
+      cve2 = Katello::ContentViewEnvironment.find_by!(content_view_id: view2.id, environment_id: dev.id)
+      host.content_facet.content_view_environments = [cve2]
       host.save!
     end
 
     def test_content_facet_cvenv_update
       # Only called once from before_update callback, not from setter (SAT-36519 fix)
       host.expects(:update_candlepin_associations).once
-      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(view2.id, dev.id)
-      host.content_facet.content_view_environments = [cvenv]
+      cve = Katello::ContentViewEnvironment.find_by!(content_view_id: view2.id, environment_id: dev.id)
+      host.content_facet.content_view_environments = [cve]
       host.save!
       host.reload.content_facet.reload
 

--- a/test/models/erratum_test.rb
+++ b/test/models/erratum_test.rb
@@ -163,11 +163,11 @@ module Katello
     def setup
       super
       @host = hosts(:one)
-      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
-        katello_content_views(:library_dev_view).id,
-        katello_environments(:library).id
+      cve = Katello::ContentViewEnvironment.find_by!(
+        content_view_id: katello_content_views(:library_dev_view).id,
+        environment_id: katello_environments(:library).id
       )
-      @host.content_facet.content_view_environments = [cvenv]
+      @host.content_facet.content_view_environments = [cve]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!
@@ -221,11 +221,11 @@ module Katello
       @repo = katello_repositories(:rhel_6_x86_64)
       @security = katello_errata(:security)
       @host = hosts(:one)
-      cvenv = Katello::ContentViewEnvironment.find_by_cv_and_lce!(
-        katello_content_views(:library_dev_view).id,
-        katello_environments(:library).id
+      cve = Katello::ContentViewEnvironment.find_by!(
+        content_view_id: katello_content_views(:library_dev_view).id,
+        environment_id: katello_environments(:library).id
       )
-      @host.content_facet.content_view_environments = [cvenv]
+      @host.content_facet.content_view_environments = [cve]
       @view_repo = katello_repositories(:rhel_6_x86_64_library_view_1)
       @host.content_facet.bound_repositories = [@repo, @view_repo]
       @host.content_facet.save!


### PR DESCRIPTION
Commit 6363ae3628 (#39493 - Fix duplicate Candlepin PUT requests during registration) was cherry-picked from master to KATELLO-4.21. On master, the attribute had already been renamed from `cves_changed` to `cvenvs_changed` by a46d7afdf6 (#39330 - Remove deprecated CV/LCE params). That rename was never cherry-picked to KATELLO-4.21, so the branch still defines `attr_accessor :cves_changed`.

The cherry-pick introduced `self.cvenvs_changed = true` — a call to a setter that does not exist on this branch — causing HTTP 500 on every `subscription-manager register` call and breaking all downstream content operations.

The fix is a one-line correction to match the existing attribute name on KATELLO-4.21.