### PR TITLE
Refs #39351 - Fix installed_packages API route documentation

### DIFF
--- a/app/controllers/katello/api/v2/host_packages_controller.rb
+++ b/app/controllers/katello/api/v2/host_packages_controller.rb
@@ -22,7 +22,7 @@ module Katello
       param :groups, Array, :desc => N_("List of package group names (Deprecated)"), :required => false
     end
 
-    api :GET, "/host_packages/installed_packages", N_("Return a list of installed packages distinct by name")
+    api :GET, "/hosts/host_packages/installed_packages", N_("Return a list of installed packages distinct by name")
     param_group :search, ::Katello::Api::V2::ApiController
     def installed_packages
       _sort_by, _sort_order, options = sort_options


### PR DESCRIPTION
## Summary

The installed_packages API endpoint was documented with an incorrect route path. The actual working route is `/api/v2/hosts/host_packages/installed_packages`, not `/api/host_packages/installed_packages`.

This causes the API documentation (/apidoc) to display an incorrect route to users.

## Changes
- Updated API documentation annotation in `HostPackagesController#installed_packages` from `/host_packages/installed_packages` to `/hosts/host_packages/installed_packages`

## Testing
- Verify in /apidoc that the installed_packages endpoint now correctly shows the route as `/api/v2/hosts/host_packages/installed_packages`
- Test the endpoint: `curl -u admin:password 'https://satellite.example.com/api/v2/hosts/host_packages/installed_packages'`

Fixes SAT-45527