### PR TITLE
Fixes #39612 - fix duplicate module stream count

### DIFF
--- a/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
+++ b/webpack/scenes/ContentViews/Details/Versions/ContentViewVersionContent.js
@@ -14,7 +14,6 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
     docker_manifest_list_count: dockerManifestListCount = 0,
     docker_tag_count: dockerTagCount = 0,
     file_count: fileCount = 0,
-    module_stream_count: moduleStreamCount = 0,
     ansible_collection_count: ansibleCollectionCount = 0,
   } = cvVersion;
 
@@ -36,7 +35,7 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
 
   const noCounts =
     !Number(debCount) && !Number(dockerManifestCount) && !Number(dockerTagCount) &&
-    !Number(fileCount) && !Number(moduleStreamCount) && !Number(ansibleCollectionCount) &&
+    !Number(fileCount) && !Number(ansibleCollectionCount) &&
     !Number(dockerManifestListCount) && !contentConfigTypes?.length;
 
   if (noCounts) {
@@ -45,13 +44,6 @@ const ContentViewVersionContent = ({ cvId, versionId, cvVersion }) => {
 
   return (
     <>
-      {moduleStreamCount > 0 &&
-        <>
-          <Link to={`/versions/${versionId}/moduleStreams`}>
-            {`${moduleStreamCount} Module streams`}
-          </Link><br />
-        </>
-      }
       {debCount > 0 &&
         <>
           <Link to={`/versions/${versionId}/debPackages`}>
@@ -100,7 +92,6 @@ ContentViewVersionContent.propTypes = {
     docker_manifest_list_count: PropTypes.number,
     docker_tag_count: PropTypes.number,
     file_count: PropTypes.number,
-    module_stream_count: PropTypes.number,
     ansible_collection_count: PropTypes.number,
   }),
 };
@@ -113,7 +104,6 @@ ContentViewVersionContent.defaultProps = {
     docker_manifest_count: 0,
     docker_tag_count: 0,
     file_count: 0,
-    module_stream_count: 0,
     ansible_collection_count: 0,
   },
 };

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/ContentViewVersionDetailConfig.js
@@ -16,7 +16,6 @@ import {
   getDockerTags,
   getErrata,
   getFiles,
-  getModuleStreams,
   getPackageGroups,
   getRepositories,
   getRPMPackages,
@@ -33,8 +32,6 @@ import {
   selectFilesStatus,
   selectErrata,
   selectErrataStatus,
-  selectModuleStreams,
-  selectModuleStreamsStatus,
   selectRepositories,
   selectRepositoriesStatus,
   selectRPMPackageGroups,
@@ -253,31 +250,6 @@ export default ({ cvId, versionId }) => [
         title: __('Updated'),
         getProperty: item => item?.updated,
       },
-    ],
-  },
-  {
-    name: __('Module Streams'),
-    route: 'moduleStreams',
-    repoType: 'yum',
-    getCountKey: item => item?.module_stream_count,
-    responseSelector: state => selectModuleStreams(state),
-    statusSelector: state => selectModuleStreamsStatus(state),
-    autocompleteEndpoint: '/katello/api/v2/module_streams',
-    autocompleteQueryParams: { content_view_version_id: versionId },
-    bookmarkController: 'katello_content_view_components',
-    fetchItems: params => getModuleStreams({ content_view_version_id: versionId, ...params }),
-    columnHeaders: [
-      {
-        title: __('Name'),
-        getProperty: item => (
-          <a href={urlBuilder(`content/module_streams/${item?.id}`, '')}>
-            {item?.name}
-          </a>),
-      },
-      { title: __('Stream'), getProperty: item => item?.stream },
-      { title: __('Version'), getProperty: item => item?.version },
-      { title: __('Context'), getProperty: item => item?.context },
-      { title: __('Arch'), getProperty: item => item?.arch },
     ],
   },
   {

--- a/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/VersionDetails/__tests__/ContentViewVersionDetails.test.js
@@ -165,7 +165,7 @@ const testConfig = [
   },
   {
     name: 'Module Streams',
-    countKey: 'module_stream_count',
+    countKey: 'modulemd_count',
     autoCompleteUrl: '/module_streams/auto_complete_search',
     dataUrl: api.getApiUrl('/module_streams'),
     data: ContentViewVersionModuleStreamsData,
@@ -259,6 +259,51 @@ testConfig.forEach(({
     assertNockRequest(scope);
     done();
   }));
+
+test('Does not duplicate Module Streams tab when both count keys are present', async () => {
+  const { version } = ContentViewVersionDetailsData;
+  const autocompleteScope = mockAutocomplete(
+    nockInstance,
+    '/module_streams/auto_complete_search',
+    autocompleteQuery('Module Streams'),
+  );
+
+  const scope = nockInstance
+    .get(cvVersions)
+    .query(true)
+    .reply(200, {
+      ...getTabSpecificData('modulemd_count'),
+      module_stream_count: ContentViewVersionDetailsCounts.module_stream_count,
+    });
+
+  const tabScope = nockInstance
+    .get(api.getApiUrl('/module_streams'))
+    .query(queryParams('Module Streams'))
+    .reply(200, ContentViewVersionModuleStreamsData);
+
+  const { getByText, queryByText, getAllByRole } = renderWithRedux(
+    withCVRoute(<ContentViewVersionDetails cvId={3} details={cvDetailData} />),
+    renderOptions,
+  );
+
+  expect(queryByText(`Version ${version}`)).toBeNull();
+  await patientlyWaitFor(() => {
+    expect(getByText(`Version ${version}`)).toBeTruthy();
+  });
+
+  await patientlyWaitFor(() => {
+    const moduleStreamTabs = getAllByRole('tab', { name: /Module Streams/ });
+    expect(moduleStreamTabs).toHaveLength(1);
+  });
+
+  await new Promise((resolve) => {
+    assertNockRequest(autocompleteScope, () => {
+      assertNockRequest(scope, () => {
+        assertNockRequest(tabScope, resolve);
+      });
+    });
+  });
+});
 
 test('Can change repository selector', async (done) => {
   const {

--- a/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersionContent.test.js
+++ b/webpack/scenes/ContentViews/Details/Versions/__tests__/contentViewVersionContent.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { renderWithRedux } from 'react-testing-lib-wrapper';
+import ContentViewVersionContent from '../ContentViewVersionContent';
+
+const renderContent = cvVersion =>
+  renderWithRedux(<ContentViewVersionContent
+    cvId={3}
+    versionId={73}
+    cvVersion={cvVersion}
+  />);
+
+test('Shows no content when version has no counts', () => {
+  const { getByText } = renderContent({});
+
+  expect(getByText('No content')).toBeInTheDocument();
+});
+
+test('Shows module streams once from the generic content config', () => {
+  const { getByText, getAllByText } = renderContent({ modulemd_count: 14 });
+
+  expect(getAllByText('14 Module streams')).toHaveLength(1);
+  expect(getByText('14 Module streams').closest('a'))
+    .toHaveAttribute('href', expect.stringContaining('moduleStreams'));
+});
+
+test('Does not duplicate module streams when both count keys are present', () => {
+  const { getAllByText, queryByText } = renderContent({
+    modulemd_count: 14,
+    module_stream_count: 14,
+  });
+
+  expect(getAllByText('14 Module streams')).toHaveLength(1);
+  expect(queryByText('No content')).not.toBeInTheDocument();
+});
+
+test('Does not show module streams from the legacy count key alone', () => {
+  const { getByText, queryByText } = renderContent({ module_stream_count: 14 });
+
+  expect(queryByText(/Module streams/i)).not.toBeInTheDocument();
+  expect(getByText('No content')).toBeInTheDocument();
+});


### PR DESCRIPTION
#### What are the changes introduced in this pull request?
After Module Streams moved to the generic content UI, the old hardcoded rendering was left in place. Content View versions showed Module Streams twice: once from the legacy UI (module_stream_count) and once from ContentConfig (modulemd_count).

- Removed the explicit Module Streams link from the versions Additional Content column (ContentViewVersionContent.js).
- Removed the explicit Module Streams tab from version details (ContentViewVersionDetailConfig.js).
- Module Streams now render only through the generic ContentConfig path.
- Updated the version details tab test to use modulemd_count.
- Added unit tests that assert a single Additional Content entry and a single Module Streams tab when both count keys are present.

#### Considerations taken when implementing this change?
- This is a display-only fix. Content is not duplicated; only the leftover explicit UI was removed.
- The API still returns both module_stream_count and modulemd_count. The generic UI keys off modulemd_count (singularLabel: 'modulemd'). A version with only the legacy key would no longer show Module Streams in these two places.
- The generic Module Streams tab uses repoType: 'modulemd', not yum. The repository filter on that tab may not list yum repos the way the old explicit tab did.
- Compare, host Module Streams, and per-repository content counts were left unchanged; they were not part of this regression.
- Webpack must be recompiled (or --watch allowed to rebuild) before the UI change is visible.

#### What are the testing steps for this pull request?
1. Create CV, Product and Repository which has module streams
2. Publish/Promote CV
3. Make sure duplicate module stream count not displaying in Content view version and in version details page. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Corrected Module Streams availability detection for content view versions.
- Prevented duplicate Module Streams tabs when multiple count values are returned.
- Ensured Module Streams links, autocomplete, and related data requests appear correctly.
- Ignored outdated count information to prevent inaccurate or duplicate content.

## Tests
- Added coverage for empty versions, Module Streams rendering, tab deduplication, links, autocomplete, and data loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->