### PR TITLE
Refs #39571 - Truncate CVEnv list and show version info on host edit

### DIFF
--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -48,8 +48,24 @@
       <%= hidden_field_tag 'host[content_facet_attributes][content_view_environment_ids][]', cvenv_id, :id => nil %>
     <% end %>
 
+    <% host_cvenvs = @host.content_view_environments.any? ? @host.content_view_environments : (@host.hostgroup&.content_view_environment ? [@host.hostgroup.content_view_environment] : []) %>
+    <% cvenv_labels = host_cvenvs.map(&:label) %>
+    <% cvenv_display = cvenv_labels.join(', ') %>
+    <% cvenv_truncated = truncate(cvenv_display, :length => 70) %>
+    <% cvenv_overflow = cvenv_display.length > 70 %>
+    <% cvenv_popover_lines = host_cvenvs.map do |cvenv|
+      version_info = cvenv.content_view.default? ? '' : " <small class=\"text-muted\">#{_('Version')} #{cvenv.content_view_version.version}#{cvenv.content_view_version.latest? ? ' (' + _('latest') + ')' : ''}</small>"
+      "<strong>#{h(cvenv.label)}</strong>#{version_info}"
+    end %>
     <%= field(f, 'content_facet.content_view_environment', {:label => _("Content View Environment")}) do %>
-      <%= select_tag :host_content_view_environment_id, content_view_environment_options(@host, :selected_host_group => @hostgroup || @host&.hostgroup), :class => 'form-control', :disabled => true %>
+      <% if cvenv_overflow %>
+        <div class="input-group">
+          <%= text_field_tag :host_content_view_environment_id, cvenv_truncated, :class => 'form-control', :disabled => true %>
+          <span class="input-group-btn"><%= popover("", cvenv_popover_lines.join('<br>'), :class => 'btn btn-default') %></span>
+        </div>
+      <% else %>
+        <%= text_field_tag :host_content_view_environment_id, cvenv_display, :class => 'form-control', :disabled => true %>
+      <% end %>
     <% end %>
   <% else %>
     <%# On host create, show a CVEnv dropdown %>

--- a/app/views/overrides/activation_keys/_host_environment_select.html.erb
+++ b/app/views/overrides/activation_keys/_host_environment_select.html.erb
@@ -54,7 +54,7 @@
     <% cvenv_truncated = truncate(cvenv_display, :length => 70) %>
     <% cvenv_overflow = cvenv_display.length > 70 %>
     <% cvenv_popover_lines = host_cvenvs.map do |cvenv|
-      version_info = cvenv.content_view.default? ? '' : " <small class=\"text-muted\">#{_('Version')} #{cvenv.content_view_version.version}#{cvenv.content_view_version.latest? ? ' (' + _('latest') + ')' : ''}</small>"
+      version_info = (cvenv.content_view.default? || cvenv.content_view.rolling?) ? '' : " <small class=\"text-muted\">#{_('Version')} #{cvenv.content_view_version.version}#{cvenv.content_view_version.latest? ? ' (' + _('latest') + ')' : ''}</small>"
       "<strong>#{h(cvenv.label)}</strong>#{version_info}"
     end %>
     <%= field(f, 'content_facet.content_view_environment', {:label => _("Content View Environment")}) do %>


### PR DESCRIPTION
## Summary
- Follow-up to https://github.com/Katello/katello/pull/11808 which added a disabled CVEnv field to the host edit page.
- Uses a disabled text field instead of a disabled select to properly
  display multiple CVEnvs.
- For hosts with many content view environments, the text field is
  truncated at 70 characters with an "i" popover icon showing the full
  list.
<img width="1919" height="857" alt="CvenvTruncated" src="https://github.com/user-attachments/assets/22e69ab2-39ce-4bbb-b497-c9a35674d09d" />

- When CVEnvs don't need truncation "i" icon is not shown

<img width="1909" height="932" alt="CvenvJustWithLibrary" src="https://github.com/user-attachments/assets/8b9e33c2-b7c5-4915-a0b1-8862d02a0b41" />
- The popover displays each CVEnv label in bold with version info
  (e.g. Version 4.0 (latest)) in muted text, similar to the All Hosts
  page CVEnv column popover.
- The popover uses the same Foreman popover helper as Organization and
  Location fields.

## Testing steps I did
- [x] Host edit with single CVEnv — shows full label, no popover icon
- [x] Host edit with many CVEnvs — truncated text with popover showing all CVEnvs and versions
- [x] Resubmitting host edit page does not change unchanged form values

Co-authored with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version metadata is now hidden for disabled host-edit Content View Environments.
  * Default and rolling Content Views no longer display version or “latest” indicators when editing is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->