### PR TITLE
Fixes #39701 - fix cross org vulnerability (CVE-2026-79654)

### DIFF
--- a/app/controllers/katello/api/v2/content_view_histories_controller.rb
+++ b/app/controllers/katello/api/v2/content_view_histories_controller.rb
@@ -17,7 +17,7 @@ module Katello
     private
 
     def find_content_view
-      @view = ContentView.find(params[:content_view_id]) if params[:content_view_id]
+      @view = ContentView.readable.find(params[:content_view_id]) if params[:content_view_id]
     end
   end
 end

--- a/test/controllers/api/v2/content_view_histories_controller_test.rb
+++ b/test/controllers/api/v2/content_view_histories_controller_test.rb
@@ -4,6 +4,7 @@ module Katello
   class Api::V2::ContentViewHistoriesControllerTest < ActionController::TestCase
     def models
       @library_dev_staging_view = ContentView.find(katello_content_views(:library_dev_staging_view).id)
+      @organization = @library_dev_staging_view.organization
     end
 
     def permissions
@@ -20,7 +21,7 @@ module Katello
     end
 
     def test_index
-      get :index, params: { :content_view_id => @library_dev_staging_view }
+      get :index, params: { :organization_id => @organization.id, :content_view_id => @library_dev_staging_view.id }
 
       assert_response :success
       assert_template 'katello/api/v2/content_view_histories/index'
@@ -28,10 +29,10 @@ module Katello
 
     def test_index_protected
       allowed_perms = [@view_permission]
-      denied_perms = [@create_permission, @update_permission, :destroy_content_views]
+      denied_perms = [@create_permission, @update_permission, @destroy_permission]
 
-      assert_protected_action(:index, allowed_perms, denied_perms) do
-        get :index, params: { :content_view_id => @library_dev_staging_view.id }
+      assert_protected_action(:index, allowed_perms, denied_perms, [@organization]) do
+        get :index, params: { :organization_id => @organization.id, :content_view_id => @library_dev_staging_view.id }
       end
     end
   end


### PR DESCRIPTION
Make sure results for content view history API-endpoint are correctly scoped.

Fixes CVE-2026-79654



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content view history access by ensuring requested content views are loaded only when readable.
  * Prevented inaccessible content views from being returned through the history interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->