### PR TITLE
Refs #38838 - Fix partial repository type cache lookup

### DIFF
--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -126,10 +126,7 @@ module Katello
       end
 
       def self.instance_for_type(repo, smart_proxy)
-        repo_types = Katello::RepositoryTypeManager.enabled_repository_types(false)
-        # Populate cache on first call if empty
-        repo_types = Katello::RepositoryTypeManager.enabled_repository_types if repo_types.empty?
-        repo_types[repo.root.content_type].pulp3_service_class.new(repo, smart_proxy)
+        repo.root.repository_type.pulp3_service_class.new(repo, smart_proxy)
       end
 
       def should_purge_empty_contents?

--- a/test/services/katello/pulp3/repository/docker/distribution_test.rb
+++ b/test/services/katello/pulp3/repository/docker/distribution_test.rb
@@ -14,11 +14,25 @@ module Katello
           @mock_smart_proxy.stubs(:pulp_primary?).returns(true)
           @docker_repo = katello_repositories(:pulp3_docker_1)
           @docker_repo.stubs(:container_repository_name).returns("a repo name")
-          @docker_repo_service = @docker_repo.backend_service(@mock_smart_proxy)
         end
 
         def test_distribution_options_path
-          assert_equal @docker_repo_service.distribution_options(@docker_repo_service.relative_path)[:base_path], "a repo name"
+          docker_repo_service = @docker_repo.backend_service(@mock_smart_proxy)
+
+          assert_equal docker_repo_service.distribution_options(docker_repo_service.relative_path)[:base_path], "a repo name"
+        end
+
+        def test_instance_for_type_loads_type_missing_from_cache
+          repository_type_manager = ::Katello::RepositoryTypeManager
+          original_repository_types = repository_type_manager.enabled_repository_types(false)
+          partial_repository_types = {
+            'yum' => repository_type_manager.find_defined('yum'),
+          }
+          repository_type_manager.instance_variable_set(:@enabled_repository_types, partial_repository_types)
+
+          assert_instance_of ::Katello::Pulp3::Repository::Docker, @docker_repo.backend_service(@mock_smart_proxy)
+        ensure
+          repository_type_manager.instance_variable_set(:@enabled_repository_types, original_repository_types)
         end
 
         def teardown

--- a/test/services/katello/repository_type_manager_test.rb
+++ b/test/services/katello/repository_type_manager_test.rb
@@ -3,9 +3,14 @@ require 'katello_test_helper'
 module Katello
   class RepositoryTypeManagerTest < ActiveSupport::TestCase
     def setup
+      @enabled_repository_types = ::Katello::RepositoryTypeManager.enabled_repository_types(false)
       ::Katello::RepositoryTypeManager.instance_variable_set(:@enabled_repository_types, {})
       @feature = SmartProxy.pulp_primary.features.detect { |feature| feature.name == 'Pulpcore' }.smart_proxy_features.first
       @feature.update(capabilities: [])
+    end
+
+    def teardown
+      ::Katello::RepositoryTypeManager.instance_variable_set(:@enabled_repository_types, @enabled_repository_types)
     end
 
     def test_enabled_repository_types_update_false


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Repository service lookup now resolves the requested type through `RootRepository#repository_type`, which uses `RepositoryTypeManager.find`. This fills a missing type when the enabled repository type cache is already partially populated instead of raising `NoMethodError` on `nil.pulp3_service_class`.

The regression test starts with a cache containing only `yum` and verifies that a Docker repository service can still be created. `RepositoryTypeManagerTest` also restores the cache after each test so its global state no longer leaks into tests that run later.

The failure was observed twice in the Foreman plugin matrix for [theforeman/foreman#11189](https://github.com/theforeman/foreman/pull/11189): first on [Ruby 3.0](https://github.com/theforeman/foreman/actions/runs/32367271583/job/96419791463), then on [Ruby 3.3](https://github.com/theforeman/foreman/actions/runs/32370983330/job/96432345868) after rerunning the same commit. Both failures came from `DistributionTest#test_distribution_options_path` during setup.

#### Considerations taken when implementing this change?

This keeps the caching behavior introduced by [#11532](https://github.com/Katello/katello/pull/11532). `RepositoryTypeManager.find` returns an already cached type without refreshing capabilities and only populates the requested type when it is missing.

#### What are the testing steps for this pull request?

- Run `bundle exec rubocop app/services/katello/pulp3/repository.rb test/services/katello/pulp3/repository/docker/distribution_test.rb test/services/katello/repository_type_manager_test.rb`
- Run the Katello tests, including `DistributionTest#test_instance_for_type_loads_type_missing_from_cache`
- Verify the full test suite passes with randomized test ordering

Ruby syntax checks and RuboCop pass locally for all changed files. The Rails tests require the combined Foreman plugin environment and are left to PR CI.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the failure was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an `Assisted-By` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repository service selection for Docker repositories.
  - Repository operations now continue to work reliably when repository-type information is temporarily incomplete or unavailable.
  - Improved consistency when switching between or initializing repository services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->