### PR TITLE
Fixes #39211 - Defer capsule distribution refreshes after all syncs

### DIFF
--- a/app/lib/actions/katello/capsule_content/sync_capsule.rb
+++ b/app/lib/actions/katello/capsule_content/sync_capsule.rb
@@ -2,7 +2,6 @@ module Actions
   module Katello
     module CapsuleContent
       class SyncCapsule < ::Actions::EntryAction
-        # rubocop:disable Metrics/MethodLength
         execution_plan_hooks.use :update_content_counts, :on => :success
         def plan(smart_proxy, options = {})
           plan_self(:smart_proxy_id => smart_proxy.id,
@@ -22,36 +21,55 @@ module Actions
             if environment.nil? && content_view.nil? && repository.nil?
               options[:repository_ids_list] = repos.pluck(:id)
             end
-            if smart_proxy.has_feature?(SmartProxy::PULP3_FEATURE)
-              plan_action(Actions::Pulp3::Orchestration::Repository::RefreshRepos, smart_proxy, options)
-            end
 
-            repos.in_groups_of(Setting[:foreman_proxy_content_batch_size], false) do |repo_batch|
-              concurrence do
-                repo_batch.each do |repo|
-                  if smart_proxy.pulp3_support?(repo)
-                    plan_action(Actions::Pulp3::CapsuleContent::Sync,
-                      repo, smart_proxy,
-                      skip_metadata_check: skip_metadata_check)
-                  end
+            plan_classic_sync(smart_proxy, repos, options, skip_metadata_check)
+            # Cutover seam: refresh distributions only after every sync batch.
+            # A later Capsule pulpcore >= 3.113 path can replace this with proxy
+            # UpstreamPulp.replicate() without rewriting SyncCapsule again.
+            plan_distribution_cutover(smart_proxy, repos)
+          end
+        end
+
+        def plan_classic_sync(smart_proxy, repos, options, skip_metadata_check)
+          if smart_proxy.has_feature?(SmartProxy::PULP3_FEATURE)
+            plan_action(Actions::Pulp3::Orchestration::Repository::RefreshRepos, smart_proxy, options)
+          end
+
+          repos.in_groups_of(Setting[:foreman_proxy_content_batch_size], false) do |repo_batch|
+            concurrence do
+              repo_batch.each do |repo|
+                if smart_proxy.pulp3_support?(repo)
+                  plan_action(Actions::Pulp3::CapsuleContent::Sync,
+                    repo, smart_proxy,
+                    skip_metadata_check: skip_metadata_check)
                 end
               end
+            end
 
-              concurrence do
-                repo_batch.each do |repo|
-                  if repo.is_a?(::Katello::Repository) &&
-                      repo.distribution_bootable? &&
-                      repo.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
-                    plan_action(Katello::Repository::FetchPxeFiles,
-                                id: repo.id,
-                                capsule_id: smart_proxy.id)
-                  end
-                end
+            plan_pxe_fetch(smart_proxy, repo_batch)
+          end
+        end
+
+        def plan_pxe_fetch(smart_proxy, repos)
+          concurrence do
+            Array(repos).each do |repo|
+              if repo.is_a?(::Katello::Repository) &&
+                  repo.distribution_bootable? &&
+                  repo.download_policy == ::Katello::RootRepository::DOWNLOAD_ON_DEMAND
+                plan_action(Katello::Repository::FetchPxeFiles,
+                            id: repo.id,
+                            capsule_id: smart_proxy.id)
               end
             end
           end
         end
-        # rubocop:enable Metrics/MethodLength
+
+        def plan_distribution_cutover(smart_proxy, repos)
+          pulp3_repos = repos.select { |repo| smart_proxy.pulp3_support?(repo) }
+          return if pulp3_repos.empty?
+
+          plan_action(Actions::Pulp3::CapsuleContent::RefreshAllDistributions, smart_proxy, pulp3_repos)
+        end
 
         def repos_to_sync(smart_proxy, environment, content_view, repository, skip_metatadata_check = false)
           smart_proxy_helper = ::Katello::SmartProxyHelper.new(smart_proxy)

--- a/app/lib/actions/pulp3/capsule_content/generate_metadata.rb
+++ b/app/lib/actions/pulp3/capsule_content/generate_metadata.rb
@@ -5,13 +5,11 @@ module Actions
         middleware.use Actions::Middleware::ExecuteIfContentsChanged
         def plan(repository, smart_proxy, options = {})
           options[:contents_changed] = (options && options.key?(:contents_changed)) ? options[:contents_changed] : true
-          sequence do
-            unless repository.repository_type.pulp3_skip_publication
-              plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id,
-                         :options => options).output
-            end
-            plan_action(RefreshDistribution, repository, smart_proxy,
-                          :contents_changed => options[:contents_changed])
+          # RefreshDistribution is planned from SyncCapsule#plan_distribution_cutover
+          # after all sync batches (atomic cutover). Do not inline it here.
+          unless repository.repository_type.pulp3_skip_publication
+            plan_self(:repository_id => repository.id, :smart_proxy_id => smart_proxy.id,
+                       :options => options).output
           end
         end
 

--- a/app/lib/actions/pulp3/capsule_content/refresh_all_distributions.rb
+++ b/app/lib/actions/pulp3/capsule_content/refresh_all_distributions.rb
@@ -1,0 +1,24 @@
+module Actions
+  module Pulp3
+    module CapsuleContent
+      class RefreshAllDistributions < Actions::EntryAction
+        def plan(smart_proxy, repos)
+          repos = Array(repos).compact
+          return if repos.empty?
+
+          plan_self(:smart_proxy_id => smart_proxy.id,
+                    :repository_ids => repos.map(&:id))
+          concurrence do
+            repos.each do |repo|
+              plan_action(RefreshDistribution, repo, smart_proxy)
+            end
+          end
+        end
+
+        def humanized_name
+          _("Refresh smart proxy distributions")
+        end
+      end
+    end
+  end
+end

--- a/app/lib/actions/pulp3/capsule_content/refresh_distribution.rb
+++ b/app/lib/actions/pulp3/capsule_content/refresh_distribution.rb
@@ -2,19 +2,46 @@ module Actions
   module Pulp3
     module CapsuleContent
       class RefreshDistribution < Pulp3::AbstractAsyncTask
-        include Helpers::Presenter
-        middleware.use Actions::Middleware::ExecuteIfContentsChanged
-
-        def plan(repository, smart_proxy, options = {})
+        def plan(repository, smart_proxy)
           plan_self(:repository_id => repository.id,
-                             :smart_proxy_id => smart_proxy.id,
-                             :options => options)
+                    :smart_proxy_id => smart_proxy.id)
         end
 
         def invoke_external_task
-          smart_proxy = ::SmartProxy.unscoped.find(input[:smart_proxy_id])
-          repo = ::Katello::Repository.find(input[:repository_id])
           repo.backend_service(smart_proxy).with_mirror_adapter.refresh_distributions
+        end
+
+        def rescue_external_task(error)
+          if distribution_uniqueness_conflict?(error) && !retried_distribution_refresh?
+            # A concurrent RefreshDistribution created this distribution first.
+            # Re-invoke so refresh_distributions finds the existing distribution
+            # and issues a partial_update instead. Dynflow will poll the new task.
+            # Only retry once; if the follow-up refresh still conflicts, fall back
+            # to the parent error handling rather than replaying indefinitely.
+            output[:retried_distribution_refresh] = true
+            self.external_task = invoke_external_task
+          else
+            super
+          end
+        end
+
+        private
+
+        def repo
+          @repo ||= ::Katello::Repository.find(input[:repository_id])
+        end
+
+        def smart_proxy
+          @smart_proxy ||= super
+        end
+
+        def distribution_uniqueness_conflict?(error)
+          error.is_a?(::Katello::Errors::Pulp3Error) &&
+            ::Katello::Pulp3::DistributionConflict.create_race?(error)
+        end
+
+        def retried_distribution_refresh?
+          output[:retried_distribution_refresh]
         end
       end
     end

--- a/app/services/katello/pulp3/distribution_conflict.rb
+++ b/app/services/katello/pulp3/distribution_conflict.rb
@@ -1,0 +1,20 @@
+module Katello
+  module Pulp3
+    module DistributionConflict
+      # Matches Pulp3 errors indicating a distribution base_path conflict
+      # from a concurrent create: either a uniqueness violation or an overlap.
+      CREATE_RACE_PATTERN = /
+        ["']base_path["'].*?
+        (
+          must\ be\ unique | code=['"]unique |
+          Overlaps\ with\ existing\ distribution
+        )
+      /mx
+
+      def self.create_race?(error_or_message)
+        message = error_or_message.respond_to?(:message) ? error_or_message.message : error_or_message.to_s
+        message.match?(CREATE_RACE_PATTERN)
+      end
+    end
+  end
+end

--- a/app/services/katello/pulp3/repository.rb
+++ b/app/services/katello/pulp3/repository.rb
@@ -285,8 +285,7 @@ module Katello
           create_distribution(relative_path)
         rescue api.client_module::ApiError => e
           # Now it seems there is a distribution. Fetch it and save the reference.
-          if e.message.include?("\"base_path\":[\"This field must be unique.\"]") ||
-              e.message.include?("\"base_path\":[\"Overlaps with existing distribution\"")
+          if ::Katello::Pulp3::DistributionConflict.create_race?(e)
             dist = lookup_distributions(base_path: repo.relative_path).first
             save_distribution_references([dist.pulp_href])
             return update_distribution

--- a/test/actions/katello/capsule_content_test.rb
+++ b/test/actions/katello/capsule_content_test.rb
@@ -63,10 +63,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 yum repo without the proper plugin' do
@@ -77,6 +74,8 @@ module ::Actions::Katello::CapsuleContent
       repo.root.update_attribute(:unprotected, true)
       tree = plan_action_tree(action_class, capsule_content.smart_proxy, :repository_id => repo.id)
       refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::Sync)
+      refute_tree_planned(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution)
+      refute_tree_planned(tree, Actions::Pulp3::CapsuleContent::RefreshAllDistributions)
     end
 
     it 'plans correctly for a pulp3 yum repo' do
@@ -103,10 +102,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 docker repo' do
@@ -120,10 +116,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 ansible collection repo' do
@@ -133,10 +126,7 @@ module ::Actions::Katello::CapsuleContent
       repo = katello_repositories(:pulp3_ansible_collection_1)
       tree = plan_action_tree(action_class, capsule_content.smart_proxy, :repository_id => repo.id)
       assert_tree_planned_steps(tree, ::Actions::Pulp3::ContentGuard::Refresh)
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp3 apt repo' do
@@ -163,10 +153,7 @@ module ::Actions::Katello::CapsuleContent
         assert_equal repo.id, input[:repository_id]
       end
 
-      assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
-        assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        assert_equal repo.id, input[:repository_id]
-      end
+      assert_refresh_boundary(tree, [repo.id])
     end
 
     it 'plans correctly for a pulp2 apt repo' do
@@ -182,6 +169,8 @@ module ::Actions::Katello::CapsuleContent
                 }
 
       assert_tree_planned_with(tree, ::Actions::Pulp3::Orchestration::Repository::RefreshRepos, options)
+      refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+      refute_tree_planned(tree, Actions::Pulp3::CapsuleContent::RefreshAllDistributions)
     end
 
     it 'plans correctly for a pulp yum repo' do
@@ -219,6 +208,7 @@ module ::Actions::Katello::CapsuleContent
       with_pulp3_features(capsule_content.smart_proxy)
       capsule_content.smart_proxy.add_lifecycle_environment(dev_environment)
       repos_in_dev = Katello::Repository.in_environment(dev_environment).pluck(:pulp_id)
+      repo_ids_in_dev = Katello::Repository.in_environment(dev_environment).pluck(:id)
 
       tree = plan_action_tree(action_class, capsule_content.smart_proxy, :environment_id => dev_environment.id)
       options = { smart_proxy_id: capsule_content.smart_proxy.id,
@@ -241,14 +231,17 @@ module ::Actions::Katello::CapsuleContent
         assert_includes repos_in_dev, repo.pulp_id
       end
 
+      assert_refresh_boundary(tree, repo_ids_in_dev)
+    end
+
+    def assert_refresh_boundary(tree, expected_repo_ids)
+      assert_tree_planned_steps(tree, Actions::Pulp3::CapsuleContent::RefreshAllDistributions)
+      planned_repo_ids = []
       assert_tree_planned_with(tree, Actions::Pulp3::CapsuleContent::RefreshDistribution) do |input|
         assert_equal capsule_content.smart_proxy.id, input[:smart_proxy_id]
-        repo = Katello::Repository.find(input[:repository_id])
-        assert_includes repos_in_dev, repo.pulp_id
-        repos_in_dev.delete(repo.pulp_id)
+        planned_repo_ids << input[:repository_id]
       end
-
-      assert_empty repos_in_dev
+      assert_equal expected_repo_ids.uniq.sort, planned_repo_ids.sort
     end
 
     it 'fails when trying to sync to the default capsule' do

--- a/test/actions/pulp3/capsule_content/refresh_distribution_test.rb
+++ b/test/actions/pulp3/capsule_content/refresh_distribution_test.rb
@@ -1,0 +1,174 @@
+require 'katello_test_helper'
+
+module ::Actions::Pulp3::CapsuleContent
+  class DistributionConflictTest < ActiveSupport::TestCase
+    it 'matches both async task and direct api race messages' do
+      async_error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+      api_error = RuntimeError.new('{"base_path":["Overlaps with existing distribution"]}')
+
+      assert ::Katello::Pulp3::DistributionConflict.create_race?(async_error)
+      assert ::Katello::Pulp3::DistributionConflict.create_race?(api_error)
+      refute ::Katello::Pulp3::DistributionConflict.create_race?("Remote artifacts cannot be exported")
+    end
+  end
+
+  class GenerateMetadataTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::CapsuleSupport
+    include Support::Actions::RemoteAction
+
+    let(:proxy) { capsule_content.smart_proxy }
+
+    before do
+      set_user
+      SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
+      SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+    end
+
+    it 'does not plan RefreshDistribution inline for publication-less repos (e.g. docker)' do
+      repo = katello_repositories(:pulp3_docker_1)
+      tree = plan_action_tree(::Actions::Pulp3::CapsuleContent::GenerateMetadata,
+                              repo, proxy)
+
+      refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+    end
+
+    it 'does not plan RefreshDistribution inline for publication-based repos (e.g. file)' do
+      repo = katello_repositories(:pulp3_file_1)
+      tree = plan_action_tree(::Actions::Pulp3::CapsuleContent::GenerateMetadata,
+                              repo, proxy)
+
+      refute_tree_planned(tree, ::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+    end
+  end
+
+  class RefreshDistributionTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::CapsuleSupport
+    include Support::Actions::RemoteAction
+
+    let(:proxy) { capsule_content.smart_proxy }
+    let(:repo) { katello_repositories(:pulp3_docker_1) }
+
+    before do
+      set_user
+      SmartProxy.any_instance.stubs(:ping_pulp3).returns({})
+      SmartProxy.any_instance.stubs(:pulp3_configuration).returns(nil)
+    end
+
+    def build_action_with_output
+      action = create_action(::Actions::Pulp3::CapsuleContent::RefreshDistribution)
+      action.stubs(:input).returns('repository_id' => repo.id, 'smart_proxy_id' => proxy.id)
+      action_output = {}
+      action.stubs(:output).returns(action_output)
+      [action, action_output]
+    end
+
+    it 'recovers from a concurrent distribution creation by retrying as an update' do
+      action, action_output = build_action_with_output
+
+      mock_task = mock('pulp_task')
+      action.expects(:invoke_external_task).returns(mock_task)
+      action.expects(:external_task=).with(mock_task)
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+      action.rescue_external_task(error)
+      assert action_output[:retried_distribution_refresh]
+    end
+
+    it 'recovers when both name and base_path are reported as non-unique (real Pulp error format)' do
+      action, action_output = build_action_with_output
+
+      mock_task = mock('pulp_task')
+      action.expects(:invoke_external_task).returns(mock_task)
+      action.expects(:external_task=).with(mock_task)
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'name': [ErrorDetail(string='This field must be unique.', code='unique')], " \
+        "'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+      action.rescue_external_task(error)
+      assert action_output[:retried_distribution_refresh]
+    end
+
+    # Non-Pulp3Errors fall through to the parent's rescue_external_task,
+    # which delegates to Dynflow's default handler. We verify here that
+    # RefreshDistribution does not intercept them for its own retry logic.
+    it 'does not attempt recovery for non-Pulp3Errors' do
+      action, _action_output = build_action_with_output
+      action.expects(:invoke_external_task).never
+
+      action.rescue_external_task(RuntimeError.new("connection refused"))
+    end
+
+    it 'recovers from an overlap conflict (base_path overlaps existing distribution)' do
+      action, action_output = build_action_with_output
+
+      mock_task = mock('pulp_task')
+      action.expects(:invoke_external_task).returns(mock_task)
+      action.expects(:external_task=).with(mock_task)
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': ['Overlaps with existing distribution']}"
+      )
+      action.rescue_external_task(error)
+      assert action_output[:retried_distribution_refresh]
+    end
+
+    it 're-raises the conflict after the one allowed retry is exhausted' do
+      action, action_output = build_action_with_output
+      action_output[:retried_distribution_refresh] = true
+      action.expects(:invoke_external_task).never
+
+      error = ::Katello::Errors::Pulp3Error.new(
+        "{'base_path': [ErrorDetail(string='This field must be unique.', code='unique')]}"
+      )
+
+      assert_raises(::Katello::Errors::Pulp3Error) { action.rescue_external_task(error) }
+    end
+
+    it 're-raises Pulp3Errors unrelated to distribution uniqueness' do
+      action, _action_output = build_action_with_output
+      action.expects(:invoke_external_task).never
+
+      error = ::Katello::Errors::Pulp3Error.new("Remote artifacts cannot be exported")
+      assert_raises(::Katello::Errors::Pulp3Error) { action.rescue_external_task(error) }
+    end
+  end
+
+  class RefreshAllDistributionsTest < ActiveSupport::TestCase
+    include Dynflow::Testing
+    include Support::Actions::Fixtures
+    include Support::CapsuleSupport
+
+    let(:action_class) { ::Actions::Pulp3::CapsuleContent::RefreshAllDistributions }
+
+    def setup
+      set_user
+    end
+
+    def test_plans_refresh_for_each_repo
+      proxy = capsule_content.smart_proxy
+      yum = katello_repositories(:fedora_17_x86_64)
+      file = katello_repositories(:pulp3_file_1)
+      action = create_action(action_class)
+      plan_action(action, proxy, [yum, file])
+
+      assert_action_planned_with action, ::Actions::Pulp3::CapsuleContent::RefreshDistribution, yum, proxy
+      assert_action_planned_with action, ::Actions::Pulp3::CapsuleContent::RefreshDistribution, file, proxy
+    end
+
+    def test_empty_list_is_a_noop
+      proxy = capsule_content.smart_proxy
+      action = create_action(action_class)
+      plan_action(action, proxy, [])
+      refute_action_planned action, ::Actions::Pulp3::CapsuleContent::RefreshDistribution
+    end
+  end
+end


### PR DESCRIPTION
## Problem

On current Katello master, Capsule `RefreshDistribution` is still planned **inside** each repo's `GenerateMetadata`. Clients see distributions flip one-by-one while other repos are still syncing. Pulp's `finalize_replication` (pulpcore 3.107, issue #7333) is the same idea: content is ready, then distributions become visible together. Capsules on 3.105 do not run that path, so Katello still has to do the cutover itself.

This is also the seam SAT-36270 needs later. A later replicate path should replace one method, not rewrite `SyncCapsule`.

Follow-up to closed #11700, rebased onto current master and framed as a post-sync cutover rather than an intra-plan race.

## Solution

- Stop planning `RefreshDistribution` from `GenerateMetadata`.
- After all sync batches, `SyncCapsule#plan_distribution_cutover` plans `RefreshAllDistributions` for Pulp 3 repos. Empty list is a no-op.
- `sync_container_gateway` stays in `SyncCapsule#run` (after cutover), including for colocated container-gateway proxies (#11810).
- One-shot retry on uniqueness/overlap `Pulp3Error`, shared via `Katello::Pulp3::DistributionConflict`.

This PR does **not** call `UpstreamPulp.replicate()`, bump client gems, or serialize overlapping top-level capsule sync tasks.

## Test plan

- [x] Capsule sync planning: `RefreshDistribution` is not under `GenerateMetadata`; it is after all `CapsuleContent::Sync`
- [x] Empty / non-Pulp3 repo list: no refresh actions
- [x] `rescue_external_task` uniqueness vs overlap vs unrelated errors
- [ ] Capsule sync still succeeds for yum, file, docker, ansible, deb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Capsule synchronization now refreshes content distributions after repository synchronization completes.
  * Multiple repository distributions can be refreshed concurrently for faster processing.

* **Bug Fixes**
  * Improved recovery from distribution-creation conflicts and uniqueness races.
  * Failed conflict-related refreshes are retried automatically before reporting an error.
  * Unnecessary distribution refreshes are avoided when no supported repositories require updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->