### PR TITLE
Refs #39604 - Fix rubocop failures from CVE abbreviation cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,7 @@ Katello/CveAbbreviation:
   Enabled: true
   Exclude:
     - app/controllers/katello/api/v2/errata_controller.rb
+    - app/lib/katello/concerns/base_template_scope_extensions.rb
     - app/services/katello/pulp3/erratum.rb
     - test/controllers/api/v2/errata_controller_test.rb
 

--- a/developer_docs/quick_reference.md
+++ b/developer_docs/quick_reference.md
@@ -36,10 +36,12 @@ curl https://$(hostname)/api/v2/ping            # Get basic status of database a
 cd $GITDIR/foreman
 bundle exec rake test:katello                   # All Katello tests
 
-# For individual test files, ALWAYS use ktest:
+# For individual test files, ALWAYS use ktest (or foreman-test in foremanctl/containerized environments):
 cd $GITDIR/katello
 ktest /path/to/test_file.rb                     # Specific file
 ktest /path/to/test_file.rb -n test_method_name # Specific method
+foreman-test /path/to/test_file.rb                     # Specific file (foremanctl/containerized)
+foreman-test /path/to/test_file.rb -n test_method_name # Specific method (foremanctl/containerized)
 
 # JavaScript testing:
 cd $GITDIR/katello

--- a/test/controllers/api/v2/content_view_environments_controller_test.rb
+++ b/test/controllers/api/v2/content_view_environments_controller_test.rb
@@ -96,15 +96,15 @@ module Katello
     end
 
     def test_show
-      cve = katello_content_view_environments(:library_dev_view_library)
-      get :show, params: { :id => cve.id }
+      cvenv = katello_content_view_environments(:library_dev_view_library)
+      get :show, params: { :id => cvenv.id }
 
       assert_response :success
-      assert_equal cve.id, resp.id
-      assert_equal cve.label, resp.label
-      assert_equal cve.hostgroups.pluck(:id).sort, resp.hostgroups.map(&:id).sort
-      assert_equal cve.hostgroups.pluck(:name).sort, resp.hostgroups.map(&:name).sort
-      assert_equal cve.hostgroups.count, resp.hostgroups_count
+      assert_equal cvenv.id, resp.id
+      assert_equal cvenv.label, resp.label
+      assert_equal cvenv.hostgroups.pluck(:id).sort, resp.hostgroups.map(&:id).sort
+      assert_equal cvenv.hostgroups.pluck(:name).sort, resp.hostgroups.map(&:name).sort
+      assert_equal cvenv.hostgroups.count, resp.hostgroups_count
       assert_template 'api/v2/content_view_environments/show'
     end
 


### PR DESCRIPTION
## Summary
- After #11823 merged, `bundle exec rake katello:rubocop` fails on master with `Katello/CveAbbreviation` offenses.
- `Katello::BaseTemplateScopeExtensions#load_errata_and_cves_by_host` and related locals are legitimate security-CVE usage (host errata/CVE pairs), so the file is added to the cop's `Exclude` list rather than renamed.
- `test_show` in `content_view_environments_controller_test.rb` used a local named `cve` that actually refers to a content view environment (consistent with the fixture and sibling tests already using `cvenv`), so it's renamed to `cvenv`.
- Also documents `foreman-test` as the `ktest` replacement for foremanctl/containerized environments in the dev docs.

## Test plan
- [x] `bundle exec rake katello:rubocop` no longer reports `Katello/CveAbbreviation` offenses (one unrelated, pre-existing `Style/ExpandPathArguments` offense on `katello.gemspec` remains, out of scope for this fix)
- [x] `foreman-test test/controllers/api/v2/content_view_environments_controller_test.rb -n test_show` passes
- [x] `foreman-test test/lib/concerns/base_template_scope_extensions_test.rb` passes (9 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the developer quick reference to document `foreman-test` as an alternative for running individual test files and methods in containerized environments.

- **Chores**
  - Adjusted code-quality checks to accommodate an existing template-scope extension.
  - Clarified test variable naming without changing application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->