### PR TITLE
Fixes #39621 - Handle deleted evr extension case

### DIFF
--- a/db/migrate/20240924161240_katello_recreate_evr_constructs.rb
+++ b/db/migrate/20240924161240_katello_recreate_evr_constructs.rb
@@ -18,144 +18,145 @@ class KatelloRecreateEvrConstructs < ActiveRecord::Migration[6.1]
   def up
     fix_installed_package_dupes
 
-    if !extension_enabled?('evr')
-      return
-    else
+    if extension_enabled?('evr')
       execute <<~SQL
         DROP EXTENSION evr CASCADE;
       SQL
+    end
 
-      execute <<~SQL
-              create type evr_array_item as (
-          n       NUMERIC,
-          s       TEXT
-        );
+    return if column_exists?(:katello_rpms, :evr)
 
-        create type evr_t as (
-          epoch INT,
-          version evr_array_item[],
-          release evr_array_item[]
-        );
+    execute <<~SQL
+            create type evr_array_item as (
+        n       NUMERIC,
+        s       TEXT
+      );
 
-        CREATE FUNCTION evr_trigger() RETURNS trigger AS $$
-          BEGIN
-            NEW.evr = (select ROW(coalesce(NEW.epoch::numeric,0),
-                                  rpmver_array(coalesce(NEW.version,'empty'))::evr_array_item[],
-                                  rpmver_array(coalesce(NEW.release,'empty'))::evr_array_item[])::evr_t);
-            RETURN NEW;
-          END;
-        $$ language 'plpgsql';
+      create type evr_t as (
+        epoch INT,
+        version evr_array_item[],
+        release evr_array_item[]
+      );
 
-        create or replace FUNCTION empty(t TEXT)
-        	RETURNS BOOLEAN as $$
-        	BEGIN
-        		return t ~ '^[[:space:]]*$';
-        	END;
-        $$ language 'plpgsql';
+      CREATE FUNCTION evr_trigger() RETURNS trigger AS $$
+        BEGIN
+          NEW.evr = (select ROW(coalesce(NEW.epoch::numeric,0),
+                                rpmver_array(coalesce(NEW.version,'empty'))::evr_array_item[],
+                                rpmver_array(coalesce(NEW.release,'empty'))::evr_array_item[])::evr_t);
+          RETURN NEW;
+        END;
+      $$ language 'plpgsql';
 
-        create or replace FUNCTION isalpha(ch CHAR)
-          RETURNS BOOLEAN as $$
-          BEGIN
-            if ascii(ch) between ascii('a') and ascii('z') or
-                ascii(ch) between ascii('A') and ascii('Z')
-            then
-              return TRUE;
-            end if;
-            return FALSE;
-          END;
-        $$ language 'plpgsql';
+      create or replace FUNCTION empty(t TEXT)
+      	RETURNS BOOLEAN as $$
+      	BEGIN
+      		return t ~ '^[[:space:]]*$';
+      	END;
+      $$ language 'plpgsql';
 
-        create or replace FUNCTION isalphanum(ch CHAR)
-        	RETURNS BOOLEAN as $$
-        	BEGIN
-        		if ascii(ch) between ascii('a') and ascii('z') or
-        			ascii(ch) between ascii('A') and ascii('Z') or
-        			ascii(ch) between ascii('0') and ascii('9')
-        		then
-        			return TRUE;
-        		end if;
-        		return FALSE;
-        	END;
-        $$ language 'plpgsql';
+      create or replace FUNCTION isalpha(ch CHAR)
+        RETURNS BOOLEAN as $$
+        BEGIN
+          if ascii(ch) between ascii('a') and ascii('z') or
+              ascii(ch) between ascii('A') and ascii('Z')
+          then
+            return TRUE;
+          end if;
+          return FALSE;
+        END;
+      $$ language 'plpgsql';
 
-        create or replace function isdigit(ch CHAR)
-        	RETURNS BOOLEAN as $$
-        	BEGIN
-        	  if ascii(ch) between ascii('0') and ascii('9')
-        	  then
-        		return TRUE;
-        	  end if;
-        	  return FALSE;
-        	END ;
-        $$ language 'plpgsql';
+      create or replace FUNCTION isalphanum(ch CHAR)
+      	RETURNS BOOLEAN as $$
+      	BEGIN
+      		if ascii(ch) between ascii('a') and ascii('z') or
+      			ascii(ch) between ascii('A') and ascii('Z') or
+      			ascii(ch) between ascii('0') and ascii('9')
+      		then
+      			return TRUE;
+      		end if;
+      		return FALSE;
+      	END;
+      $$ language 'plpgsql';
 
-        create or replace FUNCTION rpmver_array (string1 IN VARCHAR)
-        	RETURNS evr_array_item[] as $$
-        	declare
-        		str1 VARCHAR := string1;
-        		digits VARCHAR(10) := '0123456789';
-        		lc_alpha VARCHAR(27) := 'abcdefghijklmnopqrstuvwxyz';
-        		uc_alpha VARCHAR(27) := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-        		alpha VARCHAR(54) := lc_alpha || uc_alpha;
-        		one VARCHAR;
-        		isnum BOOLEAN;
-        		ver_array evr_array_item[] := ARRAY[]::evr_array_item[];
-        	BEGIN
-        		if str1 is NULL
-        		then
-        			RAISE EXCEPTION 'VALUE_ERROR.';
-        		end if;
+      create or replace function isdigit(ch CHAR)
+      	RETURNS BOOLEAN as $$
+      	BEGIN
+      	  if ascii(ch) between ascii('0') and ascii('9')
+      	  then
+      		return TRUE;
+      	  end if;
+      	  return FALSE;
+      	END ;
+      $$ language 'plpgsql';
 
-        		one := str1;
-        		<<segment_loop>>
-        		while one <> ''
-        		loop
-        			declare
-        				segm1 VARCHAR;
-        				segm1_n NUMERIC := 0;
-        			begin
-        				-- Throw out all non-alphanum characters
-        				while one <> '' and not isalphanum(one)
-        				loop
-        					one := substr(one, 2);
-        				end loop;
-        				str1 := one;
-        				if str1 <> '' and isdigit(str1)
-        				then
-        					str1 := ltrim(str1, digits);
-        					isnum := true;
-        				else
-        					str1 := ltrim(str1, alpha);
-        					isnum := false;
-        				end if;
-        				if str1 <> ''
-        				then segm1 := substr(one, 1, length(one) - length(str1));
-        				else segm1 := one;
-        				end if;
+      create or replace FUNCTION rpmver_array (string1 IN VARCHAR)
+      	RETURNS evr_array_item[] as $$
+      	declare
+      		str1 VARCHAR := string1;
+      		digits VARCHAR(10) := '0123456789';
+      		lc_alpha VARCHAR(27) := 'abcdefghijklmnopqrstuvwxyz';
+      		uc_alpha VARCHAR(27) := 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+      		alpha VARCHAR(54) := lc_alpha || uc_alpha;
+      		one VARCHAR;
+      		isnum BOOLEAN;
+      		ver_array evr_array_item[] := ARRAY[]::evr_array_item[];
+      	BEGIN
+      		if str1 is NULL
+      		then
+      			RAISE EXCEPTION 'VALUE_ERROR.';
+      		end if;
 
-        				if segm1 = '' then return ver_array; end if; /* arbitrary */
-        				if isnum
-        				then
-        					segm1 := ltrim(segm1, '0');
-        					if segm1 <> '' then segm1_n := segm1::numeric; end if;
-        					segm1 := NULL;
-        				else
-        				end if;
-        				ver_array := array_append(ver_array, (segm1_n, segm1)::evr_array_item);
-        				one := str1;
-        			end;
-        		end loop segment_loop;
+      		one := str1;
+      		<<segment_loop>>
+      		while one <> ''
+      		loop
+      			declare
+      				segm1 VARCHAR;
+      				segm1_n NUMERIC := 0;
+      			begin
+      				-- Throw out all non-alphanum characters
+      				while one <> '' and not isalphanum(one)
+      				loop
+      					one := substr(one, 2);
+      				end loop;
+      				str1 := one;
+      				if str1 <> '' and isdigit(str1)
+      				then
+      					str1 := ltrim(str1, digits);
+      					isnum := true;
+      				else
+      					str1 := ltrim(str1, alpha);
+      					isnum := false;
+      				end if;
+      				if str1 <> ''
+      				then segm1 := substr(one, 1, length(one) - length(str1));
+      				else segm1 := one;
+      				end if;
 
-        		return ver_array;
-        	END ;
-        $$ language 'plpgsql';
+      				if segm1 = '' then return ver_array; end if; /* arbitrary */
+      				if isnum
+      				then
+      					segm1 := ltrim(segm1, '0');
+      					if segm1 <> '' then segm1_n := segm1::numeric; end if;
+      					segm1 := NULL;
+      				else
+      				end if;
+      				ver_array := array_append(ver_array, (segm1_n, segm1)::evr_array_item);
+      				one := str1;
+      			end;
+      		end loop segment_loop;
 
-      SQL
+      		return ver_array;
+      	END ;
+      $$ language 'plpgsql';
 
-      add_column :katello_rpms, :evr, :evr_t
-      add_column :katello_installed_packages, :evr, :evr_t
+    SQL
 
-      execute <<-SQL
+    add_column :katello_rpms, :evr, :evr_t
+    add_column :katello_installed_packages, :evr, :evr_t
+
+    execute <<-SQL
         update katello_rpms SET evr = (ROW(coalesce(epoch::numeric,0),
                                            rpmver_array(coalesce(version,'empty'))::evr_array_item[],
                                            rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
@@ -163,15 +164,14 @@ class KatelloRecreateEvrConstructs < ActiveRecord::Migration[6.1]
         update katello_installed_packages SET evr = (ROW(coalesce(epoch::numeric,0),
                                                          rpmver_array(coalesce(version,'empty'))::evr_array_item[],
                                                          rpmver_array(coalesce(release,'empty'))::evr_array_item[])::evr_t);
-      SQL
+    SQL
 
-      add_index :katello_rpms, [:name, :arch, :evr]
+    add_index :katello_rpms, [:name, :arch, :evr]
 
-      create_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
-      create_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
-      create_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
-      create_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
-    end
+    create_trigger :evr_insert_trigger_katello_rpms, on: :katello_rpms
+    create_trigger :evr_update_trigger_katello_rpms, on: :katello_rpms
+    create_trigger :evr_insert_trigger_katello_installed_packages, on: :katello_installed_packages
+    create_trigger :evr_update_trigger_katello_installed_packages, on: :katello_installed_packages
   end
 
   def down


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
The 20240924161240_katello_recreate_evr_constructs migration assumed that if the evr PostgreSQL extension was not present, inline EVR constructs
  (types, functions, columns, triggers) must already exist. This is not always true — the extension may have been manually dropped with CASCADE
  (destroying all dependent objects) before this migration runs, leaving the database with neither the extension nor the inline constructs.

  This change replaces the extension_enabled?('evr') early-return guard with a column_exists?(:katello_rpms, :evr) check, so the migration
  correctly handles all three possible states:

  1. Extension present → drop it, recreate inline (existing behavior)
  2. No extension, constructs exist inline → no-op (existing behavior)
  3. No extension, no constructs → create everything from scratch (previously returned early, causing 20250714190050 to fail with PG::UndefinedColumn: ERROR: column "evr" does not exist)

#### Considerations taken when implementing this change?
State 3 is reached when the 35-change-evr-extension-ownership installer hook skips ownership transfer because the postgresql-evr RPM was already
  removed during the upgrade. The migration then fails on DROP EXTENSION evr CASCADE with a permission error (extension owned by postgres,
  migration runs as foreman). An administrator unblocks the upgrade by manually dropping the extension as postgres, but CASCADE destroys all EVR
  constructs. On the next db:migrate, this migration found no extension, assumed inline constructs existed, and returned early — leaving the evr
  column missing and causing AddMissingRpmsEvrIndex to crash.

  This fix is preventive only — it stops new systems from entering the broken state. Systems already affected (where this migration was recorded
  as a no-op) need manual remediation per the KCS article (https://access.redhat.com/solutions/7137526).


#### What are the testing steps for this pull request?

1. On a system with the evr extension installed: verify the migration drops the extension and recreates all EVR constructs inline (existing
  behavior preserved).
  2. On a system where EVR constructs already exist inline (no extension): verify the migration is a no-op (existing behavior preserved).
  3. On a system where both the extension and EVR constructs are missing (the broken state): verify the migration creates all types (evr_t,
  evr_array_item), functions (evr_trigger, rpmver_array, etc.), columns, triggers, and the index from scratch — and that AddMissingRpmsEvrIndex
  succeeds afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration handling for EVR support across different installation states.
  * Prevented unnecessary removal of existing EVR configuration.
  * Ensured migrations safely skip already-completed setup while continuing when EVR support requires initialization.
  * Reduced the risk of migration failures during upgrades and installations with partially configured EVR support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->