### PR TITLE
Fixes #39677 - pulp_primary? returns false for non-Pulp smart proxies

### DIFF
--- a/app/models/katello/concerns/smart_proxy_extensions.rb
+++ b/app/models/katello/concerns/smart_proxy_extensions.rb
@@ -474,7 +474,7 @@ module Katello
       end
 
       def pulp_primary?
-        !pulp_mirror?
+        pulp3_enabled? && !pulp_mirror?
       end
 
       def supported_pulp_types

--- a/test/models/concerns/smart_proxy_extensions_test.rb
+++ b/test/models/concerns/smart_proxy_extensions_test.rb
@@ -392,7 +392,13 @@ module Katello
     def test_save_with_organization_location
       set_default_location
       @proxy.destroy!
-      @proxy = FactoryBot.create(:smart_proxy, :with_pulp3)
+      # In production the Pulpcore feature is associated by the associate_features
+      # before_save hook, so it is present when the before_create taxonomy callbacks
+      # run. The :with_pulp3 factory trait only adds it in after(:create), so build
+      # the feature here to reflect the real ordering.
+      @proxy = FactoryBot.build(:smart_proxy)
+      @proxy.smart_proxy_features.build(feature: pulp_features.first)
+      @proxy.save!
       @proxy_mirror.save!
 
       assert @proxy.pulp_primary?
@@ -410,6 +416,20 @@ module Katello
       assert_not_equal Katello::KTEnvironment.all.count, 0
       assert_equal @proxy.lifecycle_environments.all, Katello::KTEnvironment.all
       assert_equal @proxy_mirror.lifecycle_environments.all.count, 0
+    end
+
+    def test_non_pulp_proxy_is_not_pulp_primary
+      proxy = FactoryBot.create(:smart_proxy)
+
+      refute proxy.has_feature?(::SmartProxy::PULP3_FEATURE)
+      refute proxy.pulp_primary?
+    end
+
+    def test_non_pulp_proxy_not_associated_with_lifecycle_environments
+      assert_not_equal 0, Katello::KTEnvironment.all.count
+      proxy = FactoryBot.create(:smart_proxy)
+
+      assert_equal 0, proxy.lifecycle_environments.count
     end
 
     def test_rhsm_url_without_rhsm_url_setting


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

`SmartProxy#pulp_primary?` was defined as `!pulp_mirror?`, and `pulp_mirror?` reads `setting('Pulpcore', 'mirror')`. A smart proxy that does not have the Pulpcore feature has no such setting, so `setting(...)` returns `nil`, `!pulp_mirror?` evaluates to `true`, and the predicate reported non-Pulp proxies (e.g. DNS/DHCP-only) as pulp primaries.

Because the `before_create` callbacks `associate_organizations`, `associate_default_locations`, and `associate_lifecycle_environments` are all gated on `pulp_primary?`, those non-content proxies were being auto-enrolled in every organization, the default location, and every lifecycle environment.

This gates the predicate on `pulp3_enabled?`:

```ruby
def pulp_primary?
  pulp3_enabled? && !pulp_mirror?
end
```

#### Considerations taken when implementing this change?

- This aligns the per-instance `pulp_primary?` predicate with the semantics the `SmartProxy.pulp_primary` class scope already uses (`with_features(PULP3_FEATURE)` plus non-mirror), so the two are now consistent.
- Added a unit test for a proxy without the Pulpcore feature (not pulp primary, not auto-enrolled in lifecycle environments).
- The existing `test_save_with_organization_location` only passed because of the old buggy behavior: the `:with_pulp3` factory trait associates the Pulpcore feature in `after(:create)`, so the feature was absent when the `before_create` taxonomy callbacks ran. In production the `associate_features` `before_save` hook populates features before `before_create`. The test now builds the feature before save to reflect that real ordering, rather than changing the shared factory trait (which is relied upon by `build`-only tests).

#### What are the testing steps for this pull request?

1. Deploy/register a smart proxy that does NOT have the Pulpcore (content) feature (e.g. a DNS/DHCP-only proxy).
2. Confirm it is no longer automatically assigned to all organizations, the default location, or all lifecycle environments.
3. Register a Pulp content smart proxy (Pulpcore feature, non-mirror) and confirm it is still auto-associated with all organizations, the default location, and all lifecycle environments.
4. Register a Pulp mirror smart proxy and confirm it is not auto-associated (unchanged behavior).

Unit tests:

```
bundle exec rake test:katello TEST=test/models/concerns/smart_proxy_extensions_test.rb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Smart Proxies are now recognized as Pulp primary only when Pulp 3 is enabled and mirror mode is disabled.
  * Non-Pulp proxies are no longer automatically treated as Pulp primary or associated with lifecycle environments.
* **Tests**
  * Added coverage for Smart Proxy feature configuration and lifecycle environment associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->