### PR TITLE
SAT-45527: Add installed_packages API route

### DIFF
--- a/config/routes/overrides.rb
+++ b/config/routes/overrides.rb
@@ -86,6 +86,7 @@ Foreman::Application.routes.draw do
 
           resources :packages, :only => [:index], :controller => :host_packages do
             get :auto_complete_search, :on => :collection
+            get :installed_packages, :on => :collection
 
             collection do
               put :remove


### PR DESCRIPTION
## Summary

The installed_packages API endpoint was documented in the controller at `/api/hosts/host_packages/installed_packages` but the route was not properly defined in the routes configuration, making the endpoint inaccessible.

This fix adds the route definition to match the API documentation.

## Changes
- Added `get :installed_packages` route to the packages resources in `config/routes/overrides.rb`

## Testing
- Verify the `/api/v2/hosts/host_packages/installed_packages` endpoint is now accessible

Fixes SAT-45527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint for retrieving installed packages associated with a host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->