### PR TITLE
Make republish repository assertion order independent

### DIFF
--- a/test/actions/katello/content_view_version/republish_repositories_test.rb
+++ b/test/actions/katello/content_view_version/republish_repositories_test.rb
@@ -20,7 +20,16 @@ module Katello::Host
 
         plan_action(action, @version)
 
-        assert_action_planned_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate, @version.repositories)
+        assert_action_planned_with(action, ::Actions::Katello::Repository::BulkMetadataGenerate) do |plan_input|
+          actual_ids = plan_input.first.ids.sort
+          expected_ids = @version.repositories
+                                 .joins(:root)
+                                 .where.not(root: { mirroring_policy: ::Katello::RootRepository::MIRRORING_POLICY_COMPLETE })
+                                 .ids
+                                 .sort
+
+          assert_equal expected_ids, actual_ids
+        end
       end
     end
   end


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

The republish repositories action test compared two unordered ActiveRecord relations directly. The production query includes a root repository join and mirroring-policy filter, which can return the same repositories in a different order in CI.

- Assert against the same non-`mirror_complete` repository scope used by the action.
- Compare sorted repository IDs to make the assertion independent of database row order.

This was being seen intermittently in a Foreman PR and is my attempt to try and fix it: https://github.com/theforeman/foreman/actions/runs/34471203029/job/102851963461?pr=11228

#### Considerations taken when implementing this change?

Repository processing order is not significant for this action. The assertion also needs to reflect that repositories using the complete mirroring policy are intentionally excluded by default.

#### What are the testing steps for this pull request?

- `ruby -c test/actions/katello/content_view_version/republish_repositories_test.rb` — passes.
- `git diff --check` — passes.
- Run `ktest test/actions/katello/content_view_version/republish_repositories_test.rb` from the Katello directory; the test should pass consistently regardless of repository query order.
- Run `bundle exec rake test:katello`; the intermittent `RepublishRepositoriesTest::Version Republish Repositories#test_0001_plans with default values` failure should no longer occur.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to verify that bulk metadata generation is planned only for repositories that do not use complete mirroring.
  * Repository identifiers are now compared in sorted order for consistent test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->