### PR TITLE
Fixes #39753 - Add spacing between digest and type on container images page

### DIFF
--- a/webpack/scenes/ContainerImages/Synced/Details/ManifestDetails.js
+++ b/webpack/scenes/ContainerImages/Synced/Details/ManifestDetails.js
@@ -186,6 +186,8 @@ const ManifestDetails = () => {
               </TextContent>
             </GridItem>
 
+            <GridItem span={12} />
+
             <GridItem span={12}>
               <ExpandableSection
                 toggleText={__('Content views, lifecycle environments, pullable paths')}


### PR DESCRIPTION
## Summary
Add visual spacing between the Digest/Type field row and the expandable section on the container images details page. The fields were previously too close together, impacting readability.

## Changes
- Added empty `GridItem span={12}` spacer following existing PatternFly layout patterns in the component
- Provides vertical separation between the metadata fields and the expandable section below

## Testing

1. Navigate to Content > Container Images
2. Open a synced container image manifest details page
3. Verify the Digest and Type fields are visually separated from the expandable section below
4. Verify the surrounding details-page layout remains properly aligned
5. Test on different viewport sizes to ensure spacing is consistent

Fixes SAT-43467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved manifest details layout by adding a full-width row break between the Type field and the expandable section, creating clearer visual separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->