### PR TITLE
Fixes #39637 - correct Candlepin request body and headers

### DIFF
--- a/app/lib/katello/http_resource.rb
+++ b/app/lib/katello/http_resource.rb
@@ -93,7 +93,9 @@ module Katello
         end
 
         client = rest_client(REQUEST_MAP[method], method, path)
-        args = [method, payload, headers].compact
+        bodyless_methods = [:get, :delete]
+        # get/delete take (headers); post/put/patch take (payload, headers).
+        args = bodyless_methods.include?(method) ? [method, headers || {}] : [method, payload, headers || {}]
 
         process_response(client.send(*args))
       rescue RestClient::Exception => e

--- a/test/lib/http_resource_test.rb
+++ b/test/lib/http_resource_test.rb
@@ -68,5 +68,41 @@ module Katello
       RestClient::Resource.any_instance.expects(:post).with(payload, headers).returns(mock_response)
       TestHttpResource.post('/path', payload, headers)
     end
+
+    # Regression: bodyless POST must send nil body + real headers, NOT the headers
+    # hash smuggled into the payload slot. The old `.compact` produced
+    # post({headers}) which serialized headers as an x-www-form-urlencoded body and
+    # broke OAuth signing against Candlepin (Redmine #39637).
+    def test_post_nil_payload_keeps_headers_as_headers
+      headers = { headerOne: 'headerOneValue' }
+      mock_response = stub(code: 200, body: '')
+      # payload stays nil; headers stay in the headers slot
+      RestClient::Resource.any_instance.expects(:post).with(nil, headers).returns(mock_response)
+      TestHttpResource.post('/path', nil, headers)
+    end
+
+    # Regression: PUT with a nil body behaves the same as POST.
+    def test_put_nil_payload_keeps_headers_as_headers
+      headers = { headerOne: 'headerOneValue' }
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:put).with(nil, headers).returns(mock_response)
+      TestHttpResource.put('/path', nil, headers)
+    end
+
+    # Regression: headerless GET must call get({}), never get(nil) (which raises
+    # TypeError: no implicit conversion of nil into Hash) and never get(nil, nil)
+    # (ArgumentError). This is the Candlepin ping path (get('/candlepin/status')).
+    def test_get_no_headers_passes_empty_hash
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:get).with({}).returns(mock_response)
+      TestHttpResource.get('/path')
+    end
+
+    # Regression: headerless DELETE must call delete({}), not delete(nil).
+    def test_delete_no_headers_passes_empty_hash
+      mock_response = stub(code: 200, body: '')
+      RestClient::Resource.any_instance.expects(:delete).with({}).returns(mock_response)
+      TestHttpResource.delete('/path')
+    end
   end
 end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Ensures that the body is sent in the body field and headers are sent in the headers field for REST client actions with Candlepin. Also adds tests.

Regression seems to have occurred due to changes in Candlepin 5. It seems it was lenient before, and not lenient now.

#### Considerations taken when implementing this change?

I considered if request.execute should be used here to help split up the arguments better, but rest_client is a `RestClient::Resource instead of a RestClient::Request` . I'd have to do something like

```ruby
process_response(
  RestClient::Request.execute(
    client.options.merge(
      method:  method,
      url:     client.url,
      payload: payload,
      headers: (client.options[:headers] || {}).merge(headers || {})
    )
  )
)
```
So the PR keeps send.

#### What are the testing steps for this pull request?
Try to create a custom repo on a CP 5 machine with and without the patch. Also test other CP actions to check for other regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP request handling to preserve headers correctly across supported request types.
  - Ensured requests without payloads or headers are sent with the expected empty values.

- **Tests**
  - Added coverage for payload-free POST and PUT requests.
  - Added coverage for GET and DELETE requests without headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->